### PR TITLE
Fix #89. Make some of UI Events composed events

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -16,7 +16,7 @@ Editor: Gary Kacmarcik, Google, garykac@google.com
 Editor: Travis Leithead, Microsoft, travil@microsoft.com
 Abstract:
 	This specification defines UI Events which extend the DOM Event objects
-	defined in [[DOM4]]. UI Events are those typically implemented by visual
+	defined in [[DOM]]. UI Events are those typically implemented by visual
 	user agents for handling user interaction such as mouse and keyboard input.
 </pre>
 

--- a/index.html
+++ b/index.html
@@ -9,13 +9,161 @@
   <link href="styles.css" rel="stylesheet" type="text/css">
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-WD" rel="stylesheet" type="text/css">
   <meta content="Bikeshed 1.0.0" name="generator">
-<style>
+<style>/* style-md-lists */
+
+            /* This is a weird hack for me not yet following the commonmark spec
+               regarding paragraph and lists. */
+            [data-md] > :first-child {
+                margin-top: 0;
+            }
+            [data-md] > :last-child {
+                margin-bottom: 0;
+            }</style>
+<style>/* style-selflinks */
+
+            .heading, .issue, .note, .example, li, dt {
+                position: relative;
+            }
+            a.self-link {
+                position: absolute;
+                top: 0;
+                left: calc(-1 * (3.5rem - 26px));
+                width: calc(3.5rem - 26px);
+                height: 2em;
+                text-align: center;
+                border: none;
+                transition: opacity .2s;
+                opacity: .5;
+            }
+            a.self-link:hover {
+                opacity: 1;
+            }
+            .heading > a.self-link {
+                font-size: 83%;
+            }
+            li > a.self-link {
+                left: calc(-1 * (3.5rem - 26px) - 2em);
+            }
+            dfn > a.self-link {
+                top: auto;
+                left: auto;
+                opacity: 0;
+                width: 1.5em;
+                height: 1.5em;
+                background: gray;
+                color: white;
+                font-style: normal;
+                transition: opacity .2s, background-color .2s, color .2s;
+            }
+            dfn:hover > a.self-link {
+                opacity: 1;
+            }
+            dfn > a.self-link:hover {
+                color: black;
+            }
+
+            a.self-link::before            { content: "¶"; }
+            .heading > a.self-link::before { content: "§"; }
+            dfn > a.self-link::before      { content: "#"; }</style>
+<style>/* style-counters */
+
+            body {
+                counter-reset: example figure issue;
+            }
+            .issue {
+                counter-increment: issue;
+            }
+            .issue:not(.no-marker)::before {
+                content: "Issue " counter(issue);
+            }
+
+            .example {
+                counter-increment: example;
+            }
+            .example:not(.no-marker)::before {
+                content: "Example " counter(example);
+            }
+            .invalid.example:not(.no-marker)::before,
+            .illegal.example:not(.no-marker)::before {
+                content: "Invalid Example" counter(example);
+            }
+
+            figcaption {
+                counter-increment: figure;
+            }
+            figcaption:not(.no-marker)::before {
+                content: "Figure " counter(figure);
+            }</style>
+<style>/* style-autolinks */
+
+            .css.css, .property.property, .descriptor.descriptor {
+                color: #005a9c;
+                font-size: inherit;
+                font-family: inherit;
+            }
+            .css::before, .property::before, .descriptor::before {
+                content: "‘";
+            }
+            .css::after, .property::after, .descriptor::after {
+                content: "’";
+            }
+            .property, .descriptor {
+                /* Don't wrap property and descriptor names */
+                white-space: nowrap;
+            }
+            .type { /* CSS value <type> */
+                font-style: italic;
+            }
+            pre .property::before, pre .property::after {
+                content: "";
+            }
+            [data-link-type="property"]::before,
+            [data-link-type="propdesc"]::before,
+            [data-link-type="descriptor"]::before,
+            [data-link-type="value"]::before,
+            [data-link-type="function"]::before,
+            [data-link-type="at-rule"]::before,
+            [data-link-type="selector"]::before,
+            [data-link-type="maybe"]::before {
+                content: "‘";
+            }
+            [data-link-type="property"]::after,
+            [data-link-type="propdesc"]::after,
+            [data-link-type="descriptor"]::after,
+            [data-link-type="value"]::after,
+            [data-link-type="function"]::after,
+            [data-link-type="at-rule"]::after,
+            [data-link-type="selector"]::after,
+            [data-link-type="maybe"]::after {
+                content: "’";
+            }
+
+            [data-link-type].production::before,
+            [data-link-type].production::after,
+            .prod [data-link-type]::before,
+            .prod [data-link-type]::after {
+                content: "";
+            }
+
+            [data-link-type=element],
+            [data-link-type=element-attr] {
+                font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+                font-size: .9em;
+            }
+            [data-link-type=element]::before { content: "<" }
+            [data-link-type=element]::after  { content: ">" }
+
+            [data-link-type=biblio] {
+                white-space: pre;
+            }</style>
+<style>/* style-dfn-panel */
+
         .dfn-panel {
-            display: inline-block;
             position: absolute;
             z-index: 35;
             height: auto;
             width: -webkit-fit-content;
+            width: fit-content;
             max-width: 300px;
             max-height: 500px;
             overflow: auto;
@@ -31,12 +179,13 @@
         .dfn-panel a { color: black; }
         .dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
         .dfn-panel > b + b { margin-top: 0.25em; }
-        .dfn-panel > span { display: list-item; list-style: inside; }
+        .dfn-panel ul { padding: 0; }
+        .dfn-panel li { list-style: inside; }
         .dfn-panel.activated {
             display: inline-block;
             position: fixed;
             left: .5em;
-            bottom: .5em;
+            bottom: 2em;
             margin: 0 auto;
             max-width: calc(100vw - 1.5em - .4em - .5em);
             max-height: 30vh;
@@ -44,18 +193,76 @@
 
         .dfn-paneled { cursor: pointer; }
         </style>
+<style>/* style-syntax-highlighting */
+pre.idl.highlight { color: #708090; }
+        .highlight:not(.idl) { background: hsl(24, 20%, 95%); }
+        code.highlight { padding: .1em; border-radius: .3em; }
+        pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
+        .highlight .c { color: #708090 } /* Comment */
+        .highlight .k { color: #990055 } /* Keyword */
+        .highlight .l { color: #000000 } /* Literal */
+        .highlight .n { color: #0077aa } /* Name */
+        .highlight .o { color: #999999 } /* Operator */
+        .highlight .p { color: #999999 } /* Punctuation */
+        .highlight .cm { color: #708090 } /* Comment.Multiline */
+        .highlight .cp { color: #708090 } /* Comment.Preproc */
+        .highlight .c1 { color: #708090 } /* Comment.Single */
+        .highlight .cs { color: #708090 } /* Comment.Special */
+        .highlight .kc { color: #990055 } /* Keyword.Constant */
+        .highlight .kd { color: #990055 } /* Keyword.Declaration */
+        .highlight .kn { color: #990055 } /* Keyword.Namespace */
+        .highlight .kp { color: #990055 } /* Keyword.Pseudo */
+        .highlight .kr { color: #990055 } /* Keyword.Reserved */
+        .highlight .kt { color: #990055 } /* Keyword.Type */
+        .highlight .ld { color: #000000 } /* Literal.Date */
+        .highlight .m { color: #000000 } /* Literal.Number */
+        .highlight .s { color: #a67f59 } /* Literal.String */
+        .highlight .na { color: #0077aa } /* Name.Attribute */
+        .highlight .nc { color: #0077aa } /* Name.Class */
+        .highlight .no { color: #0077aa } /* Name.Constant */
+        .highlight .nd { color: #0077aa } /* Name.Decorator */
+        .highlight .ni { color: #0077aa } /* Name.Entity */
+        .highlight .ne { color: #0077aa } /* Name.Exception */
+        .highlight .nf { color: #0077aa } /* Name.Function */
+        .highlight .nl { color: #0077aa } /* Name.Label */
+        .highlight .nn { color: #0077aa } /* Name.Namespace */
+        .highlight .py { color: #0077aa } /* Name.Property */
+        .highlight .nt { color: #669900 } /* Name.Tag */
+        .highlight .nv { color: #222222 } /* Name.Variable */
+        .highlight .ow { color: #999999 } /* Operator.Word */
+        .highlight .mb { color: #000000 } /* Literal.Number.Bin */
+        .highlight .mf { color: #000000 } /* Literal.Number.Float */
+        .highlight .mh { color: #000000 } /* Literal.Number.Hex */
+        .highlight .mi { color: #000000 } /* Literal.Number.Integer */
+        .highlight .mo { color: #000000 } /* Literal.Number.Oct */
+        .highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
+        .highlight .sc { color: #a67f59 } /* Literal.String.Char */
+        .highlight .sd { color: #a67f59 } /* Literal.String.Doc */
+        .highlight .s2 { color: #a67f59 } /* Literal.String.Double */
+        .highlight .se { color: #a67f59 } /* Literal.String.Escape */
+        .highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
+        .highlight .si { color: #a67f59 } /* Literal.String.Interpol */
+        .highlight .sx { color: #a67f59 } /* Literal.String.Other */
+        .highlight .sr { color: #a67f59 } /* Literal.String.Regex */
+        .highlight .s1 { color: #a67f59 } /* Literal.String.Single */
+        .highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
+        .highlight .vc { color: #0077aa } /* Name.Variable.Class */
+        .highlight .vg { color: #0077aa } /* Name.Variable.Global */
+        .highlight .vi { color: #0077aa } /* Name.Variable.Instance */
+        .highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
+        </style>
  <body class="h-entry">
   <div class="head">
    <header>
-    <p data-fill-with="logo"><a href="http://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/Icons/w3c_home" width="72"></a></p>
-    <h1 class="p-name no-ref" id="title">UI Events </h1>
-    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">W3C Working Draft, <time class="dt-updated" datetime="2016-03-06">6 March 2016</time></span></h2>
+    <p data-fill-with="logo"><a href="http://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"></a></p>
+    <h1>UI Events</h1>
+    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">W3C Working Draft, <time class="dt-updated" datetime="2016-06-23">23 June 2016</time></span></h2>
    </header>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
-     <dd><a class="u-url" href="http://www.w3.org/TR/2016/WD-uievents--20160306/">http://www.w3.org/TR/2016/WD-uievents--20160306/</a>
-     <dt>Latest version:
+     <dd><a class="u-url" href="http://www.w3.org/TR/2016/WD-uievents-20160623/">http://www.w3.org/TR/2016/WD-uievents-20160623/</a>
+     <dt>Latest published version:
      <dd><a href="http://www.w3.org/TR/uievents/">http://www.w3.org/TR/uievents/</a>
      <dt>Editor's Draft:
      <dd><a href="https://github.com/w3c/uievents/">https://github.com/w3c/uievents/</a>
@@ -79,7 +286,7 @@
   <div class="p-summary" data-fill-with="abstract">
    <p>This specification defines UI Events which extend the DOM Event objects
 
-defined in <a data-link-type="biblio" href="#biblio-dom4">[DOM4]</a>. UI Events are those typically implemented by visual
+defined in <a data-link-type="biblio" href="#biblio-dom">[DOM]</a>. UI Events are those typically implemented by visual
 user agents for handling user interaction such as mouse and keyboard input.</p>
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="status"><span class="content">Status of this document</span></h2>
@@ -537,6 +744,7 @@ described in this specification in order to make Web applications, and a user is
 the person who uses those Web applications in an implementation.</p>
     <p>And finally:</p>
     <p class="note" role="note">This is a note.</p>
+    <p></p>
     <p class="XXX">This is an open issue.</p>
     <p class="warning">This is a warning.</p>
 <pre class="idl-ignore" data-highlight="webidl" data-no-idl="">interface <b>Example</b> {
@@ -546,7 +754,7 @@ the person who uses those Web applications in an implementation.</p>
    </section>
    <section>
     <h2 class="heading settled" data-level="3" id="dom-event-architecture"><span class="secno">3. </span><span class="content">DOM Event Architecture</span><a class="self-link" href="#dom-event-architecture"></a></h2>
-    <p><em>This section is non-normative. Refer to <a data-link-type="biblio" href="#biblio-dom4">[DOM4]</a> for a normative description
+    <p><em>This section is non-normative. Refer to <a data-link-type="biblio" href="#biblio-dom">[DOM]</a> for a normative description
 of the DOM event architecture</em></p>
     <h3 class="heading settled" data-level="3.1" id="event-flow"><span class="secno">3.1. </span><span class="content">Event dispatch and DOM event flow</span><a class="self-link" href="#event-flow"></a></h3>
     <p>This section gives a brief overview of the event <a data-link-type="dfn" href="#dispatch" id="ref-for-dispatch-2">dispatch</a> mechanism
@@ -674,7 +882,7 @@ the <em>bubbling phase</em>.</p>
     initializing the internal state of the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#event">Event</a></code> object’s key modifiers:
     specifically, the internal state queried for using the <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate-1">getModifierState()</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate-1">getModifierState()</a></code> methods. This section supplements the DOM4 steps for intializing a new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#event">Event</a></code> object with these optional modifier states.</p>
     <p>For the purposes of constructing a <code class="idl"><a data-link-type="idl" href="#keyboardevent-keyboardevent" id="ref-for-keyboardevent-keyboardevent-5">KeyboardEvent</a></code>, <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-2">MouseEvent</a></code>, or
-    object derived from these objects using the algorithm below, all <code class="idl"><a data-link-type="idl" href="#keyboardevent-keyboardevent" id="ref-for-keyboardevent-keyboardevent-6">KeyboardEvent</a></code>, <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-3">MouseEvent</a></code>, and derived objects have <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="internal-key-modifier-state">internal key modifier state<span class="dfn-panel"><b><a href="#internal-key-modifier-state">#internal-key-modifier-state</a></b><b>Referenced in:</b><span><a href="#ref-for-internal-key-modifier-state-1">3.6. Constructing Mouse and Keyboard Events</a></span></span></dfn> which can be set and
+    object derived from these objects using the algorithm below, all <code class="idl"><a data-link-type="idl" href="#keyboardevent-keyboardevent" id="ref-for-keyboardevent-keyboardevent-6">KeyboardEvent</a></code>, <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-3">MouseEvent</a></code>, and derived objects have <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="internal-key-modifier-state">internal key modifier state</dfn> which can be set and
     retrieved using the <a href="#keys-modifiers">key modifier names</a> described in the <a href="http://www.w3.org/TR/uievents-key/#keys-modifier">Modifier Keys table</a> in <a data-link-type="biblio" href="#biblio-uievents-key">[UIEvents-Key]</a>.</p>
     <p>The following steps supplement the algorithm defined for constructing
     events in DOM4:</p>
@@ -686,7 +894,7 @@ then run the following sub-steps:</p>
       <ul>
        <li data-md="">
         <p>For each <code class="idl"><a data-link-type="idl" href="#dictdef-eventmodifierinit" id="ref-for-dictdef-eventmodifierinit-2">EventModifierInit</a></code> argument, if the dictionary member
-begins with the string <code>"modifier"</code>, then let the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="modifier-key-name">key modifier name<span class="dfn-panel"><b><a href="#modifier-key-name">#modifier-key-name</a></b><b>Referenced in:</b><span><a href="#ref-for-modifier-key-name-1">3.6. Constructing Mouse and Keyboard Events</a></span></span></dfn> be the
+begins with the string <code>"modifier"</code>, then let the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="modifier-key-name">key modifier name</dfn> be the
 dictionary member’s name excluding the prefix <code>"modifier"</code>, and set the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#event">Event</a></code> object’s <a href="#internal-key-modifier-state" id="ref-for-internal-key-modifier-state-1">internal key modifier state</a> that matches the <a href="#modifier-key-name" id="ref-for-modifier-key-name-1">key modifier name</a> to the corresponding value.</p>
       </ul>
     </ul>
@@ -720,6 +928,8 @@ implementation:</p>
         <p><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-bubbles">bubbles</a></code> attribute</p>
        <li data-md="">
         <p><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-cancelable">cancelable</a></code> attribute</p>
+       <li data-md="">
+        <p><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-composed">composed</a></code> attribute</p>
        <li data-md="">
         <p><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-timestamp">timeStamp</a></code> attribute</p>
        <li data-md="">
@@ -1027,10 +1237,10 @@ events.</p>
 		associated with User Interface events.</p>
     <p>To create an instance of the <code class="idl"><a data-link-type="idl" href="#uievent-uievent" id="ref-for-uievent-uievent-2">UIEvent</a></code> interface, use the UIEvent
 		constructor, passing an optional <code class="idl"><a data-link-type="idl" href="#dictdef-uieventinit-uieventinit" id="ref-for-dictdef-uieventinit-uieventinit-1">UIEventInit</a></code> dictionary.</p>
-<pre class="idl def">[<dfn class="idl-code" data-dfn-for="UIEvent" data-dfn-type="constructor" data-export="" data-lt="UIEvent(type, eventInitDict)" id="dom-uievent-uievent">Constructor<a class="self-link" href="#dom-uievent-uievent"></a></dfn>(DOMString <dfn class="idl-code" data-dfn-for="UIEvent/UIEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-uievent-uievent-type-eventinitdict-type">type<a class="self-link" href="#dom-uievent-uievent-type-eventinitdict-type"></a></dfn>, optional <a data-link-type="idl-name" href="#dictdef-uieventinit-uieventinit" id="ref-for-dictdef-uieventinit-uieventinit-2">UIEventInit</a> <dfn class="idl-code" data-dfn-for="UIEvent/UIEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-uievent-uievent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-uievent-uievent-type-eventinitdict-eventinitdict"></a></dfn>)]
-interface <dfn class="dfn-paneled idl-code" data-dfn-for="UIEvent" data-dfn-type="interface" data-export="" id="uievent-uievent">UIEvent<span class="dfn-panel"><b><a href="#uievent-uievent">#uievent-uievent</a></b><b>Referenced in:</b><span><a href="#ref-for-uievent-uievent-1">5.1.1. Interface UIEvent</a> <a href="#ref-for-uievent-uievent-2">(2)</a></span><span><a href="#ref-for-uievent-uievent-3">5.1.2. UI Event Types</a></span><span><a href="#ref-for-uievent-uievent-4">5.1.2.1. load</a> <a href="#ref-for-uievent-uievent-5">(2)</a> <a href="#ref-for-uievent-uievent-6">(3)</a></span><span><a href="#ref-for-uievent-uievent-7">5.1.2.2. unload</a> <a href="#ref-for-uievent-uievent-8">(2)</a> <a href="#ref-for-uievent-uievent-9">(3)</a></span><span><a href="#ref-for-uievent-uievent-10">5.1.2.3. abort</a> <a href="#ref-for-uievent-uievent-11">(2)</a> <a href="#ref-for-uievent-uievent-12">(3)</a></span><span><a href="#ref-for-uievent-uievent-13">5.1.2.4. error</a> <a href="#ref-for-uievent-uievent-14">(2)</a> <a href="#ref-for-uievent-uievent-15">(3)</a></span><span><a href="#ref-for-uievent-uievent-16">5.1.2.5. select</a> <a href="#ref-for-uievent-uievent-17">(2)</a> <a href="#ref-for-uievent-uievent-18">(3)</a></span><span><a href="#ref-for-uievent-uievent-19">5.2.1. Interface FocusEvent</a></span><span><a href="#ref-for-uievent-uievent-20">5.2.4.1. blur</a> <a href="#ref-for-uievent-uievent-21">(2)</a></span><span><a href="#ref-for-uievent-uievent-22">5.2.4.2. focus</a> <a href="#ref-for-uievent-uievent-23">(2)</a></span><span><a href="#ref-for-uievent-uievent-24">5.2.4.3. focusin</a> <a href="#ref-for-uievent-uievent-25">(2)</a></span><span><a href="#ref-for-uievent-uievent-26">5.2.4.4. focusout</a> <a href="#ref-for-uievent-uievent-27">(2)</a></span><span><a href="#ref-for-uievent-uievent-28">5.3.1. Interface MouseEvent</a></span><span><a href="#ref-for-uievent-uievent-29">5.3.4.1. click</a> <a href="#ref-for-uievent-uievent-30">(2)</a></span><span><a href="#ref-for-uievent-uievent-31">5.3.4.2. dblclick</a> <a href="#ref-for-uievent-uievent-32">(2)</a></span><span><a href="#ref-for-uievent-uievent-33">5.3.4.3. mousedown</a> <a href="#ref-for-uievent-uievent-34">(2)</a></span><span><a href="#ref-for-uievent-uievent-35">5.3.4.4. mouseenter</a> <a href="#ref-for-uievent-uievent-36">(2)</a></span><span><a href="#ref-for-uievent-uievent-37">5.3.4.5. mouseleave</a> <a href="#ref-for-uievent-uievent-38">(2)</a></span><span><a href="#ref-for-uievent-uievent-39">5.3.4.6. mousemove</a> <a href="#ref-for-uievent-uievent-40">(2)</a></span><span><a href="#ref-for-uievent-uievent-41">5.3.4.7. mouseout</a> <a href="#ref-for-uievent-uievent-42">(2)</a></span><span><a href="#ref-for-uievent-uievent-43">5.3.4.8. mouseover</a> <a href="#ref-for-uievent-uievent-44">(2)</a></span><span><a href="#ref-for-uievent-uievent-45">5.3.4.9. mouseup</a> <a href="#ref-for-uievent-uievent-46">(2)</a></span><span><a href="#ref-for-uievent-uievent-47">5.4.2.1. wheel</a> <a href="#ref-for-uievent-uievent-48">(2)</a></span><span><a href="#ref-for-uievent-uievent-49">5.5.1. Interface InputEvent</a></span><span><a href="#ref-for-uievent-uievent-50">5.5.3.1. beforeinput</a> <a href="#ref-for-uievent-uievent-51">(2)</a></span><span><a href="#ref-for-uievent-uievent-52">5.5.3.2. input</a> <a href="#ref-for-uievent-uievent-53">(2)</a></span><span><a href="#ref-for-uievent-uievent-54">5.6.1. Interface KeyboardEvent</a></span><span><a href="#ref-for-uievent-uievent-55">5.6.4.1. keydown</a> <a href="#ref-for-uievent-uievent-56">(2)</a></span><span><a href="#ref-for-uievent-uievent-57">5.6.4.2. keyup</a> <a href="#ref-for-uievent-uievent-58">(2)</a></span><span><a href="#ref-for-uievent-uievent-59">5.7.1. Interface CompositionEvent</a></span><span><a href="#ref-for-uievent-uievent-60">5.7.7.1. compositionstart</a> <a href="#ref-for-uievent-uievent-61">(2)</a></span><span><a href="#ref-for-uievent-uievent-62">5.7.7.2. compositionupdate</a> <a href="#ref-for-uievent-uievent-63">(2)</a></span><span><a href="#ref-for-uievent-uievent-64">5.7.7.3. compositionend</a> <a href="#ref-for-uievent-uievent-65">(2)</a></span><span><a href="#ref-for-uievent-uievent-66">7.1.1. Initializers for interface UIEvent</a></span><span><a href="#ref-for-uievent-uievent-67">9. Legacy Event Types</a></span><span><a href="#ref-for-uievent-uievent-68">9.1. Legacy UIEvent events</a></span><span><a href="#ref-for-uievent-uievent-69">9.1.1. Legacy UIEvent event types</a></span><span><a href="#ref-for-uievent-uievent-70">9.1.1.1. DOMActivate</a> <a href="#ref-for-uievent-uievent-71">(2)</a> <a href="#ref-for-uievent-uievent-72">(3)</a></span><span><a href="#ref-for-uievent-uievent-73">9.2.1.1. DOMFocusIn</a> <a href="#ref-for-uievent-uievent-74">(2)</a></span><span><a href="#ref-for-uievent-uievent-75">9.2.1.2. DOMFocusOut</a> <a href="#ref-for-uievent-uievent-76">(2)</a></span><span><a href="#ref-for-uievent-uievent-77">9.3.1.1. keypress</a> <a href="#ref-for-uievent-uievent-78">(2)</a></span><span><a href="#ref-for-uievent-uievent-79">12.1. Changes between DOM Level 2 Events and UI Events</a></span></span></dfn> : <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event">Event</a> {
-  readonly attribute <a data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a>? <dfn class="dfn-paneled idl-code" data-dfn-for="UIEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="Window? " id="dom-uievent-view">view<span class="dfn-panel"><b><a href="#dom-uievent-view">#dom-uievent-view</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-uievent-view-1">5.1.2.1. load</a></span><span><a href="#ref-for-dom-uievent-view-2">5.1.2.2. unload</a></span><span><a href="#ref-for-dom-uievent-view-3">5.1.2.3. abort</a></span><span><a href="#ref-for-dom-uievent-view-4">5.1.2.4. error</a></span><span><a href="#ref-for-dom-uievent-view-5">5.1.2.5. select</a></span><span><a href="#ref-for-dom-uievent-view-6">5.2.4.1. blur</a></span><span><a href="#ref-for-dom-uievent-view-7">5.2.4.2. focus</a></span><span><a href="#ref-for-dom-uievent-view-8">5.2.4.3. focusin</a></span><span><a href="#ref-for-dom-uievent-view-9">5.2.4.4. focusout</a></span><span><a href="#ref-for-dom-uievent-view-10">5.3.4.1. click</a></span><span><a href="#ref-for-dom-uievent-view-11">5.3.4.2. dblclick</a></span><span><a href="#ref-for-dom-uievent-view-12">5.3.4.3. mousedown</a></span><span><a href="#ref-for-dom-uievent-view-13">5.3.4.4. mouseenter</a></span><span><a href="#ref-for-dom-uievent-view-14">5.3.4.5. mouseleave</a></span><span><a href="#ref-for-dom-uievent-view-15">5.3.4.6. mousemove</a></span><span><a href="#ref-for-dom-uievent-view-16">5.3.4.7. mouseout</a></span><span><a href="#ref-for-dom-uievent-view-17">5.3.4.8. mouseover</a></span><span><a href="#ref-for-dom-uievent-view-18">5.3.4.9. mouseup</a></span><span><a href="#ref-for-dom-uievent-view-19">5.4.2.1. wheel</a></span><span><a href="#ref-for-dom-uievent-view-20">5.5.3.1. beforeinput</a></span><span><a href="#ref-for-dom-uievent-view-21">5.5.3.2. input</a></span><span><a href="#ref-for-dom-uievent-view-22">5.6.4.1. keydown</a></span><span><a href="#ref-for-dom-uievent-view-23">5.6.4.2. keyup</a></span><span><a href="#ref-for-dom-uievent-view-24">5.7.7.1. compositionstart</a></span><span><a href="#ref-for-dom-uievent-view-25">5.7.7.2. compositionupdate</a></span><span><a href="#ref-for-dom-uievent-view-26">5.7.7.3. compositionend</a></span><span><a href="#ref-for-dom-uievent-view-27">7.1.1. Initializers for interface UIEvent</a></span><span><a href="#ref-for-dom-uievent-view-28">7.1.2. Initializers for interface MouseEvent</a></span><span><a href="#ref-for-dom-uievent-view-29">7.1.3. Initializers for interface WheelEvent</a></span><span><a href="#ref-for-dom-uievent-view-30">7.1.4. Initializers for interface KeyboardEvent</a></span><span><a href="#ref-for-dom-uievent-view-31">7.1.5. Initializers for interface CompositionEvent</a></span><span><a href="#ref-for-dom-uievent-view-32">9.1.1.1. DOMActivate</a></span><span><a href="#ref-for-dom-uievent-view-33">9.2.1.1. DOMFocusIn</a></span><span><a href="#ref-for-dom-uievent-view-34">9.2.1.2. DOMFocusOut</a></span><span><a href="#ref-for-dom-uievent-view-35">9.3.1.1. keypress</a></span></span></dfn>;
-  readonly attribute long <dfn class="dfn-paneled idl-code" data-dfn-for="UIEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="long " id="dom-uievent-detail">detail<span class="dfn-panel"><b><a href="#dom-uievent-detail">#dom-uievent-detail</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-uievent-detail-1">5.1.2.1. load</a></span><span><a href="#ref-for-dom-uievent-detail-2">5.1.2.2. unload</a></span><span><a href="#ref-for-dom-uievent-detail-3">5.1.2.3. abort</a></span><span><a href="#ref-for-dom-uievent-detail-4">5.1.2.4. error</a></span><span><a href="#ref-for-dom-uievent-detail-5">5.1.2.5. select</a></span><span><a href="#ref-for-dom-uievent-detail-6">5.2.4.1. blur</a></span><span><a href="#ref-for-dom-uievent-detail-7">5.2.4.2. focus</a></span><span><a href="#ref-for-dom-uievent-detail-8">5.2.4.3. focusin</a></span><span><a href="#ref-for-dom-uievent-detail-9">5.2.4.4. focusout</a></span><span><a href="#ref-for-dom-uievent-detail-10">5.3.4.1. click</a></span><span><a href="#ref-for-dom-uievent-detail-11">5.3.4.2. dblclick</a></span><span><a href="#ref-for-dom-uievent-detail-12">5.3.4.3. mousedown</a> <a href="#ref-for-dom-uievent-detail-13">(2)</a></span><span><a href="#ref-for-dom-uievent-detail-14">5.3.4.4. mouseenter</a></span><span><a href="#ref-for-dom-uievent-detail-15">5.3.4.5. mouseleave</a></span><span><a href="#ref-for-dom-uievent-detail-16">5.3.4.6. mousemove</a></span><span><a href="#ref-for-dom-uievent-detail-17">5.3.4.7. mouseout</a></span><span><a href="#ref-for-dom-uievent-detail-18">5.3.4.8. mouseover</a></span><span><a href="#ref-for-dom-uievent-detail-19">5.3.4.9. mouseup</a></span><span><a href="#ref-for-dom-uievent-detail-20">5.4.2.1. wheel</a></span><span><a href="#ref-for-dom-uievent-detail-21">5.5.3.1. beforeinput</a></span><span><a href="#ref-for-dom-uievent-detail-22">5.5.3.2. input</a></span><span><a href="#ref-for-dom-uievent-detail-23">5.6.4.1. keydown</a></span><span><a href="#ref-for-dom-uievent-detail-24">5.6.4.2. keyup</a></span><span><a href="#ref-for-dom-uievent-detail-25">5.7.7.1. compositionstart</a></span><span><a href="#ref-for-dom-uievent-detail-26">5.7.7.2. compositionupdate</a></span><span><a href="#ref-for-dom-uievent-detail-27">5.7.7.3. compositionend</a></span><span><a href="#ref-for-dom-uievent-detail-28">7.1.1. Initializers for interface UIEvent</a></span><span><a href="#ref-for-dom-uievent-detail-29">7.1.2. Initializers for interface MouseEvent</a></span><span><a href="#ref-for-dom-uievent-detail-30">7.1.3. Initializers for interface WheelEvent</a></span><span><a href="#ref-for-dom-uievent-detail-31">7.1.4. Initializers for interface KeyboardEvent</a></span><span><a href="#ref-for-dom-uievent-detail-32">7.1.5. Initializers for interface CompositionEvent</a></span><span><a href="#ref-for-dom-uievent-detail-33">9.1.1.1. DOMActivate</a></span><span><a href="#ref-for-dom-uievent-detail-34">9.2.1.1. DOMFocusIn</a></span><span><a href="#ref-for-dom-uievent-detail-35">9.2.1.2. DOMFocusOut</a></span><span><a href="#ref-for-dom-uievent-detail-36">9.3.1.1. keypress</a></span></span></dfn>;
+<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="UIEvent" data-dfn-type="constructor" data-export="" data-lt="UIEvent(type, eventInitDict)|UIEvent(type)" id="dom-uievent-uievent">Constructor<a class="self-link" href="#dom-uievent-uievent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="UIEvent/UIEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-uievent-uievent-type-eventinitdict-type">type<a class="self-link" href="#dom-uievent-uievent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit-uieventinit" id="ref-for-dictdef-uieventinit-uieventinit-2">UIEventInit</a> <dfn class="nv idl-code" data-dfn-for="UIEvent/UIEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-uievent-uievent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-uievent-uievent-type-eventinitdict-eventinitdict"></a></dfn>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="UIEvent" data-dfn-type="interface" data-export="" id="uievent-uievent">UIEvent</dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event">Event</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="UIEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="Window?" id="dom-uievent-view">view</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">long</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="UIEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="long" id="dom-uievent-detail">detail</dfn>;
 };
 </pre>
     <dl>
@@ -1044,9 +1254,9 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-for="UIEvent" data-dfn-type
 				on the type of event. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-2">un-initialized value</a> of this attribute MUST be <code>0</code>.</p>
     </dl>
-<pre class="idl def">dictionary <dfn class="dfn-paneled idl-code" data-dfn-for="UIEventInit" data-dfn-type="dictionary" data-export="" id="dictdef-uieventinit-uieventinit">UIEventInit<span class="dfn-panel"><b><a href="#dictdef-uieventinit-uieventinit">#dictdef-uieventinit-uieventinit</a></b><b>Referenced in:</b><span><a href="#ref-for-dictdef-uieventinit-uieventinit-1">5.1.1. Interface UIEvent</a> <a href="#ref-for-dictdef-uieventinit-uieventinit-2">(2)</a></span><span><a href="#ref-for-dictdef-uieventinit-uieventinit-3">5.2.1. Interface FocusEvent</a></span><span><a href="#ref-for-dictdef-uieventinit-uieventinit-4">5.3.2. Event Modifier Initializers</a></span><span><a href="#ref-for-dictdef-uieventinit-uieventinit-5">5.5.1. Interface InputEvent</a></span><span><a href="#ref-for-dictdef-uieventinit-uieventinit-6">5.7.1. Interface CompositionEvent</a></span></span></dfn> : <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit">EventInit</a> {
-  <a data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a>? <dfn class="idl-code" data-default="null" data-dfn-for="UIEventInit" data-dfn-type="dict-member" data-export="" data-type="Window? " id="dom-uieventinit-view">view<a class="self-link" href="#dom-uieventinit-view"></a></dfn> = null;
-  long <dfn class="idl-code" data-default="0" data-dfn-for="UIEventInit" data-dfn-type="dict-member" data-export="" data-type="long " id="dom-uieventinit-detail">detail<a class="self-link" href="#dom-uieventinit-detail"></a></dfn> = 0;
+<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="UIEventInit" data-dfn-type="dictionary" data-export="" id="dictdef-uieventinit-uieventinit">UIEventInit</dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit">EventInit</a> {
+  <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a>? <dfn class="nv idl-code" data-default="null" data-dfn-for="UIEventInit" data-dfn-type="dict-member" data-export="" data-type="Window? " id="dom-uieventinit-view">view<a class="self-link" href="#dom-uieventinit-view"></a></dfn> = <span class="kt">null</span>;
+  <span class="kt">long</span> <dfn class="nv idl-code" data-default="0" data-dfn-for="UIEventInit" data-dfn-type="dict-member" data-export="" data-type="long " id="dom-uieventinit-detail">detail<a class="self-link" href="#dom-uieventinit-detail"></a></dfn> = 0;
 };
 </pre>
     <dl>
@@ -1063,7 +1273,7 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-for="UIEvent" data-dfn-type
     <p>The User Interface event types are listed below.  Some of these events
 		use the <code class="idl"><a data-link-type="idl" href="#uievent-uievent" id="ref-for-uievent-uievent-3">UIEvent</a></code> interface if generated from a user interface, but
 		the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#event">Event</a></code> interface otherwise, as detailed in each event.</p>
-    <h5 class="heading settled" data-level="5.1.2.1" id="event-type-load"><span class="secno">5.1.2.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="load">load<span class="dfn-panel"><b><a href="#load">#load</a></b><b>Referenced in:</b><span><a href="#ref-for-load-1">3.3. Synchronous and asynchronous events</a></span><span><a href="#ref-for-load-2">4.1. List of Event Types</a> <a href="#ref-for-load-3">(2)</a> <a href="#ref-for-load-4">(3)</a> <a href="#ref-for-load-5">(4)</a></span><span><a href="#ref-for-load-6">5.1.2.1. load</a></span><span><a href="#ref-for-load-7">11. Security Considerations</a> <a href="#ref-for-load-8">(2)</a></span><span><a href="#ref-for-load-9">14. Glossary</a> <a href="#ref-for-load-10">(2)</a></span></span></dfn></span><a class="self-link" href="#event-type-load"></a></h5>
+    <h5 class="heading settled" data-level="5.1.2.1" id="event-type-load"><span class="secno">5.1.2.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="load">load</dfn></span><a class="self-link" href="#event-type-load"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -1108,7 +1318,7 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-for="UIEvent" data-dfn-type
     <p class="note" role="note"> For legacy reasons, <a data-link-type="dfn" href="#load" id="ref-for-load-6"><code>load</code></a> events for resources inside the			document (e.g., images) do not include the <a data-link-type="dfn" href="#window" id="ref-for-window-14">Window</a> in the
 			propagation path in HTML implementations. See <a data-link-type="biblio" href="#biblio-html5">[HTML5]</a> for more
 			information. </p>
-    <h5 class="heading settled" data-level="5.1.2.2" id="event-type-unload"><span class="secno">5.1.2.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="unload">unload<span class="dfn-panel"><b><a href="#unload">#unload</a></b><b>Referenced in:</b><span><a href="#ref-for-unload-1">4.1. List of Event Types</a></span></span></dfn></span><a class="self-link" href="#event-type-unload"></a></h5>
+    <h5 class="heading settled" data-level="5.1.2.2" id="event-type-unload"><span class="secno">5.1.2.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="unload">unload</dfn></span><a class="self-link" href="#event-type-unload"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -1150,7 +1360,7 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-for="UIEvent" data-dfn-type
 			of this event type. If this event type is dispatched,
 			implementations are REQUIRED to dispatch this event at least on
 			the <code>Document</code> node.</p>
-    <h5 class="heading settled" data-level="5.1.2.3" id="event-type-abort"><span class="secno">5.1.2.3. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="abort">abort<span class="dfn-panel"><b><a href="#abort">#abort</a></b><b>Referenced in:</b><span><a href="#ref-for-abort-1">4.1. List of Event Types</a></span></span></dfn></span><a class="self-link" href="#event-type-abort"></a></h5>
+    <h5 class="heading settled" data-level="5.1.2.3" id="event-type-abort"><span class="secno">5.1.2.3. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="abort">abort</dfn></span><a class="self-link" href="#event-type-abort"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -1188,7 +1398,7 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-for="UIEvent" data-dfn-type
     <p>A <a data-link-type="dfn" href="#user-agent" id="ref-for-user-agent-11">user agent</a> MUST dispatch this event when the loading of a
 			resource has been aborted, such as by a user canceling the load
 			while it is still in progress.</p>
-    <h5 class="heading settled" data-level="5.1.2.4" id="event-type-error"><span class="secno">5.1.2.4. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="error">error<span class="dfn-panel"><b><a href="#error">#error</a></b><b>Referenced in:</b><span><a href="#ref-for-error-1">4.1. List of Event Types</a></span><span><a href="#ref-for-error-2">11. Security Considerations</a> <a href="#ref-for-error-3">(2)</a></span></span></dfn></span><a class="self-link" href="#event-type-error"></a></h5>
+    <h5 class="heading settled" data-level="5.1.2.4" id="event-type-error"><span class="secno">5.1.2.4. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="error">error</dfn></span><a class="self-link" href="#event-type-error"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -1227,7 +1437,7 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-for="UIEvent" data-dfn-type
 			to load, or has been loaded but cannot be interpreted according to
 			its semantics, such as an invalid image, a script execution error,
 			or non-well-formed XML.</p>
-    <h5 class="heading settled" data-level="5.1.2.5" id="event-type-select"><span class="secno">5.1.2.5. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="select">select<span class="dfn-panel"><b><a href="#select">#select</a></b><b>Referenced in:</b><span><a href="#ref-for-select-1">4.1. List of Event Types</a></span><span><a href="#ref-for-select-2">5.1.2.5. select</a> <a href="#ref-for-select-3">(2)</a> <a href="#ref-for-select-4">(3)</a> <a href="#ref-for-select-5">(4)</a></span></span></dfn></span><a class="self-link" href="#event-type-select"></a></h5>
+    <h5 class="heading settled" data-level="5.1.2.5" id="event-type-select"><span class="secno">5.1.2.5. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="select">select</dfn></span><a class="self-link" href="#event-type-select"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -1281,9 +1491,9 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-for="UIEvent" data-dfn-type
 		associated with Focus events.</p>
     <p>To create an instance of the <code class="idl"><a data-link-type="idl" href="#focusevent" id="ref-for-focusevent-6">FocusEvent</a></code> interface, use the
 		FocusEvent constructor, passing an optional <code class="idl"><a data-link-type="idl" href="#dictdef-focuseventinit" id="ref-for-dictdef-focuseventinit-1">FocusEventInit</a></code> dictionary.</p>
-<pre class="idl def">[<dfn class="idl-code" data-dfn-for="FocusEvent" data-dfn-type="constructor" data-export="" data-lt="FocusEvent(type, eventInitDict)" id="dom-focusevent-focusevent">Constructor<a class="self-link" href="#dom-focusevent-focusevent"></a></dfn>(DOMString <dfn class="idl-code" data-dfn-for="FocusEvent/FocusEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-focusevent-focusevent-type-eventinitdict-type">type<a class="self-link" href="#dom-focusevent-focusevent-type-eventinitdict-type"></a></dfn>, optional <a data-link-type="idl-name" href="#dictdef-focuseventinit" id="ref-for-dictdef-focuseventinit-2">FocusEventInit</a> <dfn class="idl-code" data-dfn-for="FocusEvent/FocusEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-focusevent-focusevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-focusevent-focusevent-type-eventinitdict-eventinitdict"></a></dfn>)]
-interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="focusevent">FocusEvent<span class="dfn-panel"><b><a href="#focusevent">#focusevent</a></b><b>Referenced in:</b><span><a href="#ref-for-focusevent-1">4.1. List of Event Types</a> <a href="#ref-for-focusevent-2">(2)</a> <a href="#ref-for-focusevent-3">(3)</a> <a href="#ref-for-focusevent-4">(4)</a></span><span><a href="#ref-for-focusevent-5">5.2.1. Interface FocusEvent</a> <a href="#ref-for-focusevent-6">(2)</a></span><span><a href="#ref-for-focusevent-7">5.2.4.1. blur</a> <a href="#ref-for-focusevent-8">(2)</a></span><span><a href="#ref-for-focusevent-9">5.2.4.2. focus</a> <a href="#ref-for-focusevent-10">(2)</a></span><span><a href="#ref-for-focusevent-11">5.2.4.3. focusin</a> <a href="#ref-for-focusevent-12">(2)</a></span><span><a href="#ref-for-focusevent-13">5.2.4.4. focusout</a> <a href="#ref-for-focusevent-14">(2)</a></span><span><a href="#ref-for-focusevent-15">9. Legacy Event Types</a> <a href="#ref-for-focusevent-16">(2)</a></span><span><a href="#ref-for-focusevent-17">9.2. Legacy FocusEvent events</a></span><span><a href="#ref-for-focusevent-18">9.2.1. Legacy FocusEvent event types</a></span><span><a href="#ref-for-focusevent-19">9.2.1.1. DOMFocusIn</a> <a href="#ref-for-focusevent-20">(2)</a></span><span><a href="#ref-for-focusevent-21">9.2.1.2. DOMFocusOut</a> <a href="#ref-for-focusevent-22">(2)</a></span><span><a href="#ref-for-focusevent-23">12.1.4. New Interfaces</a></span></span></dfn> : <a data-link-type="idl-name" href="#uievent-uievent" id="ref-for-uievent-uievent-19">UIEvent</a> {
-  readonly attribute <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <dfn class="dfn-paneled idl-code" data-dfn-for="FocusEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="EventTarget? " id="dom-focusevent-relatedtarget">relatedTarget<span class="dfn-panel"><b><a href="#dom-focusevent-relatedtarget">#dom-focusevent-relatedtarget</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-focusevent-relatedtarget-1">5.2.4.1. blur</a></span><span><a href="#ref-for-dom-focusevent-relatedtarget-2">5.2.4.2. focus</a></span><span><a href="#ref-for-dom-focusevent-relatedtarget-3">5.2.4.3. focusin</a> <a href="#ref-for-dom-focusevent-relatedtarget-4">(2)</a></span><span><a href="#ref-for-dom-focusevent-relatedtarget-5">5.2.4.4. focusout</a></span><span><a href="#ref-for-dom-focusevent-relatedtarget-6">9.2.1.1. DOMFocusIn</a></span><span><a href="#ref-for-dom-focusevent-relatedtarget-7">9.2.1.2. DOMFocusOut</a></span></span></dfn>;
+<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="FocusEvent" data-dfn-type="constructor" data-export="" data-lt="FocusEvent(type, eventInitDict)|FocusEvent(type)" id="dom-focusevent-focusevent">Constructor<a class="self-link" href="#dom-focusevent-focusevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="FocusEvent/FocusEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-focusevent-focusevent-type-eventinitdict-type">type<a class="self-link" href="#dom-focusevent-focusevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-focuseventinit" id="ref-for-dictdef-focuseventinit-2">FocusEventInit</a> <dfn class="nv idl-code" data-dfn-for="FocusEvent/FocusEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-focusevent-focusevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-focusevent-focusevent-type-eventinitdict-eventinitdict"></a></dfn>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="focusevent">FocusEvent</dfn> : <a class="n" data-link-type="idl-name" href="#uievent-uievent" id="ref-for-uievent-uievent-19">UIEvent</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="FocusEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="EventTarget?" id="dom-focusevent-relatedtarget">relatedTarget</dfn>;
 };
 </pre>
     <dl>
@@ -1294,8 +1504,8 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-expor
 				into or out of a nested context, the relevant <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a></code> SHOULD be <code>null</code>.</p>
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-3">un-initialized value</a> of this attribute MUST be <code>null</code>.</p>
     </dl>
-<pre class="idl def">dictionary <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-focuseventinit">FocusEventInit<span class="dfn-panel"><b><a href="#dictdef-focuseventinit">#dictdef-focuseventinit</a></b><b>Referenced in:</b><span><a href="#ref-for-dictdef-focuseventinit-1">5.2.1. Interface FocusEvent</a> <a href="#ref-for-dictdef-focuseventinit-2">(2)</a></span></span></dfn> : <a data-link-type="idl-name" href="#dictdef-uieventinit-uieventinit" id="ref-for-dictdef-uieventinit-uieventinit-3">UIEventInit</a> {
-  <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <dfn class="dfn-paneled idl-code" data-default="null" data-dfn-for="FocusEventInit" data-dfn-type="dict-member" data-export="" data-type="EventTarget? " id="dom-focuseventinit-relatedtarget">relatedTarget<span class="dfn-panel"><b><a href="#dom-focuseventinit-relatedtarget">#dom-focuseventinit-relatedtarget</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-focuseventinit-relatedtarget-1">5.2.1. Interface FocusEvent</a></span></span></dfn> = null;
+<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-focuseventinit">FocusEventInit</dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit-uieventinit" id="ref-for-dictdef-uieventinit-uieventinit-3">UIEventInit</a> {
+  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <dfn class="nv dfn-paneled idl-code" data-default="null" data-dfn-for="FocusEventInit" data-dfn-type="dict-member" data-export="" data-type="EventTarget? " id="dom-focuseventinit-relatedtarget">relatedTarget</dfn> = <span class="kt">null</span>;
 };
 </pre>
     <dl>
@@ -1396,7 +1606,7 @@ document.</p>
 		elements to have the current focus.</p>
     <h4 class="heading settled" data-level="5.2.4" id="events-focus-types"><span class="secno">5.2.4. </span><span class="content">Focus Event Types</span><a class="self-link" href="#events-focus-types"></a></h4>
     <p>The Focus event types are listed below.</p>
-    <h5 class="heading settled" data-level="5.2.4.1" id="event-type-blur"><span class="secno">5.2.4.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="blur">blur<span class="dfn-panel"><b><a href="#blur">#blur</a></b><b>Referenced in:</b><span><a href="#ref-for-blur-1">4.1. List of Event Types</a> <a href="#ref-for-blur-2">(2)</a></span><span><a href="#ref-for-blur-3">5.2.1. Interface FocusEvent</a></span><span><a href="#ref-for-blur-4">5.2.2. Focus Event Order</a></span><span><a href="#ref-for-blur-5">5.2.4.3. focusin</a></span><span><a href="#ref-for-blur-6">5.2.4.4. focusout</a></span><span><a href="#ref-for-blur-7">5.6.4.1. keydown</a></span><span><a href="#ref-for-blur-8">9. Legacy Event Types</a></span><span><a href="#ref-for-blur-9">9.2.1.2. DOMFocusOut</a> <a href="#ref-for-blur-10">(2)</a></span><span><a href="#ref-for-blur-11">9.2.2. Legacy FocusEvent event order</a></span><span><a href="#ref-for-blur-12">9.3.1.1. keypress</a></span><span><a href="#ref-for-blur-13">12.1. Changes between DOM Level 2 Events and UI Events</a></span></span></dfn></span><a class="self-link" href="#event-type-blur"></a></h5>
+    <h5 class="heading settled" data-level="5.2.4.1" id="event-type-blur"><span class="secno">5.2.4.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="blur">blur</dfn></span><a class="self-link" href="#event-type-blur"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -1418,6 +1628,9 @@ document.</p>
        <th>Cancelable
        <td>No
       <tr>
+       <th>Composed
+       <td>Yes
+      <tr>
        <th>Default action
        <td>None
       <tr>
@@ -1434,7 +1647,7 @@ document.</p>
 			target</a> loses focus. The focus MUST be taken from the element
 			before the dispatch of this event type.  This event type is similar
 			to <a data-link-type="dfn" href="#focusout" id="ref-for-focusout-4"><code>focusout</code></a>, but is dispatched after focus is shifted, and			does not bubble.</p>
-    <h5 class="heading settled" data-level="5.2.4.2" id="event-type-focus"><span class="secno">5.2.4.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="focus">focus<span class="dfn-panel"><b><a href="#focus">#focus</a></b><b>Referenced in:</b><span><a href="#ref-for-focus-1">4.1. List of Event Types</a> <a href="#ref-for-focus-2">(2)</a></span><span><a href="#ref-for-focus-3">5.2.1. Interface FocusEvent</a></span><span><a href="#ref-for-focus-4">5.2.2. Focus Event Order</a> <a href="#ref-for-focus-5">(2)</a></span><span><a href="#ref-for-focus-6">5.2.3. Document Focus and Focus Context</a></span><span><a href="#ref-for-focus-7">5.2.4.3. focusin</a></span><span><a href="#ref-for-focus-8">5.6.4.1. keydown</a></span><span><a href="#ref-for-focus-9">9. Legacy Event Types</a></span><span><a href="#ref-for-focus-10">9.2.1.1. DOMFocusIn</a> <a href="#ref-for-focus-11">(2)</a></span><span><a href="#ref-for-focus-12">9.2.2. Legacy FocusEvent event order</a> <a href="#ref-for-focus-13">(2)</a></span><span><a href="#ref-for-focus-14">9.3.1.1. keypress</a></span><span><a href="#ref-for-focus-15">12.1. Changes between DOM Level 2 Events and UI Events</a></span></span></dfn></span><a class="self-link" href="#event-type-focus"></a></h5>
+    <h5 class="heading settled" data-level="5.2.4.2" id="event-type-focus"><span class="secno">5.2.4.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="focus">focus</dfn></span><a class="self-link" href="#event-type-focus"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -1456,6 +1669,9 @@ document.</p>
        <th>Cancelable
        <td>No
       <tr>
+       <th>Composed
+       <td>Yes
+      <tr>
        <th>Default action
        <td>None
       <tr>
@@ -1472,7 +1688,7 @@ document.</p>
 			target</a> receives focus. The focus MUST be given to the element
 			before the dispatch of this event type.  This event type is similar
 			to <a data-link-type="dfn" href="#focusin" id="ref-for-focusin-5"><code>focusin</code></a>, but is dispatched after focus is shifted, and			does not bubble.</p>
-    <h5 class="heading settled" data-level="5.2.4.3" id="event-type-focusin"><span class="secno">5.2.4.3. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="focusin">focusin<span class="dfn-panel"><b><a href="#focusin">#focusin</a></b><b>Referenced in:</b><span><a href="#ref-for-focusin-1">4.1. List of Event Types</a></span><span><a href="#ref-for-focusin-2">5.2.1. Interface FocusEvent</a></span><span><a href="#ref-for-focusin-3">5.2.2. Focus Event Order</a> <a href="#ref-for-focusin-4">(2)</a></span><span><a href="#ref-for-focusin-5">5.2.4.2. focus</a></span><span><a href="#ref-for-focusin-6">9.2.1.1. DOMFocusIn</a></span><span><a href="#ref-for-focusin-7">9.2.2. Legacy FocusEvent event order</a> <a href="#ref-for-focusin-8">(2)</a></span></span></dfn></span><a class="self-link" href="#event-type-focusin"></a></h5>
+    <h5 class="heading settled" data-level="5.2.4.3" id="event-type-focusin"><span class="secno">5.2.4.3. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="focusin">focusin</dfn></span><a class="self-link" href="#event-type-focusin"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -1493,6 +1709,9 @@ document.</p>
       <tr>
        <th>Cancelable
        <td>No
+      <tr>
+       <th>Composed
+       <td>Yes
       <tr>
        <th>Default action
        <td>None
@@ -1516,7 +1735,7 @@ document.</p>
 			focus shifts to the next focus <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-17">event target</a>, thus having
 			access to both the element losing focus and the element gaining
 			focus without the use of the <a data-link-type="dfn" href="#blur" id="ref-for-blur-5"><code>blur</code></a> or <a data-link-type="dfn" href="#focusout" id="ref-for-focusout-5"><code>focusout</code></a> event			types. </p>
-    <h5 class="heading settled" data-level="5.2.4.4" id="event-type-focusout"><span class="secno">5.2.4.4. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="focusout">focusout<span class="dfn-panel"><b><a href="#focusout">#focusout</a></b><b>Referenced in:</b><span><a href="#ref-for-focusout-1">4.1. List of Event Types</a></span><span><a href="#ref-for-focusout-2">5.2.1. Interface FocusEvent</a></span><span><a href="#ref-for-focusout-3">5.2.2. Focus Event Order</a></span><span><a href="#ref-for-focusout-4">5.2.4.1. blur</a></span><span><a href="#ref-for-focusout-5">5.2.4.3. focusin</a></span><span><a href="#ref-for-focusout-6">9.2.1.2. DOMFocusOut</a></span><span><a href="#ref-for-focusout-7">9.2.2. Legacy FocusEvent event order</a></span></span></dfn></span><a class="self-link" href="#event-type-focusout"></a></h5>
+    <h5 class="heading settled" data-level="5.2.4.4" id="event-type-focusout"><span class="secno">5.2.4.4. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="focusout">focusout</dfn></span><a class="self-link" href="#event-type-focusout"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -1537,6 +1756,9 @@ document.</p>
       <tr>
        <th>Cancelable
        <td>No
+      <tr>
+       <th>Composed
+       <td>Yes
       <tr>
        <th>Default action
        <td>None
@@ -1567,29 +1789,29 @@ document.</p>
     <p class="note" role="note"> Ancestors of the targeted element can use event bubbling to obtain
 		notifications of mouse events which occur within their descendent
 		elements. </p>
-    <p>To create an instance of the <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-15">MouseEvent</a></code> interface, use the <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-16">MouseEvent</a></code> constructor, passing an optional <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dictdef-mouseeventinit">MouseEventInit</a></code> dictionary.</p>
+    <p>To create an instance of the <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-15">MouseEvent</a></code> interface, use the <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-16">MouseEvent</a></code> constructor, passing an optional <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dictdef-mouseeventinit">MouseEventInit</a></code> dictionary.</p>
     <p class="note" role="note"> When initializing <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-17">MouseEvent</a></code> objects using <code>initMouseEvent</code>,
-		implementations can use the client coordinates <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clientx">clientX</a></code> and <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clienty">clientY</a></code> for calculation of other coordinates (such
+		implementations can use the client coordinates <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clientx">clientX</a></code> and <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clienty">clientY</a></code> for calculation of other coordinates (such
 		as target coordinates exposed by <a data-link-type="dfn" href="#dom-level-0" id="ref-for-dom-level-0-1">DOM Level 0</a> implementations or
 		other proprietary attributes, e.g., <code>pageX</code>). </p>
-<pre class="idl def">[<dfn class="idl-code" data-dfn-for="MouseEvent" data-dfn-type="constructor" data-export="" data-lt="MouseEvent(type, eventInitDict)" id="dom-mouseevent-mouseevent">Constructor<a class="self-link" href="#dom-mouseevent-mouseevent"></a></dfn>(DOMString <dfn class="idl-code" data-dfn-for="MouseEvent/MouseEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-mouseevent-mouseevent-type-eventinitdict-type">type<a class="self-link" href="#dom-mouseevent-mouseevent-type-eventinitdict-type"></a></dfn>, optional <a data-link-type="idl-name" href="https://drafts.csswg.org/cssom-view-1/#dictdef-mouseeventinit">MouseEventInit</a> <dfn class="idl-code" data-dfn-for="MouseEvent/MouseEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-mouseevent-mouseevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-mouseevent-mouseevent-type-eventinitdict-eventinitdict"></a></dfn>)]
-interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="mouseevent">MouseEvent<span class="dfn-panel"><b><a href="#mouseevent">#mouseevent</a></b><b>Referenced in:</b><span><a href="#ref-for-mouseevent-1">3.6. Constructing Mouse and Keyboard Events</a> <a href="#ref-for-mouseevent-2">(2)</a> <a href="#ref-for-mouseevent-3">(3)</a> <a href="#ref-for-mouseevent-4">(4)</a></span><span><a href="#ref-for-mouseevent-5">4.1. List of Event Types</a> <a href="#ref-for-mouseevent-6">(2)</a> <a href="#ref-for-mouseevent-7">(3)</a> <a href="#ref-for-mouseevent-8">(4)</a> <a href="#ref-for-mouseevent-9">(5)</a> <a href="#ref-for-mouseevent-10">(6)</a> <a href="#ref-for-mouseevent-11">(7)</a> <a href="#ref-for-mouseevent-12">(8)</a> <a href="#ref-for-mouseevent-13">(9)</a></span><span><a href="#ref-for-mouseevent-14">5.3.1. Interface MouseEvent</a> <a href="#ref-for-mouseevent-15">(2)</a> <a href="#ref-for-mouseevent-16">(3)</a> <a href="#ref-for-mouseevent-17">(4)</a> <a href="#ref-for-mouseevent-18">(5)</a></span><span><a href="#ref-for-mouseevent-19">5.3.2. Event Modifier Initializers</a> <a href="#ref-for-mouseevent-20">(2)</a> <a href="#ref-for-mouseevent-21">(3)</a> <a href="#ref-for-mouseevent-22">(4)</a> <a href="#ref-for-mouseevent-23">(5)</a> <a href="#ref-for-mouseevent-24">(6)</a></span><span><a href="#ref-for-mouseevent-25">5.3.4.1. click</a> <a href="#ref-for-mouseevent-26">(2)</a> <a href="#ref-for-mouseevent-27">(3)</a> <a href="#ref-for-mouseevent-28">(4)</a> <a href="#ref-for-mouseevent-29">(5)</a> <a href="#ref-for-mouseevent-30">(6)</a> <a href="#ref-for-mouseevent-31">(7)</a> <a href="#ref-for-mouseevent-32">(8)</a> <a href="#ref-for-mouseevent-33">(9)</a> <a href="#ref-for-mouseevent-34">(10)</a> <a href="#ref-for-mouseevent-35">(11)</a> <a href="#ref-for-mouseevent-36">(12)</a></span><span><a href="#ref-for-mouseevent-37">5.3.4.2. dblclick</a> <a href="#ref-for-mouseevent-38">(2)</a> <a href="#ref-for-mouseevent-39">(3)</a> <a href="#ref-for-mouseevent-40">(4)</a> <a href="#ref-for-mouseevent-41">(5)</a> <a href="#ref-for-mouseevent-42">(6)</a> <a href="#ref-for-mouseevent-43">(7)</a> <a href="#ref-for-mouseevent-44">(8)</a> <a href="#ref-for-mouseevent-45">(9)</a> <a href="#ref-for-mouseevent-46">(10)</a> <a href="#ref-for-mouseevent-47">(11)</a> <a href="#ref-for-mouseevent-48">(12)</a></span><span><a href="#ref-for-mouseevent-49">5.3.4.3. mousedown</a> <a href="#ref-for-mouseevent-50">(2)</a> <a href="#ref-for-mouseevent-51">(3)</a> <a href="#ref-for-mouseevent-52">(4)</a> <a href="#ref-for-mouseevent-53">(5)</a> <a href="#ref-for-mouseevent-54">(6)</a> <a href="#ref-for-mouseevent-55">(7)</a> <a href="#ref-for-mouseevent-56">(8)</a> <a href="#ref-for-mouseevent-57">(9)</a> <a href="#ref-for-mouseevent-58">(10)</a> <a href="#ref-for-mouseevent-59">(11)</a> <a href="#ref-for-mouseevent-60">(12)</a></span><span><a href="#ref-for-mouseevent-61">5.3.4.4. mouseenter</a> <a href="#ref-for-mouseevent-62">(2)</a> <a href="#ref-for-mouseevent-63">(3)</a> <a href="#ref-for-mouseevent-64">(4)</a> <a href="#ref-for-mouseevent-65">(5)</a> <a href="#ref-for-mouseevent-66">(6)</a> <a href="#ref-for-mouseevent-67">(7)</a> <a href="#ref-for-mouseevent-68">(8)</a> <a href="#ref-for-mouseevent-69">(9)</a> <a href="#ref-for-mouseevent-70">(10)</a> <a href="#ref-for-mouseevent-71">(11)</a> <a href="#ref-for-mouseevent-72">(12)</a></span><span><a href="#ref-for-mouseevent-73">5.3.4.5. mouseleave</a> <a href="#ref-for-mouseevent-74">(2)</a> <a href="#ref-for-mouseevent-75">(3)</a> <a href="#ref-for-mouseevent-76">(4)</a> <a href="#ref-for-mouseevent-77">(5)</a> <a href="#ref-for-mouseevent-78">(6)</a> <a href="#ref-for-mouseevent-79">(7)</a> <a href="#ref-for-mouseevent-80">(8)</a> <a href="#ref-for-mouseevent-81">(9)</a> <a href="#ref-for-mouseevent-82">(10)</a> <a href="#ref-for-mouseevent-83">(11)</a> <a href="#ref-for-mouseevent-84">(12)</a></span><span><a href="#ref-for-mouseevent-85">5.3.4.6. mousemove</a> <a href="#ref-for-mouseevent-86">(2)</a> <a href="#ref-for-mouseevent-87">(3)</a> <a href="#ref-for-mouseevent-88">(4)</a> <a href="#ref-for-mouseevent-89">(5)</a> <a href="#ref-for-mouseevent-90">(6)</a> <a href="#ref-for-mouseevent-91">(7)</a> <a href="#ref-for-mouseevent-92">(8)</a> <a href="#ref-for-mouseevent-93">(9)</a> <a href="#ref-for-mouseevent-94">(10)</a> <a href="#ref-for-mouseevent-95">(11)</a> <a href="#ref-for-mouseevent-96">(12)</a></span><span><a href="#ref-for-mouseevent-97">5.3.4.7. mouseout</a> <a href="#ref-for-mouseevent-98">(2)</a> <a href="#ref-for-mouseevent-99">(3)</a> <a href="#ref-for-mouseevent-100">(4)</a> <a href="#ref-for-mouseevent-101">(5)</a> <a href="#ref-for-mouseevent-102">(6)</a> <a href="#ref-for-mouseevent-103">(7)</a> <a href="#ref-for-mouseevent-104">(8)</a> <a href="#ref-for-mouseevent-105">(9)</a> <a href="#ref-for-mouseevent-106">(10)</a> <a href="#ref-for-mouseevent-107">(11)</a> <a href="#ref-for-mouseevent-108">(12)</a></span><span><a href="#ref-for-mouseevent-109">5.3.4.8. mouseover</a> <a href="#ref-for-mouseevent-110">(2)</a> <a href="#ref-for-mouseevent-111">(3)</a> <a href="#ref-for-mouseevent-112">(4)</a> <a href="#ref-for-mouseevent-113">(5)</a> <a href="#ref-for-mouseevent-114">(6)</a> <a href="#ref-for-mouseevent-115">(7)</a> <a href="#ref-for-mouseevent-116">(8)</a> <a href="#ref-for-mouseevent-117">(9)</a> <a href="#ref-for-mouseevent-118">(10)</a> <a href="#ref-for-mouseevent-119">(11)</a> <a href="#ref-for-mouseevent-120">(12)</a></span><span><a href="#ref-for-mouseevent-121">5.3.4.9. mouseup</a> <a href="#ref-for-mouseevent-122">(2)</a> <a href="#ref-for-mouseevent-123">(3)</a> <a href="#ref-for-mouseevent-124">(4)</a> <a href="#ref-for-mouseevent-125">(5)</a> <a href="#ref-for-mouseevent-126">(6)</a> <a href="#ref-for-mouseevent-127">(7)</a> <a href="#ref-for-mouseevent-128">(8)</a> <a href="#ref-for-mouseevent-129">(9)</a> <a href="#ref-for-mouseevent-130">(10)</a> <a href="#ref-for-mouseevent-131">(11)</a> <a href="#ref-for-mouseevent-132">(12)</a></span><span><a href="#ref-for-mouseevent-133">5.4.1. Interface WheelEvent</a></span><span><a href="#ref-for-mouseevent-134">5.4.2.1. wheel</a> <a href="#ref-for-mouseevent-135">(2)</a> <a href="#ref-for-mouseevent-136">(3)</a> <a href="#ref-for-mouseevent-137">(4)</a> <a href="#ref-for-mouseevent-138">(5)</a> <a href="#ref-for-mouseevent-139">(6)</a> <a href="#ref-for-mouseevent-140">(7)</a> <a href="#ref-for-mouseevent-141">(8)</a> <a href="#ref-for-mouseevent-142">(9)</a> <a href="#ref-for-mouseevent-143">(10)</a> <a href="#ref-for-mouseevent-144">(11)</a></span><span><a href="#ref-for-mouseevent-145">7.1.2. Initializers for interface MouseEvent</a></span><span><a href="#ref-for-mouseevent-146">12.1. Changes between DOM Level 2 Events and UI Events</a></span><span><a href="#ref-for-mouseevent-147">12.1.3. Changes to DOM Level 2 Events interfaces</a> <a href="#ref-for-mouseevent-148">(2)</a></span></span></dfn> : <a data-link-type="idl-name" href="#uievent-uievent" id="ref-for-uievent-uievent-28">UIEvent</a> {
-  readonly attribute long <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="long " href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screenx">screenX</a>;
-  readonly attribute long <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="long " href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screeny">screenY</a>;
-  readonly attribute long <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="long " href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clientx">clientX</a>;
-  readonly attribute long <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="long " href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clienty">clientY</a>;
+<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="MouseEvent" data-dfn-type="constructor" data-export="" data-lt="MouseEvent(type, eventInitDict)|MouseEvent(type)" id="dom-mouseevent-mouseevent">Constructor<a class="self-link" href="#dom-mouseevent-mouseevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="MouseEvent/MouseEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-mouseevent-mouseevent-type-eventinitdict-type">type<a class="self-link" href="#dom-mouseevent-mouseevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/cssom-view/#dictdef-mouseeventinit">MouseEventInit</a> <dfn class="nv idl-code" data-dfn-for="MouseEvent/MouseEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-mouseevent-mouseevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-mouseevent-mouseevent-type-eventinitdict-eventinitdict"></a></dfn>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="mouseevent">MouseEvent</dfn> : <a class="n" data-link-type="idl-name" href="#uievent-uievent" id="ref-for-uievent-uievent-28">UIEvent</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screenx">screenX</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screeny">screenY</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clientx">clientX</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clienty">clientY</a>;
 
-  readonly attribute boolean <dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean " id="dom-mouseevent-ctrlkey">ctrlKey<span class="dfn-panel"><b><a href="#dom-mouseevent-ctrlkey">#dom-mouseevent-ctrlkey</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-mouseevent-ctrlkey-1">5.3.4.1. click</a></span><span><a href="#ref-for-dom-mouseevent-ctrlkey-2">5.3.4.2. dblclick</a></span><span><a href="#ref-for-dom-mouseevent-ctrlkey-3">5.3.4.3. mousedown</a></span><span><a href="#ref-for-dom-mouseevent-ctrlkey-4">5.3.4.4. mouseenter</a></span><span><a href="#ref-for-dom-mouseevent-ctrlkey-5">5.3.4.5. mouseleave</a></span><span><a href="#ref-for-dom-mouseevent-ctrlkey-6">5.3.4.6. mousemove</a></span><span><a href="#ref-for-dom-mouseevent-ctrlkey-7">5.3.4.7. mouseout</a></span><span><a href="#ref-for-dom-mouseevent-ctrlkey-8">5.3.4.8. mouseover</a></span><span><a href="#ref-for-dom-mouseevent-ctrlkey-9">5.3.4.9. mouseup</a></span><span><a href="#ref-for-dom-mouseevent-ctrlkey-10">5.4.2.1. wheel</a></span><span><a href="#ref-for-dom-mouseevent-ctrlkey-11">7.1.2. Initializers for interface MouseEvent</a></span><span><a href="#ref-for-dom-mouseevent-ctrlkey-12">7.1.3. Initializers for interface WheelEvent</a></span></span></dfn>;
-  readonly attribute boolean <dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean " id="dom-mouseevent-shiftkey">shiftKey<span class="dfn-panel"><b><a href="#dom-mouseevent-shiftkey">#dom-mouseevent-shiftkey</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-mouseevent-shiftkey-1">5.3.4.1. click</a></span><span><a href="#ref-for-dom-mouseevent-shiftkey-2">5.3.4.2. dblclick</a></span><span><a href="#ref-for-dom-mouseevent-shiftkey-3">5.3.4.3. mousedown</a></span><span><a href="#ref-for-dom-mouseevent-shiftkey-4">5.3.4.4. mouseenter</a></span><span><a href="#ref-for-dom-mouseevent-shiftkey-5">5.3.4.5. mouseleave</a></span><span><a href="#ref-for-dom-mouseevent-shiftkey-6">5.3.4.6. mousemove</a></span><span><a href="#ref-for-dom-mouseevent-shiftkey-7">5.3.4.7. mouseout</a></span><span><a href="#ref-for-dom-mouseevent-shiftkey-8">5.3.4.8. mouseover</a></span><span><a href="#ref-for-dom-mouseevent-shiftkey-9">5.3.4.9. mouseup</a></span><span><a href="#ref-for-dom-mouseevent-shiftkey-10">5.4.2.1. wheel</a></span><span><a href="#ref-for-dom-mouseevent-shiftkey-11">7.1.2. Initializers for interface MouseEvent</a></span><span><a href="#ref-for-dom-mouseevent-shiftkey-12">7.1.3. Initializers for interface WheelEvent</a></span></span></dfn>;
-  readonly attribute boolean <dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean " id="dom-mouseevent-altkey">altKey<span class="dfn-panel"><b><a href="#dom-mouseevent-altkey">#dom-mouseevent-altkey</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-mouseevent-altkey-1">5.3.4.1. click</a></span><span><a href="#ref-for-dom-mouseevent-altkey-2">5.3.4.2. dblclick</a></span><span><a href="#ref-for-dom-mouseevent-altkey-3">5.3.4.3. mousedown</a></span><span><a href="#ref-for-dom-mouseevent-altkey-4">5.3.4.4. mouseenter</a></span><span><a href="#ref-for-dom-mouseevent-altkey-5">5.3.4.5. mouseleave</a></span><span><a href="#ref-for-dom-mouseevent-altkey-6">5.3.4.6. mousemove</a></span><span><a href="#ref-for-dom-mouseevent-altkey-7">5.3.4.7. mouseout</a></span><span><a href="#ref-for-dom-mouseevent-altkey-8">5.3.4.8. mouseover</a></span><span><a href="#ref-for-dom-mouseevent-altkey-9">5.3.4.9. mouseup</a></span><span><a href="#ref-for-dom-mouseevent-altkey-10">5.4.2.1. wheel</a></span><span><a href="#ref-for-dom-mouseevent-altkey-11">7.1.2. Initializers for interface MouseEvent</a></span></span></dfn>;
-  readonly attribute boolean <dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean " id="dom-mouseevent-metakey">metaKey<span class="dfn-panel"><b><a href="#dom-mouseevent-metakey">#dom-mouseevent-metakey</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-mouseevent-metakey-1">5.3.4.1. click</a></span><span><a href="#ref-for-dom-mouseevent-metakey-2">5.3.4.2. dblclick</a></span><span><a href="#ref-for-dom-mouseevent-metakey-3">5.3.4.3. mousedown</a></span><span><a href="#ref-for-dom-mouseevent-metakey-4">5.3.4.4. mouseenter</a></span><span><a href="#ref-for-dom-mouseevent-metakey-5">5.3.4.5. mouseleave</a></span><span><a href="#ref-for-dom-mouseevent-metakey-6">5.3.4.6. mousemove</a></span><span><a href="#ref-for-dom-mouseevent-metakey-7">5.3.4.7. mouseout</a></span><span><a href="#ref-for-dom-mouseevent-metakey-8">5.3.4.8. mouseover</a></span><span><a href="#ref-for-dom-mouseevent-metakey-9">5.3.4.9. mouseup</a></span><span><a href="#ref-for-dom-mouseevent-metakey-10">5.4.2.1. wheel</a></span><span><a href="#ref-for-dom-mouseevent-metakey-11">7.1.2. Initializers for interface MouseEvent</a></span></span></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean" id="dom-mouseevent-ctrlkey">ctrlKey</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean" id="dom-mouseevent-shiftkey">shiftKey</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean" id="dom-mouseevent-altkey">altKey</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean" id="dom-mouseevent-metakey">metaKey</dfn>;
 
-  readonly attribute short <dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="short " id="dom-mouseevent-button">button<span class="dfn-panel"><b><a href="#dom-mouseevent-button">#dom-mouseevent-button</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-mouseevent-button-1">5.3.1. Interface MouseEvent</a> <a href="#ref-for-dom-mouseevent-button-2">(2)</a> <a href="#ref-for-dom-mouseevent-button-3">(3)</a> <a href="#ref-for-dom-mouseevent-button-4">(4)</a></span><span><a href="#ref-for-dom-mouseevent-button-5">5.3.4.1. click</a> <a href="#ref-for-dom-mouseevent-button-6">(2)</a> <a href="#ref-for-dom-mouseevent-button-7">(3)</a></span><span><a href="#ref-for-dom-mouseevent-button-8">5.3.4.2. dblclick</a> <a href="#ref-for-dom-mouseevent-button-9">(2)</a></span><span><a href="#ref-for-dom-mouseevent-button-10">5.3.4.3. mousedown</a></span><span><a href="#ref-for-dom-mouseevent-button-11">5.3.4.4. mouseenter</a></span><span><a href="#ref-for-dom-mouseevent-button-12">5.3.4.5. mouseleave</a></span><span><a href="#ref-for-dom-mouseevent-button-13">5.3.4.6. mousemove</a></span><span><a href="#ref-for-dom-mouseevent-button-14">5.3.4.7. mouseout</a></span><span><a href="#ref-for-dom-mouseevent-button-15">5.3.4.8. mouseover</a></span><span><a href="#ref-for-dom-mouseevent-button-16">5.3.4.9. mouseup</a></span><span><a href="#ref-for-dom-mouseevent-button-17">5.4.2.1. wheel</a></span><span><a href="#ref-for-dom-mouseevent-button-18">7.1.2. Initializers for interface MouseEvent</a></span><span><a href="#ref-for-dom-mouseevent-button-19">7.1.3. Initializers for interface WheelEvent</a></span></span></dfn>;
-  readonly attribute unsigned short <dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unsigned short " id="dom-mouseevent-buttons">buttons<span class="dfn-panel"><b><a href="#dom-mouseevent-buttons">#dom-mouseevent-buttons</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-mouseevent-buttons-1">5.3.1. Interface MouseEvent</a> <a href="#ref-for-dom-mouseevent-buttons-2">(2)</a> <a href="#ref-for-dom-mouseevent-buttons-3">(3)</a></span><span><a href="#ref-for-dom-mouseevent-buttons-4">5.3.4.1. click</a> <a href="#ref-for-dom-mouseevent-buttons-5">(2)</a> <a href="#ref-for-dom-mouseevent-buttons-6">(3)</a></span><span><a href="#ref-for-dom-mouseevent-buttons-7">5.3.4.2. dblclick</a> <a href="#ref-for-dom-mouseevent-buttons-8">(2)</a></span><span><a href="#ref-for-dom-mouseevent-buttons-9">5.3.4.3. mousedown</a></span><span><a href="#ref-for-dom-mouseevent-buttons-10">5.3.4.4. mouseenter</a></span><span><a href="#ref-for-dom-mouseevent-buttons-11">5.3.4.5. mouseleave</a></span><span><a href="#ref-for-dom-mouseevent-buttons-12">5.3.4.6. mousemove</a></span><span><a href="#ref-for-dom-mouseevent-buttons-13">5.3.4.7. mouseout</a></span><span><a href="#ref-for-dom-mouseevent-buttons-14">5.3.4.8. mouseover</a></span><span><a href="#ref-for-dom-mouseevent-buttons-15">5.3.4.9. mouseup</a></span><span><a href="#ref-for-dom-mouseevent-buttons-16">5.4.2.1. wheel</a></span></span></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">short</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="short" id="dom-mouseevent-button">button</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">short</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unsigned short" id="dom-mouseevent-buttons">buttons</dfn>;
 
-  readonly attribute <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="EventTarget? " id="dom-mouseevent-relatedtarget">relatedTarget<span class="dfn-panel"><b><a href="#dom-mouseevent-relatedtarget">#dom-mouseevent-relatedtarget</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-mouseevent-relatedtarget-1">5.3.4.1. click</a></span><span><a href="#ref-for-dom-mouseevent-relatedtarget-2">5.3.4.2. dblclick</a></span><span><a href="#ref-for-dom-mouseevent-relatedtarget-3">5.3.4.3. mousedown</a></span><span><a href="#ref-for-dom-mouseevent-relatedtarget-4">5.3.4.4. mouseenter</a></span><span><a href="#ref-for-dom-mouseevent-relatedtarget-5">5.3.4.5. mouseleave</a></span><span><a href="#ref-for-dom-mouseevent-relatedtarget-6">5.3.4.6. mousemove</a></span><span><a href="#ref-for-dom-mouseevent-relatedtarget-7">5.3.4.7. mouseout</a></span><span><a href="#ref-for-dom-mouseevent-relatedtarget-8">5.3.4.8. mouseover</a></span><span><a href="#ref-for-dom-mouseevent-relatedtarget-9">5.3.4.9. mouseup</a></span><span><a href="#ref-for-dom-mouseevent-relatedtarget-10">5.4.2.1. wheel</a></span><span><a href="#ref-for-dom-mouseevent-relatedtarget-11">7.1.2. Initializers for interface MouseEvent</a></span><span><a href="#ref-for-dom-mouseevent-relatedtarget-12">7.1.3. Initializers for interface WheelEvent</a></span></span></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="EventTarget?" id="dom-mouseevent-relatedtarget">relatedTarget</dfn>;
 
-  boolean <dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="method" data-export="" data-lt="getModifierState(keyArg)" id="dom-mouseevent-getmodifierstate">getModifierState<span class="dfn-panel"><b><a href="#dom-mouseevent-getmodifierstate">#dom-mouseevent-getmodifierstate</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-mouseevent-getmodifierstate-1">3.6. Constructing Mouse and Keyboard Events</a></span><span><a href="#ref-for-dom-mouseevent-getmodifierstate-2">5.3.2. Event Modifier Initializers</a> <a href="#ref-for-dom-mouseevent-getmodifierstate-3">(2)</a> <a href="#ref-for-dom-mouseevent-getmodifierstate-4">(3)</a> <a href="#ref-for-dom-mouseevent-getmodifierstate-5">(4)</a> <a href="#ref-for-dom-mouseevent-getmodifierstate-6">(5)</a> <a href="#ref-for-dom-mouseevent-getmodifierstate-7">(6)</a> <a href="#ref-for-dom-mouseevent-getmodifierstate-8">(7)</a> <a href="#ref-for-dom-mouseevent-getmodifierstate-9">(8)</a> <a href="#ref-for-dom-mouseevent-getmodifierstate-10">(9)</a> <a href="#ref-for-dom-mouseevent-getmodifierstate-11">(10)</a> <a href="#ref-for-dom-mouseevent-getmodifierstate-12">(11)</a> <a href="#ref-for-dom-mouseevent-getmodifierstate-13">(12)</a> <a href="#ref-for-dom-mouseevent-getmodifierstate-14">(13)</a> <a href="#ref-for-dom-mouseevent-getmodifierstate-15">(14)</a></span><span><a href="#ref-for-dom-mouseevent-getmodifierstate-16">12.1.3. Changes to DOM Level 2 Events interfaces</a></span></span></dfn>(DOMString <dfn class="idl-code" data-dfn-for="MouseEvent/getModifierState(keyArg)" data-dfn-type="argument" data-export="" id="dom-mouseevent-getmodifierstate-keyarg-keyarg">keyArg<a class="self-link" href="#dom-mouseevent-getmodifierstate-keyarg-keyarg"></a></dfn>);
+  <span class="kt">boolean</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="method" data-export="" data-lt="getModifierState(keyArg)" id="dom-mouseevent-getmodifierstate">getModifierState</dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="MouseEvent/getModifierState(keyArg)" data-dfn-type="argument" data-export="" id="dom-mouseevent-getmodifierstate-keyarg-keyarg">keyArg<a class="self-link" href="#dom-mouseevent-getmodifierstate-keyarg-keyarg"></a></dfn>);
 };
 </pre>
     <dl>
@@ -1707,15 +1929,15 @@ used to activate a user interface control or select text).</p>
        <dd> Refer to the <code class="idl"><a data-link-type="idl" href="#keyboardevent-keyboardevent" id="ref-for-keyboardevent-keyboardevent-10">KeyboardEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate-2">getModifierState()</a></code> method for a description of this parameter. 
       </dl>
     </dl>
-<pre class="idl def">dictionary <a class="idl-code" data-link-type="dictionary" href="https://drafts.csswg.org/cssom-view-1/#dictdef-mouseeventinit">MouseEventInit</a> : <a data-link-type="idl-name" href="#dictdef-eventmodifierinit" id="ref-for-dictdef-eventmodifierinit-3">EventModifierInit</a> {
-  long <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="https://drafts.csswg.org/cssom-view-1/#dom-mouseeventinit-screenx">screenX</a> = 0;
-  long <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="https://drafts.csswg.org/cssom-view-1/#dom-mouseeventinit-screeny">screenY</a> = 0;
-  long <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="https://drafts.csswg.org/cssom-view-1/#dom-mouseeventinit-clientx">clientX</a> = 0;
-  long <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="https://drafts.csswg.org/cssom-view-1/#dom-mouseeventinit-clienty">clientY</a> = 0;
+<pre class="idl highlight def"><span class="kt">dictionary</span> <a class="nv idl-code" data-link-type="dictionary" href="https://www.w3.org/TR/cssom-view/#dictdef-mouseeventinit">MouseEventInit</a> : <a class="n" data-link-type="idl-name" href="#dictdef-eventmodifierinit" id="ref-for-dictdef-eventmodifierinit-3">EventModifierInit</a> {
+  <span class="kt">long</span> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="https://www.w3.org/TR/cssom-view/#dom-mouseeventinit-screenx">screenX</a> = 0;
+  <span class="kt">long</span> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="https://www.w3.org/TR/cssom-view/#dom-mouseeventinit-screeny">screenY</a> = 0;
+  <span class="kt">long</span> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="https://www.w3.org/TR/cssom-view/#dom-mouseeventinit-clientx">clientX</a> = 0;
+  <span class="kt">long</span> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="https://www.w3.org/TR/cssom-view/#dom-mouseeventinit-clienty">clientY</a> = 0;
 
-  short <dfn class="idl-code" data-default="0" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export="" data-type="short " id="dom-mouseeventinit-button">button<a class="self-link" href="#dom-mouseeventinit-button"></a></dfn> = 0;
-  unsigned short <dfn class="idl-code" data-default="0" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export="" data-type="unsigned short " id="dom-mouseeventinit-buttons">buttons<a class="self-link" href="#dom-mouseeventinit-buttons"></a></dfn> = 0;
-  <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <dfn class="idl-code" data-default="null" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export="" data-type="EventTarget? " id="dom-mouseeventinit-relatedtarget">relatedTarget<a class="self-link" href="#dom-mouseeventinit-relatedtarget"></a></dfn> = null;
+  <span class="kt">short</span> <dfn class="nv idl-code" data-default="0" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export="" data-type="short " id="dom-mouseeventinit-button">button<a class="self-link" href="#dom-mouseeventinit-button"></a></dfn> = 0;
+  <span class="kt">unsigned</span> <span class="kt">short</span> <dfn class="nv idl-code" data-default="0" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export="" data-type="unsigned short " id="dom-mouseeventinit-buttons">buttons<a class="self-link" href="#dom-mouseeventinit-buttons"></a></dfn> = 0;
+  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <dfn class="nv idl-code" data-default="null" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export="" data-type="EventTarget? " id="dom-mouseeventinit-relatedtarget">relatedTarget<a class="self-link" href="#dom-mouseeventinit-relatedtarget"></a></dfn> = <span class="kt">null</span>;
 };
 </pre>
     <dl>
@@ -1778,22 +2000,22 @@ used to activate a user interface control or select text).</p>
 		initialize keyboard modifier attributes of the <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-20">MouseEvent</a></code> and <code class="idl"><a data-link-type="idl" href="#keyboardevent-keyboardevent" id="ref-for-keyboardevent-keyboardevent-12">KeyboardEvent</a></code> interfaces, as well as the additional modifier states
 		queried via <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate-3">getModifierState()</a></code>. The steps for
 		constructing events using this dictionary are defined in the <a href="#event-constructors">event constructors</a> section.</p>
-<pre class="idl def">dictionary <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-eventmodifierinit">EventModifierInit<span class="dfn-panel"><b><a href="#dictdef-eventmodifierinit">#dictdef-eventmodifierinit</a></b><b>Referenced in:</b><span><a href="#ref-for-dictdef-eventmodifierinit-1">3.6. Constructing Mouse and Keyboard Events</a> <a href="#ref-for-dictdef-eventmodifierinit-2">(2)</a></span><span><a href="#ref-for-dictdef-eventmodifierinit-3">5.3.1. Interface MouseEvent</a></span><span><a href="#ref-for-dictdef-eventmodifierinit-4">5.6.1. Interface KeyboardEvent</a></span></span></dfn> : <a data-link-type="idl-name" href="#dictdef-uieventinit-uieventinit" id="ref-for-dictdef-uieventinit-uieventinit-4">UIEventInit</a> {
-  boolean <dfn class="idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-ctrlkey">ctrlKey<a class="self-link" href="#dom-eventmodifierinit-ctrlkey"></a></dfn> = false;
-  boolean <dfn class="idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-shiftkey">shiftKey<a class="self-link" href="#dom-eventmodifierinit-shiftkey"></a></dfn> = false;
-  boolean <dfn class="idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-altkey">altKey<a class="self-link" href="#dom-eventmodifierinit-altkey"></a></dfn> = false;
-  boolean <dfn class="idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-metakey">metaKey<a class="self-link" href="#dom-eventmodifierinit-metakey"></a></dfn> = false;
+<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-eventmodifierinit">EventModifierInit</dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit-uieventinit" id="ref-for-dictdef-uieventinit-uieventinit-4">UIEventInit</a> {
+  <span class="kt">boolean</span> <dfn class="nv idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-ctrlkey">ctrlKey<a class="self-link" href="#dom-eventmodifierinit-ctrlkey"></a></dfn> = <span class="kt">false</span>;
+  <span class="kt">boolean</span> <dfn class="nv idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-shiftkey">shiftKey<a class="self-link" href="#dom-eventmodifierinit-shiftkey"></a></dfn> = <span class="kt">false</span>;
+  <span class="kt">boolean</span> <dfn class="nv idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-altkey">altKey<a class="self-link" href="#dom-eventmodifierinit-altkey"></a></dfn> = <span class="kt">false</span>;
+  <span class="kt">boolean</span> <dfn class="nv idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-metakey">metaKey<a class="self-link" href="#dom-eventmodifierinit-metakey"></a></dfn> = <span class="kt">false</span>;
 
-  boolean <dfn class="idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-modifieraltgraph">modifierAltGraph<a class="self-link" href="#dom-eventmodifierinit-modifieraltgraph"></a></dfn> = false;
-  boolean <dfn class="idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-modifiercapslock">modifierCapsLock<a class="self-link" href="#dom-eventmodifierinit-modifiercapslock"></a></dfn> = false;
-  boolean <dfn class="idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-modifierfn">modifierFn<a class="self-link" href="#dom-eventmodifierinit-modifierfn"></a></dfn> = false;
-  boolean <dfn class="idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-modifierfnlock">modifierFnLock<a class="self-link" href="#dom-eventmodifierinit-modifierfnlock"></a></dfn> = false;
-  boolean <dfn class="idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-modifierhyper">modifierHyper<a class="self-link" href="#dom-eventmodifierinit-modifierhyper"></a></dfn> = false;
-  boolean <dfn class="idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-modifiernumlock">modifierNumLock<a class="self-link" href="#dom-eventmodifierinit-modifiernumlock"></a></dfn> = false;
-  boolean <dfn class="idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-modifierscrolllock">modifierScrollLock<a class="self-link" href="#dom-eventmodifierinit-modifierscrolllock"></a></dfn> = false;
-  boolean <dfn class="idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-modifiersuper">modifierSuper<a class="self-link" href="#dom-eventmodifierinit-modifiersuper"></a></dfn> = false;
-  boolean <dfn class="idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-modifiersymbol">modifierSymbol<a class="self-link" href="#dom-eventmodifierinit-modifiersymbol"></a></dfn> = false;
-  boolean <dfn class="idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-modifiersymbollock">modifierSymbolLock<a class="self-link" href="#dom-eventmodifierinit-modifiersymbollock"></a></dfn> = false;
+  <span class="kt">boolean</span> <dfn class="nv idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-modifieraltgraph">modifierAltGraph<a class="self-link" href="#dom-eventmodifierinit-modifieraltgraph"></a></dfn> = <span class="kt">false</span>;
+  <span class="kt">boolean</span> <dfn class="nv idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-modifiercapslock">modifierCapsLock<a class="self-link" href="#dom-eventmodifierinit-modifiercapslock"></a></dfn> = <span class="kt">false</span>;
+  <span class="kt">boolean</span> <dfn class="nv idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-modifierfn">modifierFn<a class="self-link" href="#dom-eventmodifierinit-modifierfn"></a></dfn> = <span class="kt">false</span>;
+  <span class="kt">boolean</span> <dfn class="nv idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-modifierfnlock">modifierFnLock<a class="self-link" href="#dom-eventmodifierinit-modifierfnlock"></a></dfn> = <span class="kt">false</span>;
+  <span class="kt">boolean</span> <dfn class="nv idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-modifierhyper">modifierHyper<a class="self-link" href="#dom-eventmodifierinit-modifierhyper"></a></dfn> = <span class="kt">false</span>;
+  <span class="kt">boolean</span> <dfn class="nv idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-modifiernumlock">modifierNumLock<a class="self-link" href="#dom-eventmodifierinit-modifiernumlock"></a></dfn> = <span class="kt">false</span>;
+  <span class="kt">boolean</span> <dfn class="nv idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-modifierscrolllock">modifierScrollLock<a class="self-link" href="#dom-eventmodifierinit-modifierscrolllock"></a></dfn> = <span class="kt">false</span>;
+  <span class="kt">boolean</span> <dfn class="nv idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-modifiersuper">modifierSuper<a class="self-link" href="#dom-eventmodifierinit-modifiersuper"></a></dfn> = <span class="kt">false</span>;
+  <span class="kt">boolean</span> <dfn class="nv idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-modifiersymbol">modifierSymbol<a class="self-link" href="#dom-eventmodifierinit-modifiersymbol"></a></dfn> = <span class="kt">false</span>;
+  <span class="kt">boolean</span> <dfn class="nv idl-code" data-default="false" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-eventmodifierinit-modifiersymbollock">modifierSymbolLock<a class="self-link" href="#dom-eventmodifierinit-modifiersymbollock"></a></dfn> = <span class="kt">false</span>;
 };
 </pre>
     <dl>
@@ -2138,7 +2360,7 @@ used to activate a user interface control or select text).</p>
 		mouse event types are always targeted at the most deeply nested element.
 		Ancestors of the targeted element MAY use bubbling to obtain
 		notification of mouse events which occur within its descendent elements.</p>
-    <h5 class="heading settled" data-level="5.3.4.1" id="event-type-click"><span class="secno">5.3.4.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="click">click<span class="dfn-panel"><b><a href="#click">#click</a></b><b>Referenced in:</b><span><a href="#ref-for-click-1">3.2. Default actions and cancelable events</a> <a href="#ref-for-click-2">(2)</a></span><span><a href="#ref-for-click-3">3.4. Trusted events</a></span><span><a href="#ref-for-click-4">3.5. Activation triggers and behavior</a></span><span><a href="#ref-for-click-5">4.1. List of Event Types</a></span><span><a href="#ref-for-click-6">5.3.3. Mouse Event Order</a> <a href="#ref-for-click-7">(2)</a> <a href="#ref-for-click-8">(3)</a> <a href="#ref-for-click-9">(4)</a> <a href="#ref-for-click-10">(5)</a> <a href="#ref-for-click-11">(6)</a> <a href="#ref-for-click-12">(7)</a> <a href="#ref-for-click-13">(8)</a></span><span><a href="#ref-for-click-14">5.3.4.1. click</a> <a href="#ref-for-click-15">(2)</a> <a href="#ref-for-click-16">(3)</a> <a href="#ref-for-click-17">(4)</a> <a href="#ref-for-click-18">(5)</a> <a href="#ref-for-click-19">(6)</a> <a href="#ref-for-click-20">(7)</a> <a href="#ref-for-click-21">(8)</a> <a href="#ref-for-click-22">(9)</a> <a href="#ref-for-click-23">(10)</a> <a href="#ref-for-click-24">(11)</a> <a href="#ref-for-click-25">(12)</a> <a href="#ref-for-click-26">(13)</a></span><span><a href="#ref-for-click-27">5.3.4.2. dblclick</a> <a href="#ref-for-click-28">(2)</a> <a href="#ref-for-click-29">(3)</a> <a href="#ref-for-click-30">(4)</a> <a href="#ref-for-click-31">(5)</a></span><span><a href="#ref-for-click-32">5.6.4.1. keydown</a></span><span><a href="#ref-for-click-33">9.1.1.1. DOMActivate</a> <a href="#ref-for-click-34">(2)</a> <a href="#ref-for-click-35">(3)</a> <a href="#ref-for-click-36">(4)</a> <a href="#ref-for-click-37">(5)</a> <a href="#ref-for-click-38">(6)</a> <a href="#ref-for-click-39">(7)</a> <a href="#ref-for-click-40">(8)</a> <a href="#ref-for-click-41">(9)</a></span><span><a href="#ref-for-click-42">9.1.2. Activation event order</a> <a href="#ref-for-click-43">(2)</a></span><span><a href="#ref-for-click-44">14. Glossary</a> <a href="#ref-for-click-45">(2)</a> <a href="#ref-for-click-46">(3)</a> <a href="#ref-for-click-47">(4)</a> <a href="#ref-for-click-48">(5)</a> <a href="#ref-for-click-49">(6)</a></span></span></dfn></span><a class="self-link" href="#event-type-click"></a></h5>
+    <h5 class="heading settled" data-level="5.3.4.1" id="event-type-click"><span class="secno">5.3.4.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="click">click</dfn></span><a class="self-link" href="#event-type-click"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -2160,6 +2382,9 @@ used to activate a user interface control or select text).</p>
        <th>Cancelable
        <td>Yes
       <tr>
+       <th>Composed
+       <td>Yes
+      <tr>
        <th>Default action
        <td>Varies
       <tr>
@@ -2171,13 +2396,13 @@ used to activate a user interface control or select text).</p>
          <li><code class="idl"><a data-link-type="idl" href="#uievent-uievent" id="ref-for-uievent-uievent-30">UIEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-uievent-detail" id="ref-for-dom-uievent-detail-10">detail</a></code> :
 								indicates the <a href="#current-click-count">current click count</a>;
 								the attribute value MUST be <code>1</code> when the user begins this action and increments by <code>1</code> for each click.
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-26">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screenx">screenX</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-26">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screenx">screenX</a></code> :
 								value based on the pointer position on the screen
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-27">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screeny">screenY</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-27">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screeny">screenY</a></code> :
 								value based on the pointer position on the screen
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-28">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clientx">clientX</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-28">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clientx">clientX</a></code> :
 								value based on the pointer position within the viewport
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-29">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clienty">clientY</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-29">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clienty">clientY</a></code> :
 								value based on the pointer position within the viewport
          <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-30">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-mouseevent-altkey" id="ref-for-dom-mouseevent-altkey-1">altKey</a></code> : <code>true</code> if <code class="keycap">Alt</code> modifier was active, otherwise <code>false</code>
          <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-31">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-mouseevent-ctrlkey" id="ref-for-dom-mouseevent-ctrlkey-1">ctrlKey</a></code> : <code>true</code> if <code class="keycap">Control</code> modifier was active, otherwise <code>false</code>
@@ -2222,7 +2447,7 @@ behavior (see <a href="#event-flow-activation">§3.5 Activation triggers and beh
       <p>If the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-25">event target</a> is focusable, the <a data-link-type="dfn" href="#default-action" id="ref-for-default-action-17">default
 action</a> MUST be to give that element document focus.</p>
     </ul>
-    <h5 class="heading settled" data-level="5.3.4.2" id="event-type-dblclick"><span class="secno">5.3.4.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dblclick">dblclick<span class="dfn-panel"><b><a href="#dblclick">#dblclick</a></b><b>Referenced in:</b><span><a href="#ref-for-dblclick-1">4.1. List of Event Types</a></span><span><a href="#ref-for-dblclick-2">5.3.3. Mouse Event Order</a> <a href="#ref-for-dblclick-3">(2)</a> <a href="#ref-for-dblclick-4">(3)</a> <a href="#ref-for-dblclick-5">(4)</a> <a href="#ref-for-dblclick-6">(5)</a></span><span><a href="#ref-for-dblclick-7">5.3.4.1. click</a></span><span><a href="#ref-for-dblclick-8">5.3.4.2. dblclick</a> <a href="#ref-for-dblclick-9">(2)</a> <a href="#ref-for-dblclick-10">(3)</a> <a href="#ref-for-dblclick-11">(4)</a> <a href="#ref-for-dblclick-12">(5)</a> <a href="#ref-for-dblclick-13">(6)</a></span><span><a href="#ref-for-dblclick-14">12.1. Changes between DOM Level 2 Events and UI Events</a></span></span></dfn></span><a class="self-link" href="#event-type-dblclick"></a></h5>
+    <h5 class="heading settled" data-level="5.3.4.2" id="event-type-dblclick"><span class="secno">5.3.4.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dblclick">dblclick</dfn></span><a class="self-link" href="#event-type-dblclick"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -2244,6 +2469,9 @@ action</a> MUST be to give that element document focus.</p>
        <th>Cancelable
        <td>Yes
       <tr>
+       <th>Composed
+       <td>Yes
+      <tr>
        <th>Default action
        <td>None
       <tr>
@@ -2254,13 +2482,13 @@ action</a> MUST be to give that element document focus.</p>
          <li><code class="idl"><a data-link-type="idl" href="#uievent-uievent" id="ref-for-uievent-uievent-31">UIEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-uievent-view" id="ref-for-dom-uievent-view-11">view</a></code> : <a data-link-type="dfn" href="#window" id="ref-for-window-31"><code>Window</code></a>
          <li><code class="idl"><a data-link-type="idl" href="#uievent-uievent" id="ref-for-uievent-uievent-32">UIEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-uievent-detail" id="ref-for-dom-uievent-detail-11">detail</a></code> :
 								indicates the <a href="#current-click-count">current click count</a>
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-38">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screenx">screenX</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-38">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screenx">screenX</a></code> :
 								value based on the pointer position on the screen
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-39">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screeny">screenY</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-39">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screeny">screenY</a></code> :
 								value based on the pointer position on the screen
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-40">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clientx">clientX</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-40">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clientx">clientX</a></code> :
 								value based on the pointer position within the viewport
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-41">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clienty">clientY</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-41">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clienty">clientY</a></code> :
 								value based on the pointer position within the viewport
          <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-42">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-mouseevent-altkey" id="ref-for-dom-mouseevent-altkey-2">altKey</a></code> : <code>true</code> if <code class="keycap">Alt</code> modifier was active, otherwise <code>false</code>
          <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-43">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-mouseevent-ctrlkey" id="ref-for-dom-mouseevent-ctrlkey-2">ctrlKey</a></code> : <code>true</code> if <code class="keycap">Control</code> modifier was active, otherwise <code>false</code>
@@ -2288,7 +2516,7 @@ action</a> MUST be to select part or all of the selectable
 content. Subsequent clicks MAY select additional selectable
 portions of that content.</p>
     </ul>
-    <h5 class="heading settled" data-level="5.3.4.3" id="event-type-mousedown"><span class="secno">5.3.4.3. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="mousedown">mousedown<span class="dfn-panel"><b><a href="#mousedown">#mousedown</a></b><b>Referenced in:</b><span><a href="#ref-for-mousedown-1">3.2. Default actions and cancelable events</a> <a href="#ref-for-mousedown-2">(2)</a></span><span><a href="#ref-for-mousedown-3">4.1. List of Event Types</a></span><span><a href="#ref-for-mousedown-4">5.3.1. Interface MouseEvent</a> <a href="#ref-for-mousedown-5">(2)</a> <a href="#ref-for-mousedown-6">(3)</a></span><span><a href="#ref-for-mousedown-7">5.3.3. Mouse Event Order</a> <a href="#ref-for-mousedown-8">(2)</a> <a href="#ref-for-mousedown-9">(3)</a> <a href="#ref-for-mousedown-10">(4)</a> <a href="#ref-for-mousedown-11">(5)</a> <a href="#ref-for-mousedown-12">(6)</a> <a href="#ref-for-mousedown-13">(7)</a></span><span><a href="#ref-for-mousedown-14">5.3.4.1. click</a> <a href="#ref-for-mousedown-15">(2)</a></span><span><a href="#ref-for-mousedown-16">5.3.4.2. dblclick</a></span><span><a href="#ref-for-mousedown-17">5.3.4.3. mousedown</a> <a href="#ref-for-mousedown-18">(2)</a> <a href="#ref-for-mousedown-19">(3)</a></span><span><a href="#ref-for-mousedown-20">9.1.1.1. DOMActivate</a></span><span><a href="#ref-for-mousedown-21">14. Glossary</a></span></span></dfn></span><a class="self-link" href="#event-type-mousedown"></a></h5>
+    <h5 class="heading settled" data-level="5.3.4.3" id="event-type-mousedown"><span class="secno">5.3.4.3. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="mousedown">mousedown</dfn></span><a class="self-link" href="#event-type-mousedown"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -2310,6 +2538,9 @@ portions of that content.</p>
        <th>Cancelable
        <td>Yes
       <tr>
+       <th>Composed
+       <td>Yes
+      <tr>
        <th>Default action
        <td>Varies: Start a drag/drop operation; start a text selection; start a scroll/pan interaction (in combination with the middle mouse button, if supported)
       <tr>
@@ -2321,13 +2552,13 @@ portions of that content.</p>
          <li><code class="idl"><a data-link-type="idl" href="#uievent-uievent" id="ref-for-uievent-uievent-34">UIEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-uievent-detail" id="ref-for-dom-uievent-detail-12">detail</a></code> :
 								indicates the <a href="#current-click-count">current click count</a> incremented by one. For example, if no click happened
 								before the <a data-link-type="dfn" href="#mousedown" id="ref-for-mousedown-17"><code>mousedown</code></a>, <code class="idl"><a data-link-type="idl" href="#dom-uievent-detail" id="ref-for-dom-uievent-detail-13">detail</a></code> will contain the value <code>1</code>
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-50">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screenx">screenX</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-50">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screenx">screenX</a></code> :
 								value based on the pointer position on the screen
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-51">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screeny">screenY</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-51">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screeny">screenY</a></code> :
 								value based on the pointer position on the screen
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-52">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clientx">clientX</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-52">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clientx">clientX</a></code> :
 								value based on the pointer position within the viewport
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-53">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clienty">clientY</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-53">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clienty">clientY</a></code> :
 								value based on the pointer position within the viewport
          <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-54">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-mouseevent-altkey" id="ref-for-dom-mouseevent-altkey-3">altKey</a></code> : <code>true</code> if <code class="keycap">Alt</code> modifier was active, otherwise <code>false</code>
          <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-55">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-mouseevent-ctrlkey" id="ref-for-dom-mouseevent-ctrlkey-3">ctrlKey</a></code> : <code>true</code> if <code class="keycap">Control</code> modifier was active, otherwise <code>false</code>
@@ -2349,7 +2580,7 @@ portions of that content.</p>
 			Additionally, some implementations provide a mouse-driven panning
 			feature that is activated when the middle mouse button is pressed at
 			the time the <a data-link-type="dfn" href="#mousedown" id="ref-for-mousedown-19"><code>mousedown</code></a> event is dispatched. </p>
-    <h5 class="heading settled" data-level="5.3.4.4" id="event-type-mouseenter"><span class="secno">5.3.4.4. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="mouseenter">mouseenter<span class="dfn-panel"><b><a href="#mouseenter">#mouseenter</a></b><b>Referenced in:</b><span><a href="#ref-for-mouseenter-1">4.1. List of Event Types</a></span><span><a href="#ref-for-mouseenter-2">5.3.3. Mouse Event Order</a> <a href="#ref-for-mouseenter-3">(2)</a> <a href="#ref-for-mouseenter-4">(3)</a> <a href="#ref-for-mouseenter-5">(4)</a> <a href="#ref-for-mouseenter-6">(5)</a> <a href="#ref-for-mouseenter-7">(6)</a> <a href="#ref-for-mouseenter-8">(7)</a></span><span><a href="#ref-for-mouseenter-9">5.3.4.5. mouseleave</a></span><span><a href="#ref-for-mouseenter-10">5.3.4.8. mouseover</a></span></span></dfn></span><a class="self-link" href="#event-type-mouseenter"></a></h5>
+    <h5 class="heading settled" data-level="5.3.4.4" id="event-type-mouseenter"><span class="secno">5.3.4.4. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="mouseenter">mouseenter</dfn></span><a class="self-link" href="#event-type-mouseenter"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -2371,6 +2602,9 @@ portions of that content.</p>
        <th>Cancelable
        <td>No
       <tr>
+       <th>Composed
+       <td>Yes
+      <tr>
        <th>Default action
        <td>None
       <tr>
@@ -2380,13 +2614,13 @@ portions of that content.</p>
          <li><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#event">Event</a></code>.<code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-target">target</a></code> : <a data-link-type="dfn" href="#topmost-event-target" id="ref-for-topmost-event-target-5">topmost event target</a>
          <li><code class="idl"><a data-link-type="idl" href="#uievent-uievent" id="ref-for-uievent-uievent-35">UIEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-uievent-view" id="ref-for-dom-uievent-view-13">view</a></code> : <a data-link-type="dfn" href="#window" id="ref-for-window-33"><code>Window</code></a>
          <li><code class="idl"><a data-link-type="idl" href="#uievent-uievent" id="ref-for-uievent-uievent-36">UIEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-uievent-detail" id="ref-for-dom-uievent-detail-14">detail</a></code> : <code>0</code>
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-62">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screenx">screenX</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-62">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screenx">screenX</a></code> :
 								value based on the pointer position on the screen
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-63">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screeny">screenY</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-63">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screeny">screenY</a></code> :
 								value based on the pointer position on the screen
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-64">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clientx">clientX</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-64">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clientx">clientX</a></code> :
 								value based on the pointer position within the viewport
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-65">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clienty">clientY</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-65">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clienty">clientY</a></code> :
 								value based on the pointer position within the viewport
          <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-66">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-mouseevent-altkey" id="ref-for-dom-mouseevent-altkey-4">altKey</a></code> : <code>true</code> if <code class="keycap">Alt</code> modifier was active, otherwise <code>false</code>
          <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-67">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-mouseevent-ctrlkey" id="ref-for-dom-mouseevent-ctrlkey-4">ctrlKey</a></code> : <code>true</code> if <code class="keycap">Control</code> modifier was active, otherwise <code>false</code>
@@ -2406,7 +2640,7 @@ portions of that content.</p>
 			of its descendent elements.</p>
     <p class="note" role="note"> There are similarities between this event type and the CSS <a href="http://www.w3.org/TR/CSS2/selector.html#dynamic-pseudo-classes" title="Selectors"><code>:hover</code> pseudo-class</a> <a data-link-type="biblio" href="#biblio-css2">[CSS2]</a>.
 			See also the <a data-link-type="dfn" href="#mouseleave" id="ref-for-mouseleave-10"><code>mouseleave</code></a> event type. </p>
-    <h5 class="heading settled" data-level="5.3.4.5" id="event-type-mouseleave"><span class="secno">5.3.4.5. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="mouseleave">mouseleave<span class="dfn-panel"><b><a href="#mouseleave">#mouseleave</a></b><b>Referenced in:</b><span><a href="#ref-for-mouseleave-1">4.1. List of Event Types</a></span><span><a href="#ref-for-mouseleave-2">5.3.3. Mouse Event Order</a> <a href="#ref-for-mouseleave-3">(2)</a> <a href="#ref-for-mouseleave-4">(3)</a> <a href="#ref-for-mouseleave-5">(4)</a> <a href="#ref-for-mouseleave-6">(5)</a> <a href="#ref-for-mouseleave-7">(6)</a> <a href="#ref-for-mouseleave-8">(7)</a> <a href="#ref-for-mouseleave-9">(8)</a></span><span><a href="#ref-for-mouseleave-10">5.3.4.4. mouseenter</a></span><span><a href="#ref-for-mouseleave-11">5.3.4.7. mouseout</a></span></span></dfn></span><a class="self-link" href="#event-type-mouseleave"></a></h5>
+    <h5 class="heading settled" data-level="5.3.4.5" id="event-type-mouseleave"><span class="secno">5.3.4.5. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="mouseleave">mouseleave</dfn></span><a class="self-link" href="#event-type-mouseleave"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -2428,6 +2662,9 @@ portions of that content.</p>
        <th>Cancelable
        <td>No
       <tr>
+       <th>Composed
+       <td>Yes
+      <tr>
        <th>Default action
        <td>None
       <tr>
@@ -2437,13 +2674,13 @@ portions of that content.</p>
          <li><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#event">Event</a></code>.<code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-target">target</a></code> : <a data-link-type="dfn" href="#topmost-event-target" id="ref-for-topmost-event-target-6">topmost event target</a>
          <li><code class="idl"><a data-link-type="idl" href="#uievent-uievent" id="ref-for-uievent-uievent-37">UIEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-uievent-view" id="ref-for-dom-uievent-view-14">view</a></code> : <a data-link-type="dfn" href="#window" id="ref-for-window-34"><code>Window</code></a>
          <li><code class="idl"><a data-link-type="idl" href="#uievent-uievent" id="ref-for-uievent-uievent-38">UIEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-uievent-detail" id="ref-for-dom-uievent-detail-15">detail</a></code> : <code>0</code>
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-74">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screenx">screenX</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-74">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screenx">screenX</a></code> :
 								value based on the pointer position on the screen
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-75">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screeny">screenY</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-75">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screeny">screenY</a></code> :
 								value based on the pointer position on the screen
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-76">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clientx">clientX</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-76">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clientx">clientX</a></code> :
 								value based on the pointer position within the viewport
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-77">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clienty">clientY</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-77">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clienty">clientY</a></code> :
 								value based on the pointer position within the viewport
          <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-78">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-mouseevent-altkey" id="ref-for-dom-mouseevent-altkey-5">altKey</a></code> : <code>true</code> if <code class="keycap">Alt</code> modifier was active, otherwise <code>false</code>
          <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-79">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-mouseevent-ctrlkey" id="ref-for-dom-mouseevent-ctrlkey-5">ctrlKey</a></code> : <code>true</code> if <code class="keycap">Control</code> modifier was active, otherwise <code>false</code>
@@ -2463,7 +2700,7 @@ portions of that content.</p>
 			element and the boundaries of all of its children.</p>
     <p class="note" role="note"> There are similarities between this event type and the CSS <a href="http://www.w3.org/TR/CSS2/selector.html#dynamic-pseudo-classes" title="Selectors"><code>:hover</code> pseudo-class</a> <a data-link-type="biblio" href="#biblio-css2">[CSS2]</a>.
 			See also the <a data-link-type="dfn" href="#mouseenter" id="ref-for-mouseenter-9"><code>mouseenter</code></a> event type. </p>
-    <h5 class="heading settled" data-level="5.3.4.6" id="event-type-mousemove"><span class="secno">5.3.4.6. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="mousemove">mousemove<span class="dfn-panel"><b><a href="#mousemove">#mousemove</a></b><b>Referenced in:</b><span><a href="#ref-for-mousemove-1">4.1. List of Event Types</a></span><span><a href="#ref-for-mousemove-2">5.3.3. Mouse Event Order</a> <a href="#ref-for-mousemove-3">(2)</a> <a href="#ref-for-mousemove-4">(3)</a> <a href="#ref-for-mousemove-5">(4)</a> <a href="#ref-for-mousemove-6">(5)</a> <a href="#ref-for-mousemove-7">(6)</a> <a href="#ref-for-mousemove-8">(7)</a> <a href="#ref-for-mousemove-9">(8)</a> <a href="#ref-for-mousemove-10">(9)</a> <a href="#ref-for-mousemove-11">(10)</a> <a href="#ref-for-mousemove-12">(11)</a> <a href="#ref-for-mousemove-13">(12)</a> <a href="#ref-for-mousemove-14">(13)</a> <a href="#ref-for-mousemove-15">(14)</a> <a href="#ref-for-mousemove-16">(15)</a> <a href="#ref-for-mousemove-17">(16)</a> <a href="#ref-for-mousemove-18">(17)</a></span><span><a href="#ref-for-mousemove-19">5.3.4.1. click</a></span><span><a href="#ref-for-mousemove-20">5.3.4.6. mousemove</a> <a href="#ref-for-mousemove-21">(2)</a></span><span><a href="#ref-for-mousemove-22">12.1.2. Changes to DOM Level 2 event types</a></span></span></dfn></span><a class="self-link" href="#event-type-mousemove"></a></h5>
+    <h5 class="heading settled" data-level="5.3.4.6" id="event-type-mousemove"><span class="secno">5.3.4.6. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="mousemove">mousemove</dfn></span><a class="self-link" href="#event-type-mousemove"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -2485,6 +2722,9 @@ portions of that content.</p>
        <th>Cancelable
        <td>Yes
       <tr>
+       <th>Composed
+       <td>Yes
+      <tr>
        <th>Default action
        <td>None
       <tr>
@@ -2494,13 +2734,13 @@ portions of that content.</p>
          <li><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#event">Event</a></code>.<code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-target">target</a></code> : <a data-link-type="dfn" href="#topmost-event-target" id="ref-for-topmost-event-target-7">topmost event target</a>
          <li><code class="idl"><a data-link-type="idl" href="#uievent-uievent" id="ref-for-uievent-uievent-39">UIEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-uievent-view" id="ref-for-dom-uievent-view-15">view</a></code> : <a data-link-type="dfn" href="#window" id="ref-for-window-35"><code>Window</code></a>
          <li><code class="idl"><a data-link-type="idl" href="#uievent-uievent" id="ref-for-uievent-uievent-40">UIEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-uievent-detail" id="ref-for-dom-uievent-detail-16">detail</a></code> : <code>0</code>
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-86">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screenx">screenX</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-86">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screenx">screenX</a></code> :
 								value based on the pointer position on the screen
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-87">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screeny">screenY</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-87">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screeny">screenY</a></code> :
 								value based on the pointer position on the screen
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-88">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clientx">clientX</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-88">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clientx">clientX</a></code> :
 								value based on the pointer position within the viewport
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-89">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clienty">clientY</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-89">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clienty">clientY</a></code> :
 								value based on the pointer position within the viewport
          <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-90">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-mouseevent-altkey" id="ref-for-dom-mouseevent-altkey-6">altKey</a></code> : <code>true</code> if <code class="keycap">Alt</code> modifier was active, otherwise <code>false</code>
          <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-91">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-mouseevent-ctrlkey" id="ref-for-dom-mouseevent-ctrlkey-6">ctrlKey</a></code> : <code>true</code> if <code class="keycap">Control</code> modifier was active, otherwise <code>false</code>
@@ -2524,7 +2764,7 @@ portions of that content.</p>
     <p class="note" id="mousemove-now-cancelable" role="note"><a class="self-link" href="#mousemove-now-cancelable"></a> This event was formerly specified to be non-cancelable in DOM Level
 			2 Events <a data-link-type="biblio" href="#biblio-dom-level-2-events">[DOM-Level-2-Events]</a>, but was changed to reflect existing
 			interoperability between user agents. </p>
-    <h5 class="heading settled" data-level="5.3.4.7" id="event-type-mouseout"><span class="secno">5.3.4.7. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="mouseout">mouseout<span class="dfn-panel"><b><a href="#mouseout">#mouseout</a></b><b>Referenced in:</b><span><a href="#ref-for-mouseout-1">4.1. List of Event Types</a></span><span><a href="#ref-for-mouseout-2">5.3.3. Mouse Event Order</a> <a href="#ref-for-mouseout-3">(2)</a> <a href="#ref-for-mouseout-4">(3)</a> <a href="#ref-for-mouseout-5">(4)</a> <a href="#ref-for-mouseout-6">(5)</a> <a href="#ref-for-mouseout-7">(6)</a> <a href="#ref-for-mouseout-8">(7)</a></span><span><a href="#ref-for-mouseout-9">5.3.4.1. click</a></span><span><a href="#ref-for-mouseout-10">5.3.4.5. mouseleave</a></span><span><a href="#ref-for-mouseout-11">5.3.4.8. mouseover</a></span></span></dfn></span><a class="self-link" href="#event-type-mouseout"></a></h5>
+    <h5 class="heading settled" data-level="5.3.4.7" id="event-type-mouseout"><span class="secno">5.3.4.7. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="mouseout">mouseout</dfn></span><a class="self-link" href="#event-type-mouseout"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -2546,6 +2786,9 @@ portions of that content.</p>
        <th>Cancelable
        <td>Yes
       <tr>
+       <th>Composed
+       <td>Yes
+      <tr>
        <th>Default action
        <td>None
       <tr>
@@ -2555,13 +2798,13 @@ portions of that content.</p>
          <li><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#event">Event</a></code>.<code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-target">target</a></code> : <a data-link-type="dfn" href="#topmost-event-target" id="ref-for-topmost-event-target-8">topmost event target</a>
          <li><code class="idl"><a data-link-type="idl" href="#uievent-uievent" id="ref-for-uievent-uievent-41">UIEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-uievent-view" id="ref-for-dom-uievent-view-16">view</a></code> : <a data-link-type="dfn" href="#window" id="ref-for-window-36"><code>Window</code></a>
          <li><code class="idl"><a data-link-type="idl" href="#uievent-uievent" id="ref-for-uievent-uievent-42">UIEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-uievent-detail" id="ref-for-dom-uievent-detail-17">detail</a></code> : <code>0</code>
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-98">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screenx">screenX</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-98">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screenx">screenX</a></code> :
 								value based on the pointer position on the screen
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-99">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screeny">screenY</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-99">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screeny">screenY</a></code> :
 								value based on the pointer position on the screen
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-100">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clientx">clientX</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-100">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clientx">clientX</a></code> :
 								value based on the pointer position within the viewport
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-101">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clienty">clientY</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-101">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clienty">clientY</a></code> :
 								value based on the pointer position within the viewport
          <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-102">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-mouseevent-altkey" id="ref-for-dom-mouseevent-altkey-7">altKey</a></code> : <code>true</code> if <code class="keycap">Alt</code> modifier was active, otherwise <code>false</code>
          <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-103">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-mouseevent-ctrlkey" id="ref-for-dom-mouseevent-ctrlkey-7">ctrlKey</a></code> : <code>true</code> if <code class="keycap">Control</code> modifier was active, otherwise <code>false</code>
@@ -2579,7 +2822,7 @@ portions of that content.</p>
 			similar to <a data-link-type="dfn" href="#mouseleave" id="ref-for-mouseleave-11"><code>mouseleave</code></a>, but differs in that does bubble, and			that it MUST be dispatched when the pointer device moves from an
 			element onto the boundaries of one of its descendent elements.</p>
     <p class="note" role="note"> See also the <a data-link-type="dfn" href="#mouseover" id="ref-for-mouseover-10"><code>mouseover</code></a> event type. </p>
-    <h5 class="heading settled" data-level="5.3.4.8" id="event-type-mouseover"><span class="secno">5.3.4.8. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="mouseover">mouseover<span class="dfn-panel"><b><a href="#mouseover">#mouseover</a></b><b>Referenced in:</b><span><a href="#ref-for-mouseover-1">4.1. List of Event Types</a></span><span><a href="#ref-for-mouseover-2">5.3.3. Mouse Event Order</a> <a href="#ref-for-mouseover-3">(2)</a> <a href="#ref-for-mouseover-4">(3)</a> <a href="#ref-for-mouseover-5">(4)</a> <a href="#ref-for-mouseover-6">(5)</a> <a href="#ref-for-mouseover-7">(6)</a></span><span><a href="#ref-for-mouseover-8">5.3.4.1. click</a></span><span><a href="#ref-for-mouseover-9">5.3.4.4. mouseenter</a></span><span><a href="#ref-for-mouseover-10">5.3.4.7. mouseout</a></span><span><a href="#ref-for-mouseover-11">14. Glossary</a></span></span></dfn></span><a class="self-link" href="#event-type-mouseover"></a></h5>
+    <h5 class="heading settled" data-level="5.3.4.8" id="event-type-mouseover"><span class="secno">5.3.4.8. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="mouseover">mouseover</dfn></span><a class="self-link" href="#event-type-mouseover"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -2601,6 +2844,9 @@ portions of that content.</p>
        <th>Cancelable
        <td>Yes
       <tr>
+       <th>Composed
+       <td>Yes
+      <tr>
        <th>Default action
        <td>None
       <tr>
@@ -2610,13 +2856,13 @@ portions of that content.</p>
          <li><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#event">Event</a></code>.<code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-target">target</a></code> : <a data-link-type="dfn" href="#topmost-event-target" id="ref-for-topmost-event-target-9">topmost event target</a>
          <li><code class="idl"><a data-link-type="idl" href="#uievent-uievent" id="ref-for-uievent-uievent-43">UIEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-uievent-view" id="ref-for-dom-uievent-view-17">view</a></code> : <a data-link-type="dfn" href="#window" id="ref-for-window-37"><code>Window</code></a>
          <li><code class="idl"><a data-link-type="idl" href="#uievent-uievent" id="ref-for-uievent-uievent-44">UIEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-uievent-detail" id="ref-for-dom-uievent-detail-18">detail</a></code> : <code>0</code>
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-110">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screenx">screenX</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-110">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screenx">screenX</a></code> :
 									value based on the pointer position on the screen
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-111">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screeny">screenY</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-111">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screeny">screenY</a></code> :
 									value based on the pointer position on the screen
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-112">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clientx">clientX</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-112">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clientx">clientX</a></code> :
 									value based on the pointer position within the viewport
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-113">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clienty">clientY</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-113">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clienty">clientY</a></code> :
 									value based on the pointer position within the viewport
          <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-114">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-mouseevent-altkey" id="ref-for-dom-mouseevent-altkey-8">altKey</a></code> : <code>true</code> if <code class="keycap">Alt</code> modifier was active, otherwise <code>false</code>
          <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-115">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-mouseevent-ctrlkey" id="ref-for-dom-mouseevent-ctrlkey-8">ctrlKey</a></code> : <code>true</code> if <code class="keycap">Control</code> modifier was active, otherwise <code>false</code>
@@ -2635,7 +2881,7 @@ portions of that content.</p>
 			boundaries of an element whose ancestor element is the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-32">event
 			target</a> for the same event listener instance.</p>
     <p class="note" role="note"> See also the <a data-link-type="dfn" href="#mouseout" id="ref-for-mouseout-11"><code>mouseout</code></a> event type. </p>
-    <h5 class="heading settled" data-level="5.3.4.9" id="event-type-mouseup"><span class="secno">5.3.4.9. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="mouseup">mouseup<span class="dfn-panel"><b><a href="#mouseup">#mouseup</a></b><b>Referenced in:</b><span><a href="#ref-for-mouseup-1">4.1. List of Event Types</a></span><span><a href="#ref-for-mouseup-2">5.3.1. Interface MouseEvent</a> <a href="#ref-for-mouseup-3">(2)</a> <a href="#ref-for-mouseup-4">(3)</a></span><span><a href="#ref-for-mouseup-5">5.3.3. Mouse Event Order</a> <a href="#ref-for-mouseup-6">(2)</a> <a href="#ref-for-mouseup-7">(3)</a> <a href="#ref-for-mouseup-8">(4)</a> <a href="#ref-for-mouseup-9">(5)</a> <a href="#ref-for-mouseup-10">(6)</a> <a href="#ref-for-mouseup-11">(7)</a> <a href="#ref-for-mouseup-12">(8)</a> <a href="#ref-for-mouseup-13">(9)</a></span><span><a href="#ref-for-mouseup-14">5.3.4.1. click</a> <a href="#ref-for-mouseup-15">(2)</a></span><span><a href="#ref-for-mouseup-16">5.3.4.2. dblclick</a> <a href="#ref-for-mouseup-17">(2)</a></span><span><a href="#ref-for-mouseup-18">5.3.4.9. mouseup</a></span><span><a href="#ref-for-mouseup-19">9.1.1.1. DOMActivate</a></span><span><a href="#ref-for-mouseup-20">14. Glossary</a></span></span></dfn></span><a class="self-link" href="#event-type-mouseup"></a></h5>
+    <h5 class="heading settled" data-level="5.3.4.9" id="event-type-mouseup"><span class="secno">5.3.4.9. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="mouseup">mouseup</dfn></span><a class="self-link" href="#event-type-mouseup"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -2657,6 +2903,9 @@ portions of that content.</p>
        <th>Cancelable
        <td>Yes
       <tr>
+       <th>Composed
+       <td>Yes
+      <tr>
        <th>Default action
        <td>Invoke a context menu (in combination with the right mouse button, if supported)
       <tr>
@@ -2667,13 +2916,13 @@ portions of that content.</p>
          <li><code class="idl"><a data-link-type="idl" href="#uievent-uievent" id="ref-for-uievent-uievent-45">UIEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-uievent-view" id="ref-for-dom-uievent-view-18">view</a></code> : <a data-link-type="dfn" href="#window" id="ref-for-window-38"><code>Window</code></a>
          <li><code class="idl"><a data-link-type="idl" href="#uievent-uievent" id="ref-for-uievent-uievent-46">UIEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-uievent-detail" id="ref-for-dom-uievent-detail-19">detail</a></code> :
 								indicates the <a href="#current-click-count">current click count</a> incremented by one.
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-122">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screenx">screenX</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-122">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screenx">screenX</a></code> :
 								value based on the pointer position on the screen
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-123">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screeny">screenY</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-123">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screeny">screenY</a></code> :
 								value based on the pointer position on the screen
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-124">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clientx">clientX</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-124">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clientx">clientX</a></code> :
 								value based on the pointer position within the viewport
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-125">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clienty">clientY</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-125">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clienty">clientY</a></code> :
 								value based on the pointer position within the viewport
          <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-126">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-mouseevent-altkey" id="ref-for-dom-mouseevent-altkey-9">altKey</a></code> : <code>true</code> if <code class="keycap">Alt</code> modifier was active, otherwise <code>false</code>
          <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-127">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-mouseevent-ctrlkey" id="ref-for-dom-mouseevent-ctrlkey-9">ctrlKey</a></code> : <code>true</code> if <code class="keycap">Control</code> modifier was active, otherwise <code>false</code>
@@ -2731,17 +2980,17 @@ portions of that content.</p>
 		associated with <a data-link-type="dfn" href="#wheel" id="ref-for-wheel-4"><code>wheel</code></a> events.
 		To create an instance of the <code class="idl"><a data-link-type="idl" href="#wheelevent" id="ref-for-wheelevent-4">WheelEvent</a></code> interface, use the <code class="idl"><a data-link-type="idl" href="#wheelevent" id="ref-for-wheelevent-5">WheelEvent</a></code> constructor,
 		passing an optional <code class="idl"><a data-link-type="idl" href="#dictdef-wheeleventinit" id="ref-for-dictdef-wheeleventinit-1">WheelEventInit</a></code> dictionary.</p>
-<pre class="idl def">[<dfn class="idl-code" data-dfn-for="WheelEvent" data-dfn-type="constructor" data-export="" data-lt="WheelEvent(type, eventInitDict)" id="dom-wheelevent-wheelevent">Constructor<a class="self-link" href="#dom-wheelevent-wheelevent"></a></dfn>(DOMString <dfn class="idl-code" data-dfn-for="WheelEvent/WheelEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-wheelevent-wheelevent-type-eventinitdict-type">type<a class="self-link" href="#dom-wheelevent-wheelevent-type-eventinitdict-type"></a></dfn>, optional <a data-link-type="idl-name" href="#dictdef-wheeleventinit" id="ref-for-dictdef-wheeleventinit-2">WheelEventInit</a> <dfn class="idl-code" data-dfn-for="WheelEvent/WheelEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-wheelevent-wheelevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-wheelevent-wheelevent-type-eventinitdict-eventinitdict"></a></dfn>)]
-interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="wheelevent">WheelEvent<span class="dfn-panel"><b><a href="#wheelevent">#wheelevent</a></b><b>Referenced in:</b><span><a href="#ref-for-wheelevent-1">4.1. List of Event Types</a></span><span><a href="#ref-for-wheelevent-2">5.4. Wheel Events</a></span><span><a href="#ref-for-wheelevent-3">5.4.1. Interface WheelEvent</a> <a href="#ref-for-wheelevent-4">(2)</a> <a href="#ref-for-wheelevent-5">(3)</a></span><span><a href="#ref-for-wheelevent-6">5.4.2.1. wheel</a> <a href="#ref-for-wheelevent-7">(2)</a> <a href="#ref-for-wheelevent-8">(3)</a> <a href="#ref-for-wheelevent-9">(4)</a> <a href="#ref-for-wheelevent-10">(5)</a></span><span><a href="#ref-for-wheelevent-11">7.1.3. Initializers for interface WheelEvent</a></span><span><a href="#ref-for-wheelevent-12">12.1.4. New Interfaces</a></span><span><a href="#ref-for-wheelevent-13">14. Glossary</a> <a href="#ref-for-wheelevent-14">(2)</a></span></span></dfn> : <a data-link-type="idl-name" href="#mouseevent" id="ref-for-mouseevent-133">MouseEvent</a> {
+<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="WheelEvent" data-dfn-type="constructor" data-export="" data-lt="WheelEvent(type, eventInitDict)|WheelEvent(type)" id="dom-wheelevent-wheelevent">Constructor<a class="self-link" href="#dom-wheelevent-wheelevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="WheelEvent/WheelEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-wheelevent-wheelevent-type-eventinitdict-type">type<a class="self-link" href="#dom-wheelevent-wheelevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-wheeleventinit" id="ref-for-dictdef-wheeleventinit-2">WheelEventInit</a> <dfn class="nv idl-code" data-dfn-for="WheelEvent/WheelEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-wheelevent-wheelevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-wheelevent-wheelevent-type-eventinitdict-eventinitdict"></a></dfn>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="wheelevent">WheelEvent</dfn> : <a class="n" data-link-type="idl-name" href="#mouseevent" id="ref-for-mouseevent-133">MouseEvent</a> {
   // DeltaModeCode
-  const unsigned long <dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="const" data-export="" id="dom-wheelevent-dom_delta_pixel">DOM_DELTA_PIXEL<span class="dfn-panel"><b><a href="#dom-wheelevent-dom_delta_pixel">#dom-wheelevent-dom_delta_pixel</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-wheelevent-dom_delta_pixel-1">5.4.1. Interface WheelEvent</a> <a href="#ref-for-dom-wheelevent-dom_delta_pixel-2">(2)</a></span></span></dfn> = 0x00;
-  const unsigned long <dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="const" data-export="" id="dom-wheelevent-dom_delta_line">DOM_DELTA_LINE<span class="dfn-panel"><b><a href="#dom-wheelevent-dom_delta_line">#dom-wheelevent-dom_delta_line</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-wheelevent-dom_delta_line-1">5.4.1. Interface WheelEvent</a></span></span></dfn>  = 0x01;
-  const unsigned long <dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="const" data-export="" id="dom-wheelevent-dom_delta_page">DOM_DELTA_PAGE<span class="dfn-panel"><b><a href="#dom-wheelevent-dom_delta_page">#dom-wheelevent-dom_delta_page</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-wheelevent-dom_delta_page-1">5.4.1. Interface WheelEvent</a></span></span></dfn>  = 0x02;
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="const" data-export="" id="dom-wheelevent-dom_delta_pixel">DOM_DELTA_PIXEL</dfn> = 0x00;
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="const" data-export="" id="dom-wheelevent-dom_delta_line">DOM_DELTA_LINE</dfn>  = 0x01;
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="const" data-export="" id="dom-wheelevent-dom_delta_page">DOM_DELTA_PAGE</dfn>  = 0x02;
 
-  readonly attribute double <dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="double " id="dom-wheelevent-deltax">deltaX<span class="dfn-panel"><b><a href="#dom-wheelevent-deltax">#dom-wheelevent-deltax</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-wheelevent-deltax-1">5.4.2.1. wheel</a></span><span><a href="#ref-for-dom-wheelevent-deltax-2">7.1.3. Initializers for interface WheelEvent</a></span><span><a href="#ref-for-dom-wheelevent-deltax-3">14. Glossary</a></span></span></dfn>;
-  readonly attribute double <dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="double " id="dom-wheelevent-deltay">deltaY<span class="dfn-panel"><b><a href="#dom-wheelevent-deltay">#dom-wheelevent-deltay</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-wheelevent-deltay-1">5.4.2.1. wheel</a></span><span><a href="#ref-for-dom-wheelevent-deltay-2">7.1.3. Initializers for interface WheelEvent</a></span><span><a href="#ref-for-dom-wheelevent-deltay-3">14. Glossary</a></span></span></dfn>;
-  readonly attribute double <dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="double " id="dom-wheelevent-deltaz">deltaZ<span class="dfn-panel"><b><a href="#dom-wheelevent-deltaz">#dom-wheelevent-deltaz</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-wheelevent-deltaz-1">5.4.2.1. wheel</a></span><span><a href="#ref-for-dom-wheelevent-deltaz-2">7.1.3. Initializers for interface WheelEvent</a></span><span><a href="#ref-for-dom-wheelevent-deltaz-3">14. Glossary</a></span></span></dfn>;
-  readonly attribute unsigned long <dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unsigned long " id="dom-wheelevent-deltamode">deltaMode<span class="dfn-panel"><b><a href="#dom-wheelevent-deltamode">#dom-wheelevent-deltamode</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-wheelevent-deltamode-1">5.4.2.1. wheel</a></span><span><a href="#ref-for-dom-wheelevent-deltamode-2">7.1.3. Initializers for interface WheelEvent</a></span><span><a href="#ref-for-dom-wheelevent-deltamode-3">14. Glossary</a></span></span></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">double</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="double" id="dom-wheelevent-deltax">deltaX</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">double</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="double" id="dom-wheelevent-deltay">deltaY</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">double</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="double" id="dom-wheelevent-deltaz">deltaZ</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unsigned long" id="dom-wheelevent-deltamode">deltaMode</dfn>;
 };
 </pre>
     <dl>
@@ -2790,11 +3039,11 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-expor
 				and application configurations.</p>
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-19">un-initialized value</a> of this attribute MUST be <code>0</code>.</p>
     </dl>
-<pre class="idl def">dictionary <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-wheeleventinit">WheelEventInit<span class="dfn-panel"><b><a href="#dictdef-wheeleventinit">#dictdef-wheeleventinit</a></b><b>Referenced in:</b><span><a href="#ref-for-dictdef-wheeleventinit-1">5.4.1. Interface WheelEvent</a> <a href="#ref-for-dictdef-wheeleventinit-2">(2)</a></span></span></dfn> : <a data-link-type="idl-name" href="https://drafts.csswg.org/cssom-view-1/#dictdef-mouseeventinit">MouseEventInit</a> {
-  double <dfn class="idl-code" data-default="0.0" data-dfn-for="WheelEventInit" data-dfn-type="dict-member" data-export="" data-type="double " id="dom-wheeleventinit-deltax">deltaX<a class="self-link" href="#dom-wheeleventinit-deltax"></a></dfn> = 0.0;
-  double <dfn class="idl-code" data-default="0.0" data-dfn-for="WheelEventInit" data-dfn-type="dict-member" data-export="" data-type="double " id="dom-wheeleventinit-deltay">deltaY<a class="self-link" href="#dom-wheeleventinit-deltay"></a></dfn> = 0.0;
-  double <dfn class="idl-code" data-default="0.0" data-dfn-for="WheelEventInit" data-dfn-type="dict-member" data-export="" data-type="double " id="dom-wheeleventinit-deltaz">deltaZ<a class="self-link" href="#dom-wheeleventinit-deltaz"></a></dfn> = 0.0;
-  unsigned long <dfn class="idl-code" data-default="0" data-dfn-for="WheelEventInit" data-dfn-type="dict-member" data-export="" data-type="unsigned long " id="dom-wheeleventinit-deltamode">deltaMode<a class="self-link" href="#dom-wheeleventinit-deltamode"></a></dfn> = 0;
+<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-wheeleventinit">WheelEventInit</dfn> : <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/cssom-view/#dictdef-mouseeventinit">MouseEventInit</a> {
+  <span class="kt">double</span> <dfn class="nv idl-code" data-default="0.0" data-dfn-for="WheelEventInit" data-dfn-type="dict-member" data-export="" data-type="double " id="dom-wheeleventinit-deltax">deltaX<a class="self-link" href="#dom-wheeleventinit-deltax"></a></dfn> = 0.0;
+  <span class="kt">double</span> <dfn class="nv idl-code" data-default="0.0" data-dfn-for="WheelEventInit" data-dfn-type="dict-member" data-export="" data-type="double " id="dom-wheeleventinit-deltay">deltaY<a class="self-link" href="#dom-wheeleventinit-deltay"></a></dfn> = 0.0;
+  <span class="kt">double</span> <dfn class="nv idl-code" data-default="0.0" data-dfn-for="WheelEventInit" data-dfn-type="dict-member" data-export="" data-type="double " id="dom-wheeleventinit-deltaz">deltaZ<a class="self-link" href="#dom-wheeleventinit-deltaz"></a></dfn> = 0.0;
+  <span class="kt">unsigned</span> <span class="kt">long</span> <dfn class="nv idl-code" data-default="0" data-dfn-for="WheelEventInit" data-dfn-type="dict-member" data-export="" data-type="unsigned long " id="dom-wheeleventinit-deltamode">deltaMode<a class="self-link" href="#dom-wheeleventinit-deltamode"></a></dfn> = 0;
 };
 </pre>
     <dl>
@@ -2821,7 +3070,7 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-expor
 				wheel would have resulted in scrolling. 
     </dl>
     <h4 class="heading settled" data-level="5.4.2" id="events-wheel-types"><span class="secno">5.4.2. </span><span class="content">Wheel Event Types</span><a class="self-link" href="#events-wheel-types"></a></h4>
-    <h5 class="heading settled" data-level="5.4.2.1" id="event-type-wheel"><span class="secno">5.4.2.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="wheel">wheel<span class="dfn-panel"><b><a href="#wheel">#wheel</a></b><b>Referenced in:</b><span><a href="#ref-for-wheel-1">4.1. List of Event Types</a></span><span><a href="#ref-for-wheel-2">5.4. Wheel Events</a> <a href="#ref-for-wheel-3">(2)</a></span><span><a href="#ref-for-wheel-4">5.4.1. Interface WheelEvent</a> <a href="#ref-for-wheel-5">(2)</a> <a href="#ref-for-wheel-6">(3)</a> <a href="#ref-for-wheel-7">(4)</a></span><span><a href="#ref-for-wheel-8">5.4.2.1. wheel</a> <a href="#ref-for-wheel-9">(2)</a> <a href="#ref-for-wheel-10">(3)</a></span></span></dfn></span><a class="self-link" href="#event-type-wheel"></a></h5>
+    <h5 class="heading settled" data-level="5.4.2.1" id="event-type-wheel"><span class="secno">5.4.2.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="wheel">wheel</dfn></span><a class="self-link" href="#event-type-wheel"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -2843,6 +3092,9 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-expor
        <th>Cancelable
        <td>Yes
       <tr>
+       <th>Composed
+       <td>Yes
+      <tr>
        <th>Default action
        <td>Scroll (or zoom) the document
       <tr>
@@ -2852,15 +3104,15 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-expor
          <li><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#event">Event</a></code>.<code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-target">target</a></code> : <a data-link-type="dfn" href="#topmost-event-target" id="ref-for-topmost-event-target-11">topmost event target</a>
          <li><code class="idl"><a data-link-type="idl" href="#uievent-uievent" id="ref-for-uievent-uievent-47">UIEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-uievent-view" id="ref-for-dom-uievent-view-19">view</a></code> : <a data-link-type="dfn" href="#window" id="ref-for-window-39"><code>Window</code></a>
          <li><code class="idl"><a data-link-type="idl" href="#uievent-uievent" id="ref-for-uievent-uievent-48">UIEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-uievent-detail" id="ref-for-dom-uievent-detail-20">detail</a></code> : <code>0</code>
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-134">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screenx">screenX</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-134">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screenx">screenX</a></code> :
 								if the wheel is associated with a pointing device, the value based on the pointer position on the screen, otherwise <code>0</code>
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-135">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screeny">screenY</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-135">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screeny">screenY</a></code> :
 								if the wheel is associated with a pointing device, the value based
 								on the pointer position on the screen, otherwise <code>0</code>
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-136">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clientx">clientX</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-136">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clientx">clientX</a></code> :
 								if the wheel is associated with a pointing device, the value based
 								on the pointer position within the viewport, otherwise <code>0</code>
-         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-137">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clienty">clientY</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-137">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clienty">clientY</a></code> :
 								if the wheel is associated with a pointing device, the value
 								based on the pointer position within the viewport, otherwise <code>0</code>
          <li><code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-138">MouseEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-mouseevent-altkey" id="ref-for-dom-mouseevent-altkey-10">altKey</a></code> : <code>true</code> if <code class="keycap">Alt</code> modifier was active, otherwise <code>false</code>
@@ -2903,10 +3155,10 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-expor
     <p>Input events are sent as notifications whenever the DOM is being updated.</p>
     <h4 class="heading settled" data-level="5.5.1" id="interface-inputevent"><span class="secno">5.5.1. </span><span class="content">Interface InputEvent</span><a class="self-link" href="#interface-inputevent"></a></h4>
     <p class="intro-dom">Introduced in DOM Level 3</p>
-<pre class="idl def">[<dfn class="idl-code" data-dfn-for="InputEvent" data-dfn-type="constructor" data-export="" data-lt="InputEvent(type, eventInitDict)" id="dom-inputevent-inputevent">Constructor<a class="self-link" href="#dom-inputevent-inputevent"></a></dfn>(DOMString <dfn class="idl-code" data-dfn-for="InputEvent/InputEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-inputevent-inputevent-type-eventinitdict-type">type<a class="self-link" href="#dom-inputevent-inputevent-type-eventinitdict-type"></a></dfn>, optional <a data-link-type="idl-name" href="#dictdef-inputeventinit" id="ref-for-dictdef-inputeventinit-1">InputEventInit</a> <dfn class="idl-code" data-dfn-for="InputEvent/InputEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-inputevent-inputevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-inputevent-inputevent-type-eventinitdict-eventinitdict"></a></dfn>)]
-interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="inputevent">InputEvent<span class="dfn-panel"><b><a href="#inputevent">#inputevent</a></b><b>Referenced in:</b><span><a href="#ref-for-inputevent-1">4.1. List of Event Types</a> <a href="#ref-for-inputevent-2">(2)</a></span><span><a href="#ref-for-inputevent-3">5.5.3.1. beforeinput</a> <a href="#ref-for-inputevent-4">(2)</a> <a href="#ref-for-inputevent-5">(3)</a></span><span><a href="#ref-for-inputevent-6">5.5.3.2. input</a> <a href="#ref-for-inputevent-7">(2)</a> <a href="#ref-for-inputevent-8">(3)</a></span><span><a href="#ref-for-inputevent-9">5.6. Keyboard Events</a></span><span><a href="#ref-for-inputevent-10">6.3.5. Default actions and cancelable keyboard events</a> <a href="#ref-for-inputevent-11">(2)</a> <a href="#ref-for-inputevent-12">(3)</a></span><span><a href="#ref-for-inputevent-13">9.3.2. keypress event order</a></span></span></dfn> : <a data-link-type="idl-name" href="#uievent-uievent" id="ref-for-uievent-uievent-49">UIEvent</a> {
-  readonly attribute DOMString <dfn class="dfn-paneled idl-code" data-dfn-for="InputEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMString " id="dom-inputevent-data">data<span class="dfn-panel"><b><a href="#dom-inputevent-data">#dom-inputevent-data</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-inputevent-data-1">5.5.3.1. beforeinput</a></span><span><a href="#ref-for-dom-inputevent-data-2">5.5.3.2. input</a></span><span><a href="#ref-for-dom-inputevent-data-3">6.3.5. Default actions and cancelable keyboard events</a> <a href="#ref-for-dom-inputevent-data-4">(2)</a> <a href="#ref-for-dom-inputevent-data-5">(3)</a></span><span><a href="#ref-for-dom-inputevent-data-6">9.3.2. keypress event order</a></span></span></dfn>;
-  readonly attribute boolean <dfn class="dfn-paneled idl-code" data-dfn-for="InputEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean " id="dom-inputevent-iscomposing">isComposing<span class="dfn-panel"><b><a href="#dom-inputevent-iscomposing">#dom-inputevent-iscomposing</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-inputevent-iscomposing-1">5.5.3.1. beforeinput</a></span><span><a href="#ref-for-dom-inputevent-iscomposing-2">5.5.3.2. input</a></span></span></dfn>;
+<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="InputEvent" data-dfn-type="constructor" data-export="" data-lt="InputEvent(type, eventInitDict)|InputEvent(type)" id="dom-inputevent-inputevent">Constructor<a class="self-link" href="#dom-inputevent-inputevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="InputEvent/InputEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-inputevent-inputevent-type-eventinitdict-type">type<a class="self-link" href="#dom-inputevent-inputevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-inputeventinit" id="ref-for-dictdef-inputeventinit-1">InputEventInit</a> <dfn class="nv idl-code" data-dfn-for="InputEvent/InputEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-inputevent-inputevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-inputevent-inputevent-type-eventinitdict-eventinitdict"></a></dfn>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="inputevent">InputEvent</dfn> : <a class="n" data-link-type="idl-name" href="#uievent-uievent" id="ref-for-uievent-uievent-49">UIEvent</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="InputEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMString" id="dom-inputevent-data">data</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="InputEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean" id="dom-inputevent-iscomposing">isComposing</dfn>;
 };
 </pre>
     <dl>
@@ -2924,9 +3176,9 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-expor
 				composition session, i.e., after a <a data-link-type="dfn" href="#compositionstart" id="ref-for-compositionstart-2"><code>compositionstart</code></a> event				and before the corresponding <a data-link-type="dfn" href="#compositionend" id="ref-for-compositionend-2"><code>compositionend</code></a> event.
 				The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-21">un-initialized value</a> of this attribute MUST be <code>false</code>. 
     </dl>
-<pre class="idl def">dictionary <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-inputeventinit">InputEventInit<span class="dfn-panel"><b><a href="#dictdef-inputeventinit">#dictdef-inputeventinit</a></b><b>Referenced in:</b><span><a href="#ref-for-dictdef-inputeventinit-1">5.5.1. Interface InputEvent</a></span></span></dfn> : <a data-link-type="idl-name" href="#dictdef-uieventinit-uieventinit" id="ref-for-dictdef-uieventinit-uieventinit-5">UIEventInit</a> {
-  DOMString <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="InputEventInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-inputeventinit-data">data<a class="self-link" href="#dom-inputeventinit-data"></a></dfn> = "";
-  boolean <dfn class="idl-code" data-default="false" data-dfn-for="InputEventInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-inputeventinit-iscomposing">isComposing<a class="self-link" href="#dom-inputeventinit-iscomposing"></a></dfn> = false;
+<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-inputeventinit">InputEventInit</dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit-uieventinit" id="ref-for-dictdef-uieventinit-uieventinit-5">UIEventInit</a> {
+  <span class="kt">DOMString</span> <dfn class="nv idl-code" data-default="&quot;&quot;" data-dfn-for="InputEventInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-inputeventinit-data">data<a class="self-link" href="#dom-inputeventinit-data"></a></dfn> = "";
+  <span class="kt">boolean</span> <dfn class="nv idl-code" data-default="false" data-dfn-for="InputEventInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-inputeventinit-iscomposing">isComposing<a class="self-link" href="#dom-inputeventinit-iscomposing"></a></dfn> = <span class="kt">false</span>;
 };
 </pre>
     <dl>
@@ -2958,7 +3210,7 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-expor
        <td>
     </table>
     <h4 class="heading settled" data-level="5.5.3" id="events-input-types"><span class="secno">5.5.3. </span><span class="content">Input Event Types</span><a class="self-link" href="#events-input-types"></a></h4>
-    <h5 class="heading settled" data-level="5.5.3.1" id="event-type-beforeinput"><span class="secno">5.5.3.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="beforeinput">beforeinput<span class="dfn-panel"><b><a href="#beforeinput">#beforeinput</a></b><b>Referenced in:</b><span><a href="#ref-for-beforeinput-1">4.1. List of Event Types</a> <a href="#ref-for-beforeinput-2">(2)</a></span><span><a href="#ref-for-beforeinput-3">5.5.2. Input Event Order</a></span><span><a href="#ref-for-beforeinput-4">5.6.1. Interface KeyboardEvent</a></span><span><a href="#ref-for-beforeinput-5">5.6.3. Keyboard Event Order</a> <a href="#ref-for-beforeinput-6">(2)</a></span><span><a href="#ref-for-beforeinput-7">5.6.4.1. keydown</a> <a href="#ref-for-beforeinput-8">(2)</a> <a href="#ref-for-beforeinput-9">(3)</a> <a href="#ref-for-beforeinput-10">(4)</a></span><span><a href="#ref-for-beforeinput-11">5.6.4.2. keyup</a></span><span><a href="#ref-for-beforeinput-12">5.7.6. Input Events During Composition</a> <a href="#ref-for-beforeinput-13">(2)</a> <a href="#ref-for-beforeinput-14">(3)</a> <a href="#ref-for-beforeinput-15">(4)</a> <a href="#ref-for-beforeinput-16">(5)</a></span><span><a href="#ref-for-beforeinput-17">6.3.2. Modifier keys</a> <a href="#ref-for-beforeinput-18">(2)</a> <a href="#ref-for-beforeinput-19">(3)</a> <a href="#ref-for-beforeinput-20">(4)</a> <a href="#ref-for-beforeinput-21">(5)</a></span><span><a href="#ref-for-beforeinput-22">6.3.4. Input Method Editors</a> <a href="#ref-for-beforeinput-23">(2)</a> <a href="#ref-for-beforeinput-24">(3)</a> <a href="#ref-for-beforeinput-25">(4)</a></span><span><a href="#ref-for-beforeinput-26">6.3.5. Default actions and cancelable keyboard events</a> <a href="#ref-for-beforeinput-27">(2)</a> <a href="#ref-for-beforeinput-28">(3)</a> <a href="#ref-for-beforeinput-29">(4)</a> <a href="#ref-for-beforeinput-30">(5)</a></span><span><a href="#ref-for-beforeinput-31">9.3. Legacy KeyboardEvent events</a></span><span><a href="#ref-for-beforeinput-32">9.3.1.1. keypress</a> <a href="#ref-for-beforeinput-33">(2)</a></span><span><a href="#ref-for-beforeinput-34">9.3.2. keypress event order</a> <a href="#ref-for-beforeinput-35">(2)</a></span><span><a href="#ref-for-beforeinput-36">12.2. Changes between different drafts of UI Events</a></span></span></dfn></span><a class="self-link" href="#event-type-beforeinput"></a></h5>
+    <h5 class="heading settled" data-level="5.5.3.1" id="event-type-beforeinput"><span class="secno">5.5.3.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="beforeinput">beforeinput</dfn></span><a class="self-link" href="#event-type-beforeinput"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -2980,6 +3232,9 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-expor
        <th>Cancelable
        <td>Yes
       <tr>
+       <th>Composed
+       <td>Yes
+      <tr>
        <th>Default action
        <td>Update the DOM element
       <tr>
@@ -2997,7 +3252,7 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-expor
     </table>
     <p>A <a data-link-type="dfn" href="#user-agent" id="ref-for-user-agent-28">user agent</a> MUST dispatch this event when the DOM is about
 			to be updated.</p>
-    <h5 class="heading settled" data-level="5.5.3.2" id="event-type-input"><span class="secno">5.5.3.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="input">input<span class="dfn-panel"><b><a href="#input">#input</a></b><b>Referenced in:</b><span><a href="#ref-for-input-1">4.1. List of Event Types</a> <a href="#ref-for-input-2">(2)</a></span><span><a href="#ref-for-input-3">5.5.2. Input Event Order</a></span><span><a href="#ref-for-input-4">5.6.1. Interface KeyboardEvent</a></span><span><a href="#ref-for-input-5">5.6.3. Keyboard Event Order</a> <a href="#ref-for-input-6">(2)</a></span><span><a href="#ref-for-input-7">5.6.4.1. keydown</a> <a href="#ref-for-input-8">(2)</a> <a href="#ref-for-input-9">(3)</a> <a href="#ref-for-input-10">(4)</a></span><span><a href="#ref-for-input-11">5.6.4.2. keyup</a></span><span><a href="#ref-for-input-12">5.7.6. Input Events During Composition</a> <a href="#ref-for-input-13">(2)</a> <a href="#ref-for-input-14">(3)</a> <a href="#ref-for-input-15">(4)</a> <a href="#ref-for-input-16">(5)</a> <a href="#ref-for-input-17">(6)</a></span><span><a href="#ref-for-input-18">6.3.2. Modifier keys</a> <a href="#ref-for-input-19">(2)</a> <a href="#ref-for-input-20">(3)</a> <a href="#ref-for-input-21">(4)</a> <a href="#ref-for-input-22">(5)</a></span><span><a href="#ref-for-input-23">6.3.4. Input Method Editors</a> <a href="#ref-for-input-24">(2)</a> <a href="#ref-for-input-25">(3)</a> <a href="#ref-for-input-26">(4)</a></span><span><a href="#ref-for-input-27">6.3.5. Default actions and cancelable keyboard events</a> <a href="#ref-for-input-28">(2)</a> <a href="#ref-for-input-29">(3)</a> <a href="#ref-for-input-30">(4)</a> <a href="#ref-for-input-31">(5)</a></span><span><a href="#ref-for-input-32">9.3. Legacy KeyboardEvent events</a></span><span><a href="#ref-for-input-33">9.3.1.1. keypress</a></span><span><a href="#ref-for-input-34">9.3.2. keypress event order</a> <a href="#ref-for-input-35">(2)</a></span><span><a href="#ref-for-input-36">12.2. Changes between different drafts of UI Events</a></span></span></dfn></span><a class="self-link" href="#event-type-input"></a></h5>
+    <h5 class="heading settled" data-level="5.5.3.2" id="event-type-input"><span class="secno">5.5.3.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="input">input</dfn></span><a class="self-link" href="#event-type-input"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -3018,6 +3273,9 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-expor
       <tr>
        <th>Cancelable
        <td>No
+      <tr>
+       <th>Composed
+       <td>Yes
       <tr>
        <th>Default action
        <td>None
@@ -3055,27 +3313,27 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-expor
 		common modifiers keys: <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-ctrlkey" id="ref-for-dom-keyboardevent-ctrlkey-2">ctrlKey</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-shiftkey" id="ref-for-dom-keyboardevent-shiftkey-2">shiftKey</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-altkey" id="ref-for-dom-keyboardevent-altkey-2">altKey</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-metakey" id="ref-for-dom-keyboardevent-metakey-2">metaKey</a></code>. These attributes are equivalent to using the
 		method <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate-18">getModifierState()</a></code> with <code class="keycap">Control</code>, <code class="keycap">Shift</code>, <code class="keycap">Alt</code>, or <code class="keycap">Meta</code> respectively.
 		To create an instance of the <code class="idl"><a data-link-type="idl" href="#keyboardevent-keyboardevent" id="ref-for-keyboardevent-keyboardevent-19">KeyboardEvent</a></code> interface, use the <code class="idl"><a data-link-type="idl" href="#keyboardevent-keyboardevent" id="ref-for-keyboardevent-keyboardevent-20">KeyboardEvent</a></code> constructor, passing an optional <code class="idl"><a data-link-type="idl" href="#dictdef-keyboardeventinit" id="ref-for-dictdef-keyboardeventinit-1">KeyboardEventInit</a></code> dictionary.</p>
-<pre class="idl def" data-highlight="webidl">[<dfn class="idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="constructor" data-export="" data-lt="KeyboardEvent(type, eventInitDict)" id="dom-keyboardevent-keyboardevent">Constructor<a class="self-link" href="#dom-keyboardevent-keyboardevent"></a></dfn>(DOMString <dfn class="idl-code" data-dfn-for="KeyboardEvent/KeyboardEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-keyboardevent-keyboardevent-type-eventinitdict-type">type<a class="self-link" href="#dom-keyboardevent-keyboardevent-type-eventinitdict-type"></a></dfn>, optional <a data-link-type="idl-name" href="#dictdef-keyboardeventinit" id="ref-for-dictdef-keyboardeventinit-2">KeyboardEventInit</a> <dfn class="idl-code" data-dfn-for="KeyboardEvent/KeyboardEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-keyboardevent-keyboardevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-keyboardevent-keyboardevent-type-eventinitdict-eventinitdict"></a></dfn>)]
-interface <dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="interface" data-export="" id="keyboardevent-keyboardevent">KeyboardEvent<span class="dfn-panel"><b><a href="#keyboardevent-keyboardevent">#keyboardevent-keyboardevent</a></b><b>Referenced in:</b><span><a href="#ref-for-keyboardevent-keyboardevent-1">2. Stylistic Conventions</a> <a href="#ref-for-keyboardevent-keyboardevent-2">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-3">(3)</a></span><span><a href="#ref-for-keyboardevent-keyboardevent-4">3.6. Constructing Mouse and Keyboard Events</a> <a href="#ref-for-keyboardevent-keyboardevent-5">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-6">(3)</a> <a href="#ref-for-keyboardevent-keyboardevent-7">(4)</a></span><span><a href="#ref-for-keyboardevent-keyboardevent-8">4.1. List of Event Types</a> <a href="#ref-for-keyboardevent-keyboardevent-9">(2)</a></span><span><a href="#ref-for-keyboardevent-keyboardevent-10">5.3.1. Interface MouseEvent</a></span><span><a href="#ref-for-keyboardevent-keyboardevent-11">5.3.2. Event Modifier Initializers</a> <a href="#ref-for-keyboardevent-keyboardevent-12">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-13">(3)</a> <a href="#ref-for-keyboardevent-keyboardevent-14">(4)</a> <a href="#ref-for-keyboardevent-keyboardevent-15">(5)</a> <a href="#ref-for-keyboardevent-keyboardevent-16">(6)</a></span><span><a href="#ref-for-keyboardevent-keyboardevent-17">5.6.1. Interface KeyboardEvent</a> <a href="#ref-for-keyboardevent-keyboardevent-18">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-19">(3)</a> <a href="#ref-for-keyboardevent-keyboardevent-20">(4)</a></span><span><a href="#ref-for-keyboardevent-keyboardevent-21">5.6.2. Keyboard Event Key Location</a></span><span><a href="#ref-for-keyboardevent-keyboardevent-22">5.6.4.1. keydown</a> <a href="#ref-for-keyboardevent-keyboardevent-23">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-24">(3)</a> <a href="#ref-for-keyboardevent-keyboardevent-25">(4)</a> <a href="#ref-for-keyboardevent-keyboardevent-26">(5)</a> <a href="#ref-for-keyboardevent-keyboardevent-27">(6)</a> <a href="#ref-for-keyboardevent-keyboardevent-28">(7)</a> <a href="#ref-for-keyboardevent-keyboardevent-29">(8)</a> <a href="#ref-for-keyboardevent-keyboardevent-30">(9)</a> <a href="#ref-for-keyboardevent-keyboardevent-31">(10)</a></span><span><a href="#ref-for-keyboardevent-keyboardevent-32">5.6.4.2. keyup</a> <a href="#ref-for-keyboardevent-keyboardevent-33">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-34">(3)</a> <a href="#ref-for-keyboardevent-keyboardevent-35">(4)</a> <a href="#ref-for-keyboardevent-keyboardevent-36">(5)</a> <a href="#ref-for-keyboardevent-keyboardevent-37">(6)</a> <a href="#ref-for-keyboardevent-keyboardevent-38">(7)</a> <a href="#ref-for-keyboardevent-keyboardevent-39">(8)</a> <a href="#ref-for-keyboardevent-keyboardevent-40">(9)</a> <a href="#ref-for-keyboardevent-keyboardevent-41">(10)</a></span><span><a href="#ref-for-keyboardevent-keyboardevent-42">5.7.5. Key Events During Composition</a></span><span><a href="#ref-for-keyboardevent-keyboardevent-43">6.2.3. code Examples</a> <a href="#ref-for-keyboardevent-keyboardevent-44">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-45">(3)</a> <a href="#ref-for-keyboardevent-keyboardevent-46">(4)</a> <a href="#ref-for-keyboardevent-keyboardevent-47">(5)</a> <a href="#ref-for-keyboardevent-keyboardevent-48">(6)</a> <a href="#ref-for-keyboardevent-keyboardevent-49">(7)</a> <a href="#ref-for-keyboardevent-keyboardevent-50">(8)</a> <a href="#ref-for-keyboardevent-keyboardevent-51">(9)</a> <a href="#ref-for-keyboardevent-keyboardevent-52">(10)</a></span><span><a href="#ref-for-keyboardevent-keyboardevent-53">6.3.2. Modifier keys</a> <a href="#ref-for-keyboardevent-keyboardevent-54">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-55">(3)</a> <a href="#ref-for-keyboardevent-keyboardevent-56">(4)</a> <a href="#ref-for-keyboardevent-keyboardevent-57">(5)</a> <a href="#ref-for-keyboardevent-keyboardevent-58">(6)</a></span><span><a href="#ref-for-keyboardevent-keyboardevent-59">6.3.3. Dead keys</a> <a href="#ref-for-keyboardevent-keyboardevent-60">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-61">(3)</a> <a href="#ref-for-keyboardevent-keyboardevent-62">(4)</a></span><span><a href="#ref-for-keyboardevent-keyboardevent-63">6.3.4. Input Method Editors</a> <a href="#ref-for-keyboardevent-keyboardevent-64">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-65">(3)</a> <a href="#ref-for-keyboardevent-keyboardevent-66">(4)</a></span><span><a href="#ref-for-keyboardevent-keyboardevent-67">6.3.5. Default actions and cancelable keyboard events</a> <a href="#ref-for-keyboardevent-keyboardevent-68">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-69">(3)</a></span><span><a href="#ref-for-keyboardevent-keyboardevent-70">7.1.4. Initializers for interface KeyboardEvent</a></span><span><a href="#ref-for-keyboardevent-keyboardevent-71">8.1. Legacy KeyboardEvent supplemental interface</a></span><span><a href="#ref-for-keyboardevent-keyboardevent-72">8.1.1. Interface KeyboardEvent (supplemental)</a> <a href="#ref-for-keyboardevent-keyboardevent-73">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-74">(3)</a> <a href="#ref-for-keyboardevent-keyboardevent-75">(4)</a></span><span><a href="#ref-for-keyboardevent-keyboardevent-76">8.1.2. Interface KeyboardEventInit (supplemental)</a> <a href="#ref-for-keyboardevent-keyboardevent-77">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-78">(3)</a> <a href="#ref-for-keyboardevent-keyboardevent-79">(4)</a> <a href="#ref-for-keyboardevent-keyboardevent-80">(5)</a></span><span><a href="#ref-for-keyboardevent-keyboardevent-81">9. Legacy Event Types</a></span><span><a href="#ref-for-keyboardevent-keyboardevent-82">9.3. Legacy KeyboardEvent events</a></span><span><a href="#ref-for-keyboardevent-keyboardevent-83">9.3.1. Legacy KeyboardEvent event types</a></span><span><a href="#ref-for-keyboardevent-keyboardevent-84">9.3.1.1. keypress</a> <a href="#ref-for-keyboardevent-keyboardevent-85">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-86">(3)</a> <a href="#ref-for-keyboardevent-keyboardevent-87">(4)</a> <a href="#ref-for-keyboardevent-keyboardevent-88">(5)</a> <a href="#ref-for-keyboardevent-keyboardevent-89">(6)</a> <a href="#ref-for-keyboardevent-keyboardevent-90">(7)</a> <a href="#ref-for-keyboardevent-keyboardevent-91">(8)</a> <a href="#ref-for-keyboardevent-keyboardevent-92">(9)</a> <a href="#ref-for-keyboardevent-keyboardevent-93">(10)</a> <a href="#ref-for-keyboardevent-keyboardevent-94">(11)</a> <a href="#ref-for-keyboardevent-keyboardevent-95">(12)</a> <a href="#ref-for-keyboardevent-keyboardevent-96">(13)</a></span><span><a href="#ref-for-keyboardevent-keyboardevent-97">9.3.2. keypress event order</a></span><span><a href="#ref-for-keyboardevent-keyboardevent-98">12.1.4. New Interfaces</a></span><span><a href="#ref-for-keyboardevent-keyboardevent-99">12.2. Changes between different drafts of UI Events</a> <a href="#ref-for-keyboardevent-keyboardevent-100">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-101">(3)</a></span></span></dfn> : <a data-link-type="idl-name" href="#uievent-uievent" id="ref-for-uievent-uievent-54">UIEvent</a> {
+<pre class="idl highlight def" data-highlight="webidl">[<dfn class="nv idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="constructor" data-export="" data-lt="KeyboardEvent(type, eventInitDict)|KeyboardEvent(type)" id="dom-keyboardevent-keyboardevent">Constructor<a class="self-link" href="#dom-keyboardevent-keyboardevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="KeyboardEvent/KeyboardEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-keyboardevent-keyboardevent-type-eventinitdict-type">type<a class="self-link" href="#dom-keyboardevent-keyboardevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-keyboardeventinit" id="ref-for-dictdef-keyboardeventinit-2">KeyboardEventInit</a> <dfn class="nv idl-code" data-dfn-for="KeyboardEvent/KeyboardEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-keyboardevent-keyboardevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-keyboardevent-keyboardevent-type-eventinitdict-eventinitdict"></a></dfn>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="interface" data-export="" id="keyboardevent-keyboardevent">KeyboardEvent</dfn> : <a class="n" data-link-type="idl-name" href="#uievent-uievent" id="ref-for-uievent-uievent-54">UIEvent</a> {
   // KeyLocationCode
-  const unsigned long <dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="const" data-export="" id="dom-keyboardevent-dom_key_location_standard">DOM_KEY_LOCATION_STANDARD<span class="dfn-panel"><b><a href="#dom-keyboardevent-dom_key_location_standard">#dom-keyboardevent-dom_key_location_standard</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-keyboardevent-dom_key_location_standard-1">5.6.1. Interface KeyboardEvent</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_standard-2">(2)</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_standard-3">(3)</a></span><span><a href="#ref-for-dom-keyboardevent-dom_key_location_standard-4">5.6.2. Keyboard Event Key Location</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_standard-5">(2)</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_standard-6">(3)</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_standard-7">(4)</a></span><span><a href="#ref-for-dom-keyboardevent-dom_key_location_standard-8">6.3. Keyboard Event key Values</a></span></span></dfn> = 0x00;
-  const unsigned long <dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="const" data-export="" id="dom-keyboardevent-dom_key_location_left">DOM_KEY_LOCATION_LEFT<span class="dfn-panel"><b><a href="#dom-keyboardevent-dom_key_location_left">#dom-keyboardevent-dom_key_location_left</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-keyboardevent-dom_key_location_left-1">5.6.1. Interface KeyboardEvent</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_left-2">(2)</a></span><span><a href="#ref-for-dom-keyboardevent-dom_key_location_left-3">5.6.2. Keyboard Event Key Location</a></span><span><a href="#ref-for-dom-keyboardevent-dom_key_location_left-4">6.2.3. code Examples</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_left-5">(2)</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_left-6">(3)</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_left-7">(4)</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_left-8">(5)</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_left-9">(6)</a></span><span><a href="#ref-for-dom-keyboardevent-dom_key_location_left-10">6.3. Keyboard Event key Values</a></span></span></dfn> = 0x01;
-  const unsigned long <dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="const" data-export="" id="dom-keyboardevent-dom_key_location_right">DOM_KEY_LOCATION_RIGHT<span class="dfn-panel"><b><a href="#dom-keyboardevent-dom_key_location_right">#dom-keyboardevent-dom_key_location_right</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-keyboardevent-dom_key_location_right-1">5.6.1. Interface KeyboardEvent</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_right-2">(2)</a></span><span><a href="#ref-for-dom-keyboardevent-dom_key_location_right-3">5.6.2. Keyboard Event Key Location</a></span><span><a href="#ref-for-dom-keyboardevent-dom_key_location_right-4">6.2.3. code Examples</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_right-5">(2)</a></span><span><a href="#ref-for-dom-keyboardevent-dom_key_location_right-6">6.3. Keyboard Event key Values</a></span></span></dfn> = 0x02;
-  const unsigned long <dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="const" data-export="" id="dom-keyboardevent-dom_key_location_numpad">DOM_KEY_LOCATION_NUMPAD<span class="dfn-panel"><b><a href="#dom-keyboardevent-dom_key_location_numpad">#dom-keyboardevent-dom_key_location_numpad</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-keyboardevent-dom_key_location_numpad-1">5.6.1. Interface KeyboardEvent</a></span><span><a href="#ref-for-dom-keyboardevent-dom_key_location_numpad-2">5.6.2. Keyboard Event Key Location</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_numpad-3">(2)</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_numpad-4">(3)</a></span><span><a href="#ref-for-dom-keyboardevent-dom_key_location_numpad-5">6.3. Keyboard Event key Values</a></span></span></dfn> = 0x03;
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="const" data-export="" id="dom-keyboardevent-dom_key_location_standard">DOM_KEY_LOCATION_STANDARD</dfn> = 0x00;
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="const" data-export="" id="dom-keyboardevent-dom_key_location_left">DOM_KEY_LOCATION_LEFT</dfn> = 0x01;
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="const" data-export="" id="dom-keyboardevent-dom_key_location_right">DOM_KEY_LOCATION_RIGHT</dfn> = 0x02;
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="const" data-export="" id="dom-keyboardevent-dom_key_location_numpad">DOM_KEY_LOCATION_NUMPAD</dfn> = 0x03;
 
-  readonly attribute DOMString <dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMString " id="dom-keyboardevent-key">key<span class="dfn-panel"><b><a href="#dom-keyboardevent-key">#dom-keyboardevent-key</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-keyboardevent-key-1">2. Stylistic Conventions</a> <a href="#ref-for-dom-keyboardevent-key-2">(2)</a></span><span><a href="#ref-for-dom-keyboardevent-key-3">3.5. Activation triggers and behavior</a></span><span><a href="#ref-for-dom-keyboardevent-key-4">5.6.1. Interface KeyboardEvent</a></span><span><a href="#ref-for-dom-keyboardevent-key-5">5.6.2. Keyboard Event Key Location</a> <a href="#ref-for-dom-keyboardevent-key-6">(2)</a></span><span><a href="#ref-for-dom-keyboardevent-key-7">5.6.4.1. keydown</a></span><span><a href="#ref-for-dom-keyboardevent-key-8">5.6.4.2. keyup</a></span><span><a href="#ref-for-dom-keyboardevent-key-9">6.2.1. Motivation for the code Attribute</a> <a href="#ref-for-dom-keyboardevent-key-10">(2)</a> <a href="#ref-for-dom-keyboardevent-key-11">(3)</a> <a href="#ref-for-dom-keyboardevent-key-12">(4)</a></span><span><a href="#ref-for-dom-keyboardevent-key-13">6.2.2. The Relationship Between key and code</a> <a href="#ref-for-dom-keyboardevent-key-14">(2)</a> <a href="#ref-for-dom-keyboardevent-key-15">(3)</a> <a href="#ref-for-dom-keyboardevent-key-16">(4)</a></span><span><a href="#ref-for-dom-keyboardevent-key-17">6.2.3. code Examples</a> <a href="#ref-for-dom-keyboardevent-key-18">(2)</a> <a href="#ref-for-dom-keyboardevent-key-19">(3)</a> <a href="#ref-for-dom-keyboardevent-key-20">(4)</a> <a href="#ref-for-dom-keyboardevent-key-21">(5)</a> <a href="#ref-for-dom-keyboardevent-key-22">(6)</a> <a href="#ref-for-dom-keyboardevent-key-23">(7)</a> <a href="#ref-for-dom-keyboardevent-key-24">(8)</a></span><span><a href="#ref-for-dom-keyboardevent-key-25">6.2.4. code and Virtual Keyboards</a></span><span><a href="#ref-for-dom-keyboardevent-key-26">6.3. Keyboard Event key Values</a> <a href="#ref-for-dom-keyboardevent-key-27">(2)</a> <a href="#ref-for-dom-keyboardevent-key-28">(3)</a></span><span><a href="#ref-for-dom-keyboardevent-key-29">6.3.2. Modifier keys</a> <a href="#ref-for-dom-keyboardevent-key-30">(2)</a> <a href="#ref-for-dom-keyboardevent-key-31">(3)</a> <a href="#ref-for-dom-keyboardevent-key-32">(4)</a> <a href="#ref-for-dom-keyboardevent-key-33">(5)</a> <a href="#ref-for-dom-keyboardevent-key-34">(6)</a> <a href="#ref-for-dom-keyboardevent-key-35">(7)</a></span><span><a href="#ref-for-dom-keyboardevent-key-36">6.3.3. Dead keys</a> <a href="#ref-for-dom-keyboardevent-key-37">(2)</a></span><span><a href="#ref-for-dom-keyboardevent-key-38">6.3.4. Input Method Editors</a> <a href="#ref-for-dom-keyboardevent-key-39">(2)</a></span><span><a href="#ref-for-dom-keyboardevent-key-40">6.3.5. Default actions and cancelable keyboard events</a> <a href="#ref-for-dom-keyboardevent-key-41">(2)</a> <a href="#ref-for-dom-keyboardevent-key-42">(3)</a></span><span><a href="#ref-for-dom-keyboardevent-key-43">6.3.6. Guidelines for selecting key values</a> <a href="#ref-for-dom-keyboardevent-key-44">(2)</a> <a href="#ref-for-dom-keyboardevent-key-45">(3)</a></span><span><a href="#ref-for-dom-keyboardevent-key-46">7.1.4. Initializers for interface KeyboardEvent</a></span><span><a href="#ref-for-dom-keyboardevent-key-47">8. Legacy Key Attributes</a></span><span><a href="#ref-for-dom-keyboardevent-key-48">8.1.1. Interface KeyboardEvent (supplemental)</a></span><span><a href="#ref-for-dom-keyboardevent-key-49">9.3.1.1. keypress</a></span><span><a href="#ref-for-dom-keyboardevent-key-50">9.3.2. keypress event order</a></span><span><a href="#ref-for-dom-keyboardevent-key-51">12.2. Changes between different drafts of UI Events</a></span></span></dfn>;
-  readonly attribute DOMString <dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMString " id="dom-keyboardevent-code">code<span class="dfn-panel"><b><a href="#dom-keyboardevent-code">#dom-keyboardevent-code</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-keyboardevent-code-1">2. Stylistic Conventions</a> <a href="#ref-for-dom-keyboardevent-code-2">(2)</a></span><span><a href="#ref-for-dom-keyboardevent-code-3">5.6.1. Interface KeyboardEvent</a></span><span><a href="#ref-for-dom-keyboardevent-code-4">5.6.4.1. keydown</a></span><span><a href="#ref-for-dom-keyboardevent-code-5">5.6.4.2. keyup</a></span><span><a href="#ref-for-dom-keyboardevent-code-6">6.2. Key codes</a> <a href="#ref-for-dom-keyboardevent-code-7">(2)</a> <a href="#ref-for-dom-keyboardevent-code-8">(3)</a></span><span><a href="#ref-for-dom-keyboardevent-code-9">6.2.1. Motivation for the code Attribute</a> <a href="#ref-for-dom-keyboardevent-code-10">(2)</a> <a href="#ref-for-dom-keyboardevent-code-11">(3)</a></span><span><a href="#ref-for-dom-keyboardevent-code-12">6.2.2. The Relationship Between key and code</a> <a href="#ref-for-dom-keyboardevent-code-13">(2)</a> <a href="#ref-for-dom-keyboardevent-code-14">(3)</a></span><span><a href="#ref-for-dom-keyboardevent-code-15">6.2.3. code Examples</a> <a href="#ref-for-dom-keyboardevent-code-16">(2)</a> <a href="#ref-for-dom-keyboardevent-code-17">(3)</a> <a href="#ref-for-dom-keyboardevent-code-18">(4)</a> <a href="#ref-for-dom-keyboardevent-code-19">(5)</a> <a href="#ref-for-dom-keyboardevent-code-20">(6)</a> <a href="#ref-for-dom-keyboardevent-code-21">(7)</a> <a href="#ref-for-dom-keyboardevent-code-22">(8)</a> <a href="#ref-for-dom-keyboardevent-code-23">(9)</a></span><span><a href="#ref-for-dom-keyboardevent-code-24">6.2.4. code and Virtual Keyboards</a> <a href="#ref-for-dom-keyboardevent-code-25">(2)</a> <a href="#ref-for-dom-keyboardevent-code-26">(3)</a> <a href="#ref-for-dom-keyboardevent-code-27">(4)</a> <a href="#ref-for-dom-keyboardevent-code-28">(5)</a></span><span><a href="#ref-for-dom-keyboardevent-code-29">6.3.2. Modifier keys</a></span><span><a href="#ref-for-dom-keyboardevent-code-30">9.3.1.1. keypress</a></span></span></dfn>;
-  readonly attribute unsigned long <dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unsigned long " id="dom-keyboardevent-location">location<span class="dfn-panel"><b><a href="#dom-keyboardevent-location">#dom-keyboardevent-location</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-keyboardevent-location-1">5.6.1. Interface KeyboardEvent</a> <a href="#ref-for-dom-keyboardevent-location-2">(2)</a> <a href="#ref-for-dom-keyboardevent-location-3">(3)</a> <a href="#ref-for-dom-keyboardevent-location-4">(4)</a> <a href="#ref-for-dom-keyboardevent-location-5">(5)</a> <a href="#ref-for-dom-keyboardevent-location-6">(6)</a> <a href="#ref-for-dom-keyboardevent-location-7">(7)</a></span><span><a href="#ref-for-dom-keyboardevent-location-8">5.6.2. Keyboard Event Key Location</a> <a href="#ref-for-dom-keyboardevent-location-9">(2)</a> <a href="#ref-for-dom-keyboardevent-location-10">(3)</a> <a href="#ref-for-dom-keyboardevent-location-11">(4)</a></span><span><a href="#ref-for-dom-keyboardevent-location-12">5.6.4.1. keydown</a></span><span><a href="#ref-for-dom-keyboardevent-location-13">5.6.4.2. keyup</a></span><span><a href="#ref-for-dom-keyboardevent-location-14">6.3. Keyboard Event key Values</a> <a href="#ref-for-dom-keyboardevent-location-15">(2)</a> <a href="#ref-for-dom-keyboardevent-location-16">(3)</a></span><span><a href="#ref-for-dom-keyboardevent-location-17">7.1.4. Initializers for interface KeyboardEvent</a></span><span><a href="#ref-for-dom-keyboardevent-location-18">9.3.1.1. keypress</a></span><span><a href="#ref-for-dom-keyboardevent-location-19">12.2. Changes between different drafts of UI Events</a></span></span></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMString" id="dom-keyboardevent-key">key</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMString" id="dom-keyboardevent-code">code</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unsigned long" id="dom-keyboardevent-location">location</dfn>;
 
-  readonly attribute boolean <dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean " id="dom-keyboardevent-ctrlkey">ctrlKey<span class="dfn-panel"><b><a href="#dom-keyboardevent-ctrlkey">#dom-keyboardevent-ctrlkey</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-keyboardevent-ctrlkey-1">5.3.1. Interface MouseEvent</a></span><span><a href="#ref-for-dom-keyboardevent-ctrlkey-2">5.6.1. Interface KeyboardEvent</a></span><span><a href="#ref-for-dom-keyboardevent-ctrlkey-3">5.6.4.1. keydown</a></span><span><a href="#ref-for-dom-keyboardevent-ctrlkey-4">5.6.4.2. keyup</a></span><span><a href="#ref-for-dom-keyboardevent-ctrlkey-5">6.3.2. Modifier keys</a> <a href="#ref-for-dom-keyboardevent-ctrlkey-6">(2)</a> <a href="#ref-for-dom-keyboardevent-ctrlkey-7">(3)</a> <a href="#ref-for-dom-keyboardevent-ctrlkey-8">(4)</a> <a href="#ref-for-dom-keyboardevent-ctrlkey-9">(5)</a> <a href="#ref-for-dom-keyboardevent-ctrlkey-10">(6)</a> <a href="#ref-for-dom-keyboardevent-ctrlkey-11">(7)</a> <a href="#ref-for-dom-keyboardevent-ctrlkey-12">(8)</a> <a href="#ref-for-dom-keyboardevent-ctrlkey-13">(9)</a> <a href="#ref-for-dom-keyboardevent-ctrlkey-14">(10)</a> <a href="#ref-for-dom-keyboardevent-ctrlkey-15">(11)</a> <a href="#ref-for-dom-keyboardevent-ctrlkey-16">(12)</a></span><span><a href="#ref-for-dom-keyboardevent-ctrlkey-17">9.3.1.1. keypress</a></span></span></dfn>;
-  readonly attribute boolean <dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean " id="dom-keyboardevent-shiftkey">shiftKey<span class="dfn-panel"><b><a href="#dom-keyboardevent-shiftkey">#dom-keyboardevent-shiftkey</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-keyboardevent-shiftkey-1">5.3.1. Interface MouseEvent</a></span><span><a href="#ref-for-dom-keyboardevent-shiftkey-2">5.6.1. Interface KeyboardEvent</a></span><span><a href="#ref-for-dom-keyboardevent-shiftkey-3">5.6.4.1. keydown</a></span><span><a href="#ref-for-dom-keyboardevent-shiftkey-4">5.6.4.2. keyup</a></span><span><a href="#ref-for-dom-keyboardevent-shiftkey-5">6.2.3. code Examples</a> <a href="#ref-for-dom-keyboardevent-shiftkey-6">(2)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-7">(3)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-8">(4)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-9">(5)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-10">(6)</a></span><span><a href="#ref-for-dom-keyboardevent-shiftkey-11">6.3.2. Modifier keys</a> <a href="#ref-for-dom-keyboardevent-shiftkey-12">(2)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-13">(3)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-14">(4)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-15">(5)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-16">(6)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-17">(7)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-18">(8)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-19">(9)</a></span><span><a href="#ref-for-dom-keyboardevent-shiftkey-20">6.3.5. Default actions and cancelable keyboard events</a> <a href="#ref-for-dom-keyboardevent-shiftkey-21">(2)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-22">(3)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-23">(4)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-24">(5)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-25">(6)</a></span><span><a href="#ref-for-dom-keyboardevent-shiftkey-26">9.3.1.1. keypress</a></span></span></dfn>;
-  readonly attribute boolean <dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean " id="dom-keyboardevent-altkey">altKey<span class="dfn-panel"><b><a href="#dom-keyboardevent-altkey">#dom-keyboardevent-altkey</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-keyboardevent-altkey-1">5.3.1. Interface MouseEvent</a></span><span><a href="#ref-for-dom-keyboardevent-altkey-2">5.6.1. Interface KeyboardEvent</a></span><span><a href="#ref-for-dom-keyboardevent-altkey-3">5.6.4.1. keydown</a></span><span><a href="#ref-for-dom-keyboardevent-altkey-4">5.6.4.2. keyup</a></span><span><a href="#ref-for-dom-keyboardevent-altkey-5">6.3.2. Modifier keys</a></span><span><a href="#ref-for-dom-keyboardevent-altkey-6">9.3.1.1. keypress</a></span></span></dfn>;
-  readonly attribute boolean <dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean " id="dom-keyboardevent-metakey">metaKey<span class="dfn-panel"><b><a href="#dom-keyboardevent-metakey">#dom-keyboardevent-metakey</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-keyboardevent-metakey-1">5.3.1. Interface MouseEvent</a></span><span><a href="#ref-for-dom-keyboardevent-metakey-2">5.6.1. Interface KeyboardEvent</a></span><span><a href="#ref-for-dom-keyboardevent-metakey-3">5.6.4.1. keydown</a></span><span><a href="#ref-for-dom-keyboardevent-metakey-4">5.6.4.2. keyup</a></span><span><a href="#ref-for-dom-keyboardevent-metakey-5">6.3.2. Modifier keys</a></span><span><a href="#ref-for-dom-keyboardevent-metakey-6">9.3.1.1. keypress</a></span></span></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean" id="dom-keyboardevent-ctrlkey">ctrlKey</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean" id="dom-keyboardevent-shiftkey">shiftKey</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean" id="dom-keyboardevent-altkey">altKey</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean" id="dom-keyboardevent-metakey">metaKey</dfn>;
 
-  readonly attribute boolean <dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean " id="dom-keyboardevent-repeat">repeat<span class="dfn-panel"><b><a href="#dom-keyboardevent-repeat">#dom-keyboardevent-repeat</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-keyboardevent-repeat-1">5.6.1. Interface KeyboardEvent</a></span><span><a href="#ref-for-dom-keyboardevent-repeat-2">5.6.3. Keyboard Event Order</a></span><span><a href="#ref-for-dom-keyboardevent-repeat-3">5.6.4.1. keydown</a></span><span><a href="#ref-for-dom-keyboardevent-repeat-4">5.6.4.2. keyup</a></span><span><a href="#ref-for-dom-keyboardevent-repeat-5">7.1.4. Initializers for interface KeyboardEvent</a></span><span><a href="#ref-for-dom-keyboardevent-repeat-6">9.3.1.1. keypress</a></span></span></dfn>;
-  readonly attribute boolean <dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean " id="dom-keyboardevent-iscomposing">isComposing<span class="dfn-panel"><b><a href="#dom-keyboardevent-iscomposing">#dom-keyboardevent-iscomposing</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-keyboardevent-iscomposing-1">5.6.4.1. keydown</a></span><span><a href="#ref-for-dom-keyboardevent-iscomposing-2">5.6.4.2. keyup</a></span><span><a href="#ref-for-dom-keyboardevent-iscomposing-3">5.7.5. Key Events During Composition</a> <a href="#ref-for-dom-keyboardevent-iscomposing-4">(2)</a></span><span><a href="#ref-for-dom-keyboardevent-iscomposing-5">6.3.3. Dead keys</a> <a href="#ref-for-dom-keyboardevent-iscomposing-6">(2)</a></span><span><a href="#ref-for-dom-keyboardevent-iscomposing-7">6.3.4. Input Method Editors</a> <a href="#ref-for-dom-keyboardevent-iscomposing-8">(2)</a></span><span><a href="#ref-for-dom-keyboardevent-iscomposing-9">9.3.1.1. keypress</a></span></span></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean" id="dom-keyboardevent-repeat">repeat</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean" id="dom-keyboardevent-iscomposing">isComposing</dfn>;
 
-  boolean <dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="method" data-export="" data-lt="getModifierState(keyArg)" id="dom-keyboardevent-getmodifierstate">getModifierState<span class="dfn-panel"><b><a href="#dom-keyboardevent-getmodifierstate">#dom-keyboardevent-getmodifierstate</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-keyboardevent-getmodifierstate-1">3.6. Constructing Mouse and Keyboard Events</a></span><span><a href="#ref-for-dom-keyboardevent-getmodifierstate-2">5.3.1. Interface MouseEvent</a></span><span><a href="#ref-for-dom-keyboardevent-getmodifierstate-3">5.3.2. Event Modifier Initializers</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-4">(2)</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-5">(3)</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-6">(4)</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-7">(5)</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-8">(6)</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-9">(7)</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-10">(8)</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-11">(9)</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-12">(10)</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-13">(11)</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-14">(12)</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-15">(13)</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-16">(14)</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-17">(15)</a></span><span><a href="#ref-for-dom-keyboardevent-getmodifierstate-18">5.6.1. Interface KeyboardEvent</a></span></span></dfn>(DOMString <dfn class="idl-code" data-dfn-for="KeyboardEvent/getModifierState(keyArg)" data-dfn-type="argument" data-export="" id="dom-keyboardevent-getmodifierstate-keyarg-keyarg">keyArg<a class="self-link" href="#dom-keyboardevent-getmodifierstate-keyarg-keyarg"></a></dfn>);
+  <span class="kt">boolean</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="method" data-export="" data-lt="getModifierState(keyArg)" id="dom-keyboardevent-getmodifierstate">getModifierState</dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="KeyboardEvent/getModifierState(keyArg)" data-dfn-type="argument" data-export="" id="dom-keyboardevent-getmodifierstate-keyarg-keyarg">keyArg<a class="self-link" href="#dom-keyboardevent-getmodifierstate-keyarg-keyarg"></a></dfn>);
 };
 </pre>
     <dl>
@@ -3181,12 +3439,12 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-df
 						using keyboard events and <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-location" id="ref-for-dom-keyboardevent-location-6">location</a></code>. </p>
       </dl>
     </dl>
-<pre class="idl def">dictionary <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-keyboardeventinit">KeyboardEventInit<span class="dfn-panel"><b><a href="#dictdef-keyboardeventinit">#dictdef-keyboardeventinit</a></b><b>Referenced in:</b><span><a href="#ref-for-dictdef-keyboardeventinit-1">5.6.1. Interface KeyboardEvent</a> <a href="#ref-for-dictdef-keyboardeventinit-2">(2)</a></span><span><a href="#ref-for-dictdef-keyboardeventinit-3">8.1.2. Interface KeyboardEventInit (supplemental)</a> <a href="#ref-for-dictdef-keyboardeventinit-4">(2)</a> <a href="#ref-for-dictdef-keyboardeventinit-5">(3)</a></span></span></dfn> : <a data-link-type="idl-name" href="#dictdef-eventmodifierinit" id="ref-for-dictdef-eventmodifierinit-4">EventModifierInit</a> {
-  DOMString <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-keyboardeventinit-key">key<a class="self-link" href="#dom-keyboardeventinit-key"></a></dfn> = "";
-  DOMString <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-keyboardeventinit-code">code<a class="self-link" href="#dom-keyboardeventinit-code"></a></dfn> = "";
-  unsigned long <dfn class="idl-code" data-default="0" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export="" data-type="unsigned long " id="dom-keyboardeventinit-location">location<a class="self-link" href="#dom-keyboardeventinit-location"></a></dfn> = 0;
-  boolean <dfn class="idl-code" data-default="false" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-keyboardeventinit-repeat">repeat<a class="self-link" href="#dom-keyboardeventinit-repeat"></a></dfn> = false;
-  boolean <dfn class="idl-code" data-default="false" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-keyboardeventinit-iscomposing">isComposing<a class="self-link" href="#dom-keyboardeventinit-iscomposing"></a></dfn> = false;
+<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-keyboardeventinit">KeyboardEventInit</dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-eventmodifierinit" id="ref-for-dictdef-eventmodifierinit-4">EventModifierInit</a> {
+  <span class="kt">DOMString</span> <dfn class="nv idl-code" data-default="&quot;&quot;" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-keyboardeventinit-key">key<a class="self-link" href="#dom-keyboardeventinit-key"></a></dfn> = "";
+  <span class="kt">DOMString</span> <dfn class="nv idl-code" data-default="&quot;&quot;" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-keyboardeventinit-code">code<a class="self-link" href="#dom-keyboardeventinit-code"></a></dfn> = "";
+  <span class="kt">unsigned</span> <span class="kt">long</span> <dfn class="nv idl-code" data-default="0" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export="" data-type="unsigned long " id="dom-keyboardeventinit-location">location<a class="self-link" href="#dom-keyboardeventinit-location"></a></dfn> = 0;
+  <span class="kt">boolean</span> <dfn class="nv idl-code" data-default="false" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-keyboardeventinit-repeat">repeat<a class="self-link" href="#dom-keyboardeventinit-repeat"></a></dfn> = <span class="kt">false</span>;
+  <span class="kt">boolean</span> <dfn class="nv idl-code" data-default="false" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export="" data-type="boolean " id="dom-keyboardeventinit-iscomposing">isComposing<a class="self-link" href="#dom-keyboardeventinit-iscomposing"></a></dfn> = <span class="kt">false</span>;
 };
 </pre>
     <dl>
@@ -3349,7 +3607,7 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-df
     <p class="note" role="note"> The <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-37">event target</a> might change between different key events. For
 		example, a <a data-link-type="dfn" href="#keydown" id="ref-for-keydown-6"><code>keydown</code></a> event for the <code class="keycap">Tab</code> key will likely have		a different <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-38">event target</a> than the <a data-link-type="dfn" href="#keyup" id="ref-for-keyup-5"><code>keyup</code></a> event on the same		keystroke. </p>
     <h4 class="heading settled" data-level="5.6.4" id="events-keyboard-types"><span class="secno">5.6.4. </span><span class="content">Keyboard Event Types</span><a class="self-link" href="#events-keyboard-types"></a></h4>
-    <h5 class="heading settled" data-level="5.6.4.1" id="event-type-keydown"><span class="secno">5.6.4.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="keydown">keydown<span class="dfn-panel"><b><a href="#keydown">#keydown</a></b><b>Referenced in:</b><span><a href="#ref-for-keydown-1">3.5. Activation triggers and behavior</a></span><span><a href="#ref-for-keydown-2">4.1. List of Event Types</a></span><span><a href="#ref-for-keydown-3">5.6.1. Interface KeyboardEvent</a></span><span><a href="#ref-for-keydown-4">5.6.3. Keyboard Event Order</a> <a href="#ref-for-keydown-5">(2)</a> <a href="#ref-for-keydown-6">(3)</a></span><span><a href="#ref-for-keydown-7">5.6.4.1. keydown</a> <a href="#ref-for-keydown-8">(2)</a> <a href="#ref-for-keydown-9">(3)</a></span><span><a href="#ref-for-keydown-10">5.6.4.2. keyup</a> <a href="#ref-for-keydown-11">(2)</a></span><span><a href="#ref-for-keydown-12">5.7.4. Canceling Composition Events</a> <a href="#ref-for-keydown-13">(2)</a> <a href="#ref-for-keydown-14">(3)</a> <a href="#ref-for-keydown-15">(4)</a></span><span><a href="#ref-for-keydown-16">5.7.5. Key Events During Composition</a> <a href="#ref-for-keydown-17">(2)</a> <a href="#ref-for-keydown-18">(3)</a></span><span><a href="#ref-for-keydown-19">5.7.7.1. compositionstart</a></span><span><a href="#ref-for-keydown-20">6.2.3. code Examples</a> <a href="#ref-for-keydown-21">(2)</a> <a href="#ref-for-keydown-22">(3)</a> <a href="#ref-for-keydown-23">(4)</a></span><span><a href="#ref-for-keydown-24">6.3.2. Modifier keys</a> <a href="#ref-for-keydown-25">(2)</a> <a href="#ref-for-keydown-26">(3)</a> <a href="#ref-for-keydown-27">(4)</a> <a href="#ref-for-keydown-28">(5)</a> <a href="#ref-for-keydown-29">(6)</a> <a href="#ref-for-keydown-30">(7)</a> <a href="#ref-for-keydown-31">(8)</a> <a href="#ref-for-keydown-32">(9)</a> <a href="#ref-for-keydown-33">(10)</a> <a href="#ref-for-keydown-34">(11)</a> <a href="#ref-for-keydown-35">(12)</a> <a href="#ref-for-keydown-36">(13)</a></span><span><a href="#ref-for-keydown-37">6.3.3. Dead keys</a> <a href="#ref-for-keydown-38">(2)</a> <a href="#ref-for-keydown-39">(3)</a> <a href="#ref-for-keydown-40">(4)</a> <a href="#ref-for-keydown-41">(5)</a></span><span><a href="#ref-for-keydown-42">6.3.4. Input Method Editors</a> <a href="#ref-for-keydown-43">(2)</a> <a href="#ref-for-keydown-44">(3)</a> <a href="#ref-for-keydown-45">(4)</a> <a href="#ref-for-keydown-46">(5)</a> <a href="#ref-for-keydown-47">(6)</a> <a href="#ref-for-keydown-48">(7)</a> <a href="#ref-for-keydown-49">(8)</a> <a href="#ref-for-keydown-50">(9)</a> <a href="#ref-for-keydown-51">(10)</a> <a href="#ref-for-keydown-52">(11)</a></span><span><a href="#ref-for-keydown-53">6.3.5. Default actions and cancelable keyboard events</a> <a href="#ref-for-keydown-54">(2)</a> <a href="#ref-for-keydown-55">(3)</a> <a href="#ref-for-keydown-56">(4)</a> <a href="#ref-for-keydown-57">(5)</a> <a href="#ref-for-keydown-58">(6)</a> <a href="#ref-for-keydown-59">(7)</a> <a href="#ref-for-keydown-60">(8)</a></span><span><a href="#ref-for-keydown-61">8.1.1. Interface KeyboardEvent (supplemental)</a></span><span><a href="#ref-for-keydown-62">8.2.1. How to determine keyCode for keydown and keyup events</a> <a href="#ref-for-keydown-63">(2)</a> <a href="#ref-for-keydown-64">(3)</a></span><span><a href="#ref-for-keydown-65">9.1.2. Activation event order</a></span><span><a href="#ref-for-keydown-66">9.3.2. keypress event order</a> <a href="#ref-for-keydown-67">(2)</a></span><span><a href="#ref-for-keydown-68">14. Glossary</a></span></span></dfn></span><a class="self-link" href="#event-type-keydown"></a></h5>
+    <h5 class="heading settled" data-level="5.6.4.1" id="event-type-keydown"><span class="secno">5.6.4.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="keydown">keydown</dfn></span><a class="self-link" href="#event-type-keydown"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -3369,6 +3627,9 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-df
        <td><code>Element</code>
       <tr>
        <th>Cancelable
+       <td>Yes
+      <tr>
+       <th>Composed
        <td>Yes
       <tr>
        <th>Default action
@@ -3420,7 +3681,7 @@ details)</p>
     <p>If this event is canceled, the associated event types MUST NOT be
 			dispatched, and the associated actions MUST NOT be performed.</p>
     <p class="note" role="note"> The <a data-link-type="dfn" href="#keydown" id="ref-for-keydown-9"><code>keydown</code></a> and <a data-link-type="dfn" href="#keyup" id="ref-for-keyup-7"><code>keyup</code></a> events are traditionally			associated with detecting any key, not just those which produce a <a data-link-type="dfn" href="#character-value" id="ref-for-character-value-4">character value</a>. </p>
-    <h5 class="heading settled" data-level="5.6.4.2" id="event-type-keyup"><span class="secno">5.6.4.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="keyup">keyup<span class="dfn-panel"><b><a href="#keyup">#keyup</a></b><b>Referenced in:</b><span><a href="#ref-for-keyup-1">4.1. List of Event Types</a></span><span><a href="#ref-for-keyup-2">5.6.3. Keyboard Event Order</a> <a href="#ref-for-keyup-3">(2)</a> <a href="#ref-for-keyup-4">(3)</a> <a href="#ref-for-keyup-5">(4)</a></span><span><a href="#ref-for-keyup-6">5.6.4.1. keydown</a> <a href="#ref-for-keyup-7">(2)</a></span><span><a href="#ref-for-keyup-8">5.6.4.2. keyup</a> <a href="#ref-for-keyup-9">(2)</a></span><span><a href="#ref-for-keyup-10">5.7.4. Canceling Composition Events</a> <a href="#ref-for-keyup-11">(2)</a></span><span><a href="#ref-for-keyup-12">5.7.5. Key Events During Composition</a> <a href="#ref-for-keyup-13">(2)</a> <a href="#ref-for-keyup-14">(3)</a></span><span><a href="#ref-for-keyup-15">6.2.3. code Examples</a> <a href="#ref-for-keyup-16">(2)</a> <a href="#ref-for-keyup-17">(3)</a> <a href="#ref-for-keyup-18">(4)</a></span><span><a href="#ref-for-keyup-19">6.3.2. Modifier keys</a> <a href="#ref-for-keyup-20">(2)</a> <a href="#ref-for-keyup-21">(3)</a> <a href="#ref-for-keyup-22">(4)</a> <a href="#ref-for-keyup-23">(5)</a> <a href="#ref-for-keyup-24">(6)</a> <a href="#ref-for-keyup-25">(7)</a> <a href="#ref-for-keyup-26">(8)</a> <a href="#ref-for-keyup-27">(9)</a> <a href="#ref-for-keyup-28">(10)</a> <a href="#ref-for-keyup-29">(11)</a> <a href="#ref-for-keyup-30">(12)</a> <a href="#ref-for-keyup-31">(13)</a> <a href="#ref-for-keyup-32">(14)</a></span><span><a href="#ref-for-keyup-33">6.3.3. Dead keys</a> <a href="#ref-for-keyup-34">(2)</a> <a href="#ref-for-keyup-35">(3)</a> <a href="#ref-for-keyup-36">(4)</a></span><span><a href="#ref-for-keyup-37">6.3.4. Input Method Editors</a> <a href="#ref-for-keyup-38">(2)</a> <a href="#ref-for-keyup-39">(3)</a> <a href="#ref-for-keyup-40">(4)</a> <a href="#ref-for-keyup-41">(5)</a> <a href="#ref-for-keyup-42">(6)</a> <a href="#ref-for-keyup-43">(7)</a> <a href="#ref-for-keyup-44">(8)</a> <a href="#ref-for-keyup-45">(9)</a> <a href="#ref-for-keyup-46">(10)</a></span><span><a href="#ref-for-keyup-47">6.3.5. Default actions and cancelable keyboard events</a> <a href="#ref-for-keyup-48">(2)</a> <a href="#ref-for-keyup-49">(3)</a> <a href="#ref-for-keyup-50">(4)</a> <a href="#ref-for-keyup-51">(5)</a> <a href="#ref-for-keyup-52">(6)</a> <a href="#ref-for-keyup-53">(7)</a> <a href="#ref-for-keyup-54">(8)</a></span><span><a href="#ref-for-keyup-55">8.1.1. Interface KeyboardEvent (supplemental)</a></span><span><a href="#ref-for-keyup-56">8.2.1. How to determine keyCode for keydown and keyup events</a> <a href="#ref-for-keyup-57">(2)</a></span><span><a href="#ref-for-keyup-58">9.3.2. keypress event order</a> <a href="#ref-for-keyup-59">(2)</a></span></span></dfn></span><a class="self-link" href="#event-type-keyup"></a></h5>
+    <h5 class="heading settled" data-level="5.6.4.2" id="event-type-keyup"><span class="secno">5.6.4.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="keyup">keyup</dfn></span><a class="self-link" href="#event-type-keyup"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -3440,6 +3701,9 @@ details)</p>
        <td><code>Element</code>
       <tr>
        <th>Cancelable
+       <td>Yes
+      <tr>
+       <th>Composed
        <td>Yes
       <tr>
        <th>Default action
@@ -3496,9 +3760,9 @@ details)</p>
 		information associated with Composition Events.</p>
     <p>To create an instance of the <code class="idl"><a data-link-type="idl" href="#compositionevent" id="ref-for-compositionevent-5">CompositionEvent</a></code> interface,
 		use the <code class="idl"><a data-link-type="idl" href="#compositionevent" id="ref-for-compositionevent-6">CompositionEvent</a></code> constructor, passing an optional <code class="idl"><a data-link-type="idl" href="#dictdef-compositioneventinit" id="ref-for-dictdef-compositioneventinit-1">CompositionEventInit</a></code> dictionary.</p>
-<pre class="idl def">[<dfn class="idl-code" data-dfn-for="CompositionEvent" data-dfn-type="constructor" data-export="" data-lt="CompositionEvent(type, eventInitDict)" id="dom-compositionevent-compositionevent">Constructor<a class="self-link" href="#dom-compositionevent-compositionevent"></a></dfn>(DOMString <dfn class="idl-code" data-dfn-for="CompositionEvent/CompositionEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-compositionevent-compositionevent-type-eventinitdict-type">type<a class="self-link" href="#dom-compositionevent-compositionevent-type-eventinitdict-type"></a></dfn>, optional <a data-link-type="idl-name" href="#dictdef-compositioneventinit" id="ref-for-dictdef-compositioneventinit-2">CompositionEventInit</a> <dfn class="idl-code" data-dfn-for="CompositionEvent/CompositionEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-compositionevent-compositionevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-compositionevent-compositionevent-type-eventinitdict-eventinitdict"></a></dfn>)]
-interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="compositionevent">CompositionEvent<span class="dfn-panel"><b><a href="#compositionevent">#compositionevent</a></b><b>Referenced in:</b><span><a href="#ref-for-compositionevent-1">4.1. List of Event Types</a> <a href="#ref-for-compositionevent-2">(2)</a> <a href="#ref-for-compositionevent-3">(3)</a></span><span><a href="#ref-for-compositionevent-4">5.7.1. Interface CompositionEvent</a> <a href="#ref-for-compositionevent-5">(2)</a> <a href="#ref-for-compositionevent-6">(3)</a></span><span><a href="#ref-for-compositionevent-7">5.7.3. Handwriting Recognition Systems</a></span><span><a href="#ref-for-compositionevent-8">5.7.7.1. compositionstart</a> <a href="#ref-for-compositionevent-9">(2)</a></span><span><a href="#ref-for-compositionevent-10">5.7.7.2. compositionupdate</a> <a href="#ref-for-compositionevent-11">(2)</a></span><span><a href="#ref-for-compositionevent-12">5.7.7.3. compositionend</a> <a href="#ref-for-compositionevent-13">(2)</a></span><span><a href="#ref-for-compositionevent-14">6.3.3. Dead keys</a> <a href="#ref-for-compositionevent-15">(2)</a></span><span><a href="#ref-for-compositionevent-16">6.3.4. Input Method Editors</a> <a href="#ref-for-compositionevent-17">(2)</a> <a href="#ref-for-compositionevent-18">(3)</a> <a href="#ref-for-compositionevent-19">(4)</a></span><span><a href="#ref-for-compositionevent-20">12.1.4. New Interfaces</a></span><span><a href="#ref-for-compositionevent-21">12.2. Changes between different drafts of UI Events</a></span></span></dfn> : <a data-link-type="idl-name" href="#uievent-uievent" id="ref-for-uievent-uievent-59">UIEvent</a> {
-  readonly attribute DOMString <dfn class="dfn-paneled idl-code" data-dfn-for="CompositionEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMString " id="dom-compositionevent-data">data<span class="dfn-panel"><b><a href="#dom-compositionevent-data">#dom-compositionevent-data</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-compositionevent-data-1">5.7. Composition Events</a></span><span><a href="#ref-for-dom-compositionevent-data-2">5.7.3. Handwriting Recognition Systems</a></span><span><a href="#ref-for-dom-compositionevent-data-3">5.7.7.1. compositionstart</a> <a href="#ref-for-dom-compositionevent-data-4">(2)</a> <a href="#ref-for-dom-compositionevent-data-5">(3)</a></span><span><a href="#ref-for-dom-compositionevent-data-6">5.7.7.2. compositionupdate</a> <a href="#ref-for-dom-compositionevent-data-7">(2)</a> <a href="#ref-for-dom-compositionevent-data-8">(3)</a></span><span><a href="#ref-for-dom-compositionevent-data-9">5.7.7.3. compositionend</a></span><span><a href="#ref-for-dom-compositionevent-data-10">6.3. Keyboard Event key Values</a> <a href="#ref-for-dom-compositionevent-data-11">(2)</a></span><span><a href="#ref-for-dom-compositionevent-data-12">6.3.3. Dead keys</a> <a href="#ref-for-dom-compositionevent-data-13">(2)</a> <a href="#ref-for-dom-compositionevent-data-14">(3)</a></span><span><a href="#ref-for-dom-compositionevent-data-15">6.3.4. Input Method Editors</a> <a href="#ref-for-dom-compositionevent-data-16">(2)</a> <a href="#ref-for-dom-compositionevent-data-17">(3)</a></span><span><a href="#ref-for-dom-compositionevent-data-18">7.1.5. Initializers for interface CompositionEvent</a></span></span></dfn>;
+<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="CompositionEvent" data-dfn-type="constructor" data-export="" data-lt="CompositionEvent(type, eventInitDict)|CompositionEvent(type)" id="dom-compositionevent-compositionevent">Constructor<a class="self-link" href="#dom-compositionevent-compositionevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="CompositionEvent/CompositionEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-compositionevent-compositionevent-type-eventinitdict-type">type<a class="self-link" href="#dom-compositionevent-compositionevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-compositioneventinit" id="ref-for-dictdef-compositioneventinit-2">CompositionEventInit</a> <dfn class="nv idl-code" data-dfn-for="CompositionEvent/CompositionEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-compositionevent-compositionevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-compositionevent-compositionevent-type-eventinitdict-eventinitdict"></a></dfn>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="compositionevent">CompositionEvent</dfn> : <a class="n" data-link-type="idl-name" href="#uievent-uievent" id="ref-for-uievent-uievent-59">UIEvent</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="CompositionEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="DOMString" id="dom-compositionevent-data">data</dfn>;
 };
 </pre>
     <dl>
@@ -3512,8 +3776,8 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-expor
 				attribute MAY be the <a data-link-type="dfn" href="#empty-string" id="ref-for-empty-string-5">empty string</a>. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-31">un-initialized value</a> of this attribute MUST be <code>""</code> (the empty string).</p>
     </dl>
-<pre class="idl def">dictionary <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-compositioneventinit">CompositionEventInit<span class="dfn-panel"><b><a href="#dictdef-compositioneventinit">#dictdef-compositioneventinit</a></b><b>Referenced in:</b><span><a href="#ref-for-dictdef-compositioneventinit-1">5.7.1. Interface CompositionEvent</a> <a href="#ref-for-dictdef-compositioneventinit-2">(2)</a></span></span></dfn> : <a data-link-type="idl-name" href="#dictdef-uieventinit-uieventinit" id="ref-for-dictdef-uieventinit-uieventinit-6">UIEventInit</a> {
-  DOMString <dfn class="idl-code" data-default="&quot;&quot;" data-dfn-for="CompositionEventInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-compositioneventinit-data">data<a class="self-link" href="#dom-compositioneventinit-data"></a></dfn> = "";
+<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-compositioneventinit">CompositionEventInit</dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit-uieventinit" id="ref-for-dictdef-uieventinit-uieventinit-6">UIEventInit</a> {
+  <span class="kt">DOMString</span> <dfn class="nv idl-code" data-default="&quot;&quot;" data-dfn-for="CompositionEventInit" data-dfn-type="dict-member" data-export="" data-type="DOMString " id="dom-compositioneventinit-data">data<a class="self-link" href="#dom-compositioneventinit-data"></a></dfn> = "";
 };
 </pre>
     <dl>
@@ -3740,7 +4004,7 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-expor
        <td>
     </table>
     <h4 class="heading settled" data-level="5.7.7" id="events-composition-types"><span class="secno">5.7.7. </span><span class="content">Composition Event Types</span><a class="self-link" href="#events-composition-types"></a></h4>
-    <h5 class="heading settled" data-level="5.7.7.1" id="event-type-compositionstart"><span class="secno">5.7.7.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="compositionstart">compositionstart<span class="dfn-panel"><b><a href="#compositionstart">#compositionstart</a></b><b>Referenced in:</b><span><a href="#ref-for-compositionstart-1">4.1. List of Event Types</a></span><span><a href="#ref-for-compositionstart-2">5.5.1. Interface InputEvent</a></span><span><a href="#ref-for-compositionstart-3">5.6.1. Interface KeyboardEvent</a></span><span><a href="#ref-for-compositionstart-4">5.7. Composition Events</a> <a href="#ref-for-compositionstart-5">(2)</a></span><span><a href="#ref-for-compositionstart-6">5.7.2. Composition Event Order</a></span><span><a href="#ref-for-compositionstart-7">5.7.3. Handwriting Recognition Systems</a></span><span><a href="#ref-for-compositionstart-8">5.7.4. Canceling Composition Events</a> <a href="#ref-for-compositionstart-9">(2)</a></span><span><a href="#ref-for-compositionstart-10">5.7.5. Key Events During Composition</a></span><span><a href="#ref-for-compositionstart-11">5.7.7.1. compositionstart</a> <a href="#ref-for-compositionstart-12">(2)</a></span><span><a href="#ref-for-compositionstart-13">6.3.3. Dead keys</a> <a href="#ref-for-compositionstart-14">(2)</a></span><span><a href="#ref-for-compositionstart-15">6.3.4. Input Method Editors</a> <a href="#ref-for-compositionstart-16">(2)</a></span></span></dfn></span><a class="self-link" href="#event-type-compositionstart"></a></h5>
+    <h5 class="heading settled" data-level="5.7.7.1" id="event-type-compositionstart"><span class="secno">5.7.7.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="compositionstart">compositionstart</dfn></span><a class="self-link" href="#event-type-compositionstart"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -3760,6 +4024,9 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-expor
        <td><code>Element</code>
       <tr>
        <th>Cancelable
+       <td>Yes
+      <tr>
+       <th>Composed
        <td>Yes
       <tr>
        <th>Default action
@@ -3798,7 +4065,7 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-expor
 			session (e.g., such as GTK which doesn’t presently have such an
 			API). In these cases, calling <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-preventdefault">preventDefault()</a></code> will not
 			stop this event’s default action. </p>
-    <h5 class="heading settled" data-level="5.7.7.2" id="event-type-compositionupdate"><span class="secno">5.7.7.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="compositionupdate">compositionupdate<span class="dfn-panel"><b><a href="#compositionupdate">#compositionupdate</a></b><b>Referenced in:</b><span><a href="#ref-for-compositionupdate-1">4.1. List of Event Types</a></span><span><a href="#ref-for-compositionupdate-2">5.7. Composition Events</a></span><span><a href="#ref-for-compositionupdate-3">5.7.2. Composition Event Order</a></span><span><a href="#ref-for-compositionupdate-4">5.7.3. Handwriting Recognition Systems</a> <a href="#ref-for-compositionupdate-5">(2)</a></span><span><a href="#ref-for-compositionupdate-6">5.7.5. Key Events During Composition</a></span><span><a href="#ref-for-compositionupdate-7">5.7.6. Input Events During Composition</a> <a href="#ref-for-compositionupdate-8">(2)</a> <a href="#ref-for-compositionupdate-9">(3)</a> <a href="#ref-for-compositionupdate-10">(4)</a></span><span><a href="#ref-for-compositionupdate-11">5.7.7.2. compositionupdate</a></span><span><a href="#ref-for-compositionupdate-12">6.3.3. Dead keys</a> <a href="#ref-for-compositionupdate-13">(2)</a> <a href="#ref-for-compositionupdate-14">(3)</a> <a href="#ref-for-compositionupdate-15">(4)</a> <a href="#ref-for-compositionupdate-16">(5)</a></span><span><a href="#ref-for-compositionupdate-17">6.3.4. Input Method Editors</a> <a href="#ref-for-compositionupdate-18">(2)</a> <a href="#ref-for-compositionupdate-19">(3)</a> <a href="#ref-for-compositionupdate-20">(4)</a> <a href="#ref-for-compositionupdate-21">(5)</a> <a href="#ref-for-compositionupdate-22">(6)</a> <a href="#ref-for-compositionupdate-23">(7)</a> <a href="#ref-for-compositionupdate-24">(8)</a> <a href="#ref-for-compositionupdate-25">(9)</a></span></span></dfn></span><a class="self-link" href="#event-type-compositionupdate"></a></h5>
+    <h5 class="heading settled" data-level="5.7.7.2" id="event-type-compositionupdate"><span class="secno">5.7.7.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="compositionupdate">compositionupdate</dfn></span><a class="self-link" href="#event-type-compositionupdate"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -3819,6 +4086,9 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-expor
       <tr>
        <th>Cancelable
        <td>No
+      <tr>
+       <th>Composed
+       <td>Yes
       <tr>
        <th>Default action
        <td>None
@@ -3846,7 +4116,7 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-expor
     <p>If the composition session is canceled, this event will be fired
 			immediately before the <a data-link-type="dfn" href="#compositionend" id="ref-for-compositionend-12"><code>compositionend</code></a> event, and the <code class="idl"><a data-link-type="idl" href="#dom-compositionevent-data" id="ref-for-dom-compositionevent-data-8">data</a></code> attribute will be set to the <a data-link-type="dfn" href="#empty-string" id="ref-for-empty-string-9">empty
 			string</a>.</p>
-    <h5 class="heading settled" data-level="5.7.7.3" id="event-type-compositionend"><span class="secno">5.7.7.3. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="compositionend">compositionend<span class="dfn-panel"><b><a href="#compositionend">#compositionend</a></b><b>Referenced in:</b><span><a href="#ref-for-compositionend-1">4.1. List of Event Types</a></span><span><a href="#ref-for-compositionend-2">5.5.1. Interface InputEvent</a></span><span><a href="#ref-for-compositionend-3">5.6.1. Interface KeyboardEvent</a></span><span><a href="#ref-for-compositionend-4">5.7. Composition Events</a></span><span><a href="#ref-for-compositionend-5">5.7.2. Composition Event Order</a></span><span><a href="#ref-for-compositionend-6">5.7.3. Handwriting Recognition Systems</a></span><span><a href="#ref-for-compositionend-7">5.7.4. Canceling Composition Events</a> <a href="#ref-for-compositionend-8">(2)</a></span><span><a href="#ref-for-compositionend-9">5.7.5. Key Events During Composition</a></span><span><a href="#ref-for-compositionend-10">5.7.6. Input Events During Composition</a> <a href="#ref-for-compositionend-11">(2)</a></span><span><a href="#ref-for-compositionend-12">5.7.7.2. compositionupdate</a></span><span><a href="#ref-for-compositionend-13">5.7.7.3. compositionend</a></span><span><a href="#ref-for-compositionend-14">6.3.3. Dead keys</a> <a href="#ref-for-compositionend-15">(2)</a></span><span><a href="#ref-for-compositionend-16">6.3.4. Input Method Editors</a> <a href="#ref-for-compositionend-17">(2)</a> <a href="#ref-for-compositionend-18">(3)</a></span></span></dfn></span><a class="self-link" href="#event-type-compositionend"></a></h5>
+    <h5 class="heading settled" data-level="5.7.7.3" id="event-type-compositionend"><span class="secno">5.7.7.3. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="compositionend">compositionend</dfn></span><a class="self-link" href="#event-type-compositionend"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -3867,6 +4137,9 @@ interface <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-expor
       <tr>
        <th>Cancelable
        <td>No
+      <tr>
+       <th>Composed
+       <td>Yes
       <tr>
        <th>Default action
        <td>None
@@ -5387,13 +5660,13 @@ described in this Appendix.</p>
        <dt>long detailArg
        <dd> Specifies <code class="idl"><a data-link-type="idl" href="#dom-uievent-detail" id="ref-for-dom-uievent-detail-29">detail</a></code>. 
        <dt>long screenXArg
-       <dd> Specifies <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screenx">screenX</a></code>. 
+       <dd> Specifies <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screenx">screenX</a></code>. 
        <dt>long screenYArg
-       <dd> Specifies <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screeny">screenY</a></code>. 
+       <dd> Specifies <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screeny">screenY</a></code>. 
        <dt>long clientXArg
-       <dd> Specifies <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clientx">clientX</a></code>. 
+       <dd> Specifies <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clientx">clientX</a></code>. 
        <dt>long clientYArg
-       <dd> Specifies <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clienty">clientY</a></code>. 
+       <dd> Specifies <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clienty">clientY</a></code>. 
        <dt>boolean ctrlKeyArg
        <dd> Specifies <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-ctrlkey" id="ref-for-dom-mouseevent-ctrlkey-11">ctrlKey</a></code>. 
        <dt>boolean altKeyArg
@@ -5433,13 +5706,13 @@ described in this Appendix.</p>
        <dt>long detailArg
        <dd> Specifies <code class="idl"><a data-link-type="idl" href="#dom-uievent-detail" id="ref-for-dom-uievent-detail-30">detail</a></code>. 
        <dt>long screenXArg
-       <dd> Specifies <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screenx">screenX</a></code>. 
+       <dd> Specifies <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screenx">screenX</a></code>. 
        <dt>long screenYArg
-       <dd> Specifies <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screeny">screenY</a></code>. 
+       <dd> Specifies <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screeny">screenY</a></code>. 
        <dt>long clientXArg
-       <dd> Specifies <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clientx">clientX</a></code>. 
+       <dd> Specifies <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clientx">clientX</a></code>. 
        <dt>long clientYArg
-       <dd> Specifies <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clienty">clientY</a></code>. 
+       <dd> Specifies <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clienty">clientY</a></code>. 
        <dt>short buttonArg
        <dd> Specifies <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-button" id="ref-for-dom-mouseevent-button-19">button</a></code>. 
        <dt>EventTarget? relatedTargetArg
@@ -5568,11 +5841,11 @@ used.</p>
 		the <code class="idl"><a data-link-type="idl" href="#keyboardevent-keyboardevent" id="ref-for-keyboardevent-keyboardevent-73">KeyboardEvent</a></code> interface, which adds the <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-charcode" id="ref-for-dom-keyboardevent-charcode-5">charCode</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-keycode" id="ref-for-dom-keyboardevent-keycode-5">keyCode</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-which" id="ref-for-dom-keyboardevent-which-3">which</a></code> attributes.</p>
     <p>The partial <code class="idl"><a data-link-type="idl" href="#keyboardevent-keyboardevent" id="ref-for-keyboardevent-keyboardevent-74">KeyboardEvent</a></code> interface can be obtained by using the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-document-createevent">createEvent()</a></code> method call in
 		implementations that support this extension.</p>
-<pre class="idl def">partial interface <a class="idl-code" data-link-type="interface" href="#keyboardevent-keyboardevent" id="ref-for-keyboardevent-keyboardevent-75">KeyboardEvent</a> {
+<pre class="idl highlight def"><span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="#keyboardevent-keyboardevent" id="ref-for-keyboardevent-keyboardevent-75">KeyboardEvent</a> {
   // The following support legacy user agents
-  readonly attribute unsigned long <dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unsigned long " id="dom-keyboardevent-charcode">charCode<span class="dfn-panel"><b><a href="#dom-keyboardevent-charcode">#dom-keyboardevent-charcode</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-keyboardevent-charcode-1">6.3.1. Key Values and Unicode</a></span><span><a href="#ref-for-dom-keyboardevent-charcode-2">8. Legacy Key Attributes</a></span><span><a href="#ref-for-dom-keyboardevent-charcode-3">8.1. Legacy KeyboardEvent supplemental interface</a> <a href="#ref-for-dom-keyboardevent-charcode-4">(2)</a></span><span><a href="#ref-for-dom-keyboardevent-charcode-5">8.1.1. Interface KeyboardEvent (supplemental)</a> <a href="#ref-for-dom-keyboardevent-charcode-6">(2)</a> <a href="#ref-for-dom-keyboardevent-charcode-7">(3)</a></span><span><a href="#ref-for-dom-keyboardevent-charcode-8">8.1.2. Interface KeyboardEventInit (supplemental)</a> <a href="#ref-for-dom-keyboardevent-charcode-9">(2)</a> <a href="#ref-for-dom-keyboardevent-charcode-10">(3)</a></span><span><a href="#ref-for-dom-keyboardevent-charcode-11">8.2. Legacy key models</a></span><span><a href="#ref-for-dom-keyboardevent-charcode-12">9.3. Legacy KeyboardEvent events</a></span><span><a href="#ref-for-dom-keyboardevent-charcode-13">9.3.1.1. keypress</a></span></span></dfn>;
-  readonly attribute unsigned long <dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unsigned long " id="dom-keyboardevent-keycode">keyCode<span class="dfn-panel"><b><a href="#dom-keyboardevent-keycode">#dom-keyboardevent-keycode</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-keyboardevent-keycode-1">6.3.1. Key Values and Unicode</a></span><span><a href="#ref-for-dom-keyboardevent-keycode-2">8. Legacy Key Attributes</a></span><span><a href="#ref-for-dom-keyboardevent-keycode-3">8.1. Legacy KeyboardEvent supplemental interface</a> <a href="#ref-for-dom-keyboardevent-keycode-4">(2)</a></span><span><a href="#ref-for-dom-keyboardevent-keycode-5">8.1.1. Interface KeyboardEvent (supplemental)</a> <a href="#ref-for-dom-keyboardevent-keycode-6">(2)</a> <a href="#ref-for-dom-keyboardevent-keycode-7">(3)</a> <a href="#ref-for-dom-keyboardevent-keycode-8">(4)</a> <a href="#ref-for-dom-keyboardevent-keycode-9">(5)</a></span><span><a href="#ref-for-dom-keyboardevent-keycode-10">8.1.2. Interface KeyboardEventInit (supplemental)</a> <a href="#ref-for-dom-keyboardevent-keycode-11">(2)</a> <a href="#ref-for-dom-keyboardevent-keycode-12">(3)</a> <a href="#ref-for-dom-keyboardevent-keycode-13">(4)</a></span><span><a href="#ref-for-dom-keyboardevent-keycode-14">8.2. Legacy key models</a> <a href="#ref-for-dom-keyboardevent-keycode-15">(2)</a></span><span><a href="#ref-for-dom-keyboardevent-keycode-16">8.2.1. How to determine keyCode for keydown and keyup events</a> <a href="#ref-for-dom-keyboardevent-keycode-17">(2)</a></span><span><a href="#ref-for-dom-keyboardevent-keycode-18">8.2.2. How to determine keyCode for keypress events</a> <a href="#ref-for-dom-keyboardevent-keycode-19">(2)</a> <a href="#ref-for-dom-keyboardevent-keycode-20">(3)</a> <a href="#ref-for-dom-keyboardevent-keycode-21">(4)</a></span><span><a href="#ref-for-dom-keyboardevent-keycode-22">9.3. Legacy KeyboardEvent events</a></span><span><a href="#ref-for-dom-keyboardevent-keycode-23">9.3.1.1. keypress</a></span></span></dfn>;
-  readonly attribute unsigned long <dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unsigned long " id="dom-keyboardevent-which">which<span class="dfn-panel"><b><a href="#dom-keyboardevent-which">#dom-keyboardevent-which</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-keyboardevent-which-1">8.1. Legacy KeyboardEvent supplemental interface</a> <a href="#ref-for-dom-keyboardevent-which-2">(2)</a></span><span><a href="#ref-for-dom-keyboardevent-which-3">8.1.1. Interface KeyboardEvent (supplemental)</a> <a href="#ref-for-dom-keyboardevent-which-4">(2)</a></span><span><a href="#ref-for-dom-keyboardevent-which-5">8.1.2. Interface KeyboardEventInit (supplemental)</a> <a href="#ref-for-dom-keyboardevent-which-6">(2)</a> <a href="#ref-for-dom-keyboardevent-which-7">(3)</a></span><span><a href="#ref-for-dom-keyboardevent-which-8">9.3. Legacy KeyboardEvent events</a></span><span><a href="#ref-for-dom-keyboardevent-which-9">9.3.1.1. keypress</a></span></span></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unsigned long" id="dom-keyboardevent-charcode">charCode</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unsigned long" id="dom-keyboardevent-keycode">keyCode</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unsigned long" id="dom-keyboardevent-which">which</dfn>;
 };
 </pre>
     <dl>
@@ -5961,7 +6234,7 @@ completeness.</p>
     </table>
     <h3 class="heading settled" data-level="9.1" id="legacy-uievent-events"><span class="secno">9.1. </span><span class="content">Legacy <code class="idl"><a data-link-type="idl" href="#uievent-uievent" id="ref-for-uievent-uievent-68">UIEvent</a></code> events</span><a class="self-link" href="#legacy-uievent-events"></a></h3>
     <h4 class="heading settled" data-level="9.1.1" id="legacy-uievent-event-types"><span class="secno">9.1.1. </span><span class="content">Legacy <code class="idl"><a data-link-type="idl" href="#uievent-uievent" id="ref-for-uievent-uievent-69">UIEvent</a></code> event types</span><a class="self-link" href="#legacy-uievent-event-types"></a></h4>
-    <h5 class="heading settled" data-level="9.1.1.1" id="event-type-DOMActivate"><span class="secno">9.1.1.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domactivate">DOMActivate<span class="dfn-panel"><b><a href="#domactivate">#domactivate</a></b><b>Referenced in:</b><span><a href="#ref-for-domactivate-1">5.6.4.1. keydown</a></span><span><a href="#ref-for-domactivate-2">9. Legacy Event Types</a> <a href="#ref-for-domactivate-3">(2)</a></span><span><a href="#ref-for-domactivate-4">9.1.1.1. DOMActivate</a> <a href="#ref-for-domactivate-5">(2)</a> <a href="#ref-for-domactivate-6">(3)</a> <a href="#ref-for-domactivate-7">(4)</a> <a href="#ref-for-domactivate-8">(5)</a> <a href="#ref-for-domactivate-9">(6)</a> <a href="#ref-for-domactivate-10">(7)</a> <a href="#ref-for-domactivate-11">(8)</a> <a href="#ref-for-domactivate-12">(9)</a> <a href="#ref-for-domactivate-13">(10)</a> <a href="#ref-for-domactivate-14">(11)</a> <a href="#ref-for-domactivate-15">(12)</a> <a href="#ref-for-domactivate-16">(13)</a></span><span><a href="#ref-for-domactivate-17">9.1.2. Activation event order</a> <a href="#ref-for-domactivate-18">(2)</a></span><span><a href="#ref-for-domactivate-19">9.3.1.1. keypress</a></span></span></dfn></span><a class="self-link" href="#event-type-DOMActivate"></a></h5>
+    <h5 class="heading settled" data-level="9.1.1.1" id="event-type-DOMActivate"><span class="secno">9.1.1.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domactivate">DOMActivate</dfn></span><a class="self-link" href="#event-type-DOMActivate"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -6065,7 +6338,7 @@ completeness.</p>
     </table>
     <h3 class="heading settled" data-level="9.2" id="legacy-focusevent-events"><span class="secno">9.2. </span><span class="content">Legacy <code class="idl"><a data-link-type="idl" href="#focusevent" id="ref-for-focusevent-17">FocusEvent</a></code> events</span><a class="self-link" href="#legacy-focusevent-events"></a></h3>
     <h4 class="heading settled" data-level="9.2.1" id="legacy-focusevent-event-types"><span class="secno">9.2.1. </span><span class="content">Legacy <code class="idl"><a data-link-type="idl" href="#focusevent" id="ref-for-focusevent-18">FocusEvent</a></code> event types</span><a class="self-link" href="#legacy-focusevent-event-types"></a></h4>
-    <h5 class="heading settled" data-level="9.2.1.1" id="event-type-DOMFocusIn"><span class="secno">9.2.1.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domfocusin">DOMFocusIn<span class="dfn-panel"><b><a href="#domfocusin">#domfocusin</a></b><b>Referenced in:</b><span><a href="#ref-for-domfocusin-1">9. Legacy Event Types</a></span><span><a href="#ref-for-domfocusin-2">9.2.1.1. DOMFocusIn</a></span><span><a href="#ref-for-domfocusin-3">9.2.2. Legacy FocusEvent event order</a> <a href="#ref-for-domfocusin-4">(2)</a> <a href="#ref-for-domfocusin-5">(3)</a></span></span></dfn></span><a class="self-link" href="#event-type-DOMFocusIn"></a></h5>
+    <h5 class="heading settled" data-level="9.2.1.1" id="event-type-DOMFocusIn"><span class="secno">9.2.1.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domfocusin">DOMFocusIn</dfn></span><a class="self-link" href="#event-type-DOMFocusIn"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -6106,7 +6379,7 @@ completeness.</p>
     <p class="warning"> The <a data-link-type="dfn" href="#domfocusin" id="ref-for-domfocusin-2"><code>DOMFocusIn</code></a> event type is defined in this			specification for reference and completeness, but this
 			specification <a data-link-type="dfn" href="#deprecates" id="ref-for-deprecates-7">deprecates</a> the use of this event type in
 			favor of the related event types <a data-link-type="dfn" href="#focus" id="ref-for-focus-11"><code>focus</code></a> and <a data-link-type="dfn" href="#focusin" id="ref-for-focusin-6"><code>focusin</code></a>. </p>
-    <h5 class="heading settled" data-level="9.2.1.2" id="event-type-DOMFocusOut"><span class="secno">9.2.1.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domfocusout">DOMFocusOut<span class="dfn-panel"><b><a href="#domfocusout">#domfocusout</a></b><b>Referenced in:</b><span><a href="#ref-for-domfocusout-1">9. Legacy Event Types</a></span><span><a href="#ref-for-domfocusout-2">9.2.1.2. DOMFocusOut</a></span><span><a href="#ref-for-domfocusout-3">9.2.2. Legacy FocusEvent event order</a> <a href="#ref-for-domfocusout-4">(2)</a></span></span></dfn></span><a class="self-link" href="#event-type-DOMFocusOut"></a></h5>
+    <h5 class="heading settled" data-level="9.2.1.2" id="event-type-DOMFocusOut"><span class="secno">9.2.1.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domfocusout">DOMFocusOut</dfn></span><a class="self-link" href="#event-type-DOMFocusOut"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -6207,7 +6480,7 @@ completeness.</p>
     <p>Note that the <a data-link-type="dfn" href="#keypress" id="ref-for-keypress-13"><code>keypress</code></a> event is specific to key events, and has been	replaced by the more general event sequence of <a data-link-type="dfn" href="#beforeinput" id="ref-for-beforeinput-31"><code>beforeinput</code></a> and <a data-link-type="dfn" href="#input" id="ref-for-input-32"><code>input</code></a> events. These new <code>input</code> events are not specific to	keyboard actions and can be used to capture user input regardless of the
 	original source.</p>
     <h4 class="heading settled" data-level="9.3.1" id="legacy-keyboardevent-event-types"><span class="secno">9.3.1. </span><span class="content">Legacy <code class="idl"><a data-link-type="idl" href="#keyboardevent-keyboardevent" id="ref-for-keyboardevent-keyboardevent-83">KeyboardEvent</a></code> event types</span><a class="self-link" href="#legacy-keyboardevent-event-types"></a></h4>
-    <h5 class="heading settled" data-level="9.3.1.1" id="event-type-keypress"><span class="secno">9.3.1.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="keypress">keypress<span class="dfn-panel"><b><a href="#keypress">#keypress</a></b><b>Referenced in:</b><span><a href="#ref-for-keypress-1">4.1. List of Event Types</a></span><span><a href="#ref-for-keypress-2">5.6.4.1. keydown</a></span><span><a href="#ref-for-keypress-3">6.2.3. code Examples</a> <a href="#ref-for-keypress-4">(2)</a></span><span><a href="#ref-for-keypress-5">6.3.5. Default actions and cancelable keyboard events</a> <a href="#ref-for-keypress-6">(2)</a></span><span><a href="#ref-for-keypress-7">8.1.1. Interface KeyboardEvent (supplemental)</a></span><span><a href="#ref-for-keypress-8">8.2.2. How to determine keyCode for keypress events</a> <a href="#ref-for-keypress-9">(2)</a></span><span><a href="#ref-for-keypress-10">9. Legacy Event Types</a></span><span><a href="#ref-for-keypress-11">9.3. Legacy KeyboardEvent events</a> <a href="#ref-for-keypress-12">(2)</a> <a href="#ref-for-keypress-13">(3)</a></span><span><a href="#ref-for-keypress-14">9.3.1.1. keypress</a> <a href="#ref-for-keypress-15">(2)</a> <a href="#ref-for-keypress-16">(3)</a> <a href="#ref-for-keypress-17">(4)</a></span><span><a href="#ref-for-keypress-18">9.3.2. keypress event order</a> <a href="#ref-for-keypress-19">(2)</a> <a href="#ref-for-keypress-20">(3)</a> <a href="#ref-for-keypress-21">(4)</a> <a href="#ref-for-keypress-22">(5)</a></span><span><a href="#ref-for-keypress-23">12.2. Changes between different drafts of UI Events</a> <a href="#ref-for-keypress-24">(2)</a></span></span></dfn></span><a class="self-link" href="#event-type-keypress"></a></h5>
+    <h5 class="heading settled" data-level="9.3.1.1" id="event-type-keypress"><span class="secno">9.3.1.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="keypress">keypress</dfn></span><a class="self-link" href="#event-type-keypress"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -6432,7 +6705,7 @@ completeness.</p>
     </dl>
     <h4 class="heading settled" data-level="9.4.2" id="legacy-mutationevent-event-types"><span class="secno">9.4.2. </span><span class="content">Legacy <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#mutationevent">MutationEvent</a></code> event types</span><a class="self-link" href="#legacy-mutationevent-event-types"></a></h4>
     <p>The mutation event types are listed below.</p>
-    <h5 class="heading settled" data-level="9.4.2.1" id="event-type-DOMAttrModified"><span class="secno">9.4.2.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domattrmodified">DOMAttrModified<span class="dfn-panel"><b><a href="#domattrmodified">#domattrmodified</a></b><b>Referenced in:</b><span><a href="#ref-for-domattrmodified-1">9. Legacy Event Types</a></span><span><a href="#ref-for-domattrmodified-2">9.4.1. Interface MutationEvent</a> <a href="#ref-for-domattrmodified-3">(2)</a> <a href="#ref-for-domattrmodified-4">(3)</a> <a href="#ref-for-domattrmodified-5">(4)</a> <a href="#ref-for-domattrmodified-6">(5)</a></span><span><a href="#ref-for-domattrmodified-7">9.4.2.1. DOMAttrModified</a></span><span><a href="#ref-for-domattrmodified-8">9.4.2.3. DOMNodeInserted</a></span><span><a href="#ref-for-domattrmodified-9">9.4.2.5. DOMNodeRemoved</a></span><span><a href="#ref-for-domattrmodified-10">9.4.2.6. DOMNodeRemovedFromDocument</a></span></span></dfn></span><a class="self-link" href="#event-type-DOMAttrModified"></a></h5>
+    <h5 class="heading settled" data-level="9.4.2.1" id="event-type-DOMAttrModified"><span class="secno">9.4.2.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domattrmodified">DOMAttrModified</dfn></span><a class="self-link" href="#event-type-DOMAttrModified"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -6480,7 +6753,7 @@ completeness.</p>
 			children of the <code>Attr</code> node are changed in ways that do
 			not affect the value of <code>Attr.value</code>.</p>
     <p class="warning"> The <a data-link-type="dfn" href="#domattrmodified" id="ref-for-domattrmodified-7"><code>DOMAttrModified</code></a> event type is defined in this			specification for reference and completeness, but this specification <a data-link-type="dfn" href="#deprecates" id="ref-for-deprecates-11">deprecates</a> the use of this event type. </p>
-    <h5 class="heading settled" data-level="9.4.2.2" id="event-type-DOMCharacterDataModified"><span class="secno">9.4.2.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domcharacterdatamodified">DOMCharacterDataModified<span class="dfn-panel"><b><a href="#domcharacterdatamodified">#domcharacterdatamodified</a></b><b>Referenced in:</b><span><a href="#ref-for-domcharacterdatamodified-1">9. Legacy Event Types</a></span><span><a href="#ref-for-domcharacterdatamodified-2">9.4.1. Interface MutationEvent</a> <a href="#ref-for-domcharacterdatamodified-3">(2)</a></span><span><a href="#ref-for-domcharacterdatamodified-4">9.4.2.2. DOMCharacterDataModified</a></span></span></dfn></span><a class="self-link" href="#event-type-DOMCharacterDataModified"></a></h5>
+    <h5 class="heading settled" data-level="9.4.2.2" id="event-type-DOMCharacterDataModified"><span class="secno">9.4.2.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domcharacterdatamodified">DOMCharacterDataModified</dfn></span><a class="self-link" href="#event-type-DOMCharacterDataModified"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -6526,7 +6799,7 @@ completeness.</p>
 			target</a> of this event MUST be the <code>CharacterData</code> node
 			or the <code>ProcessingInstruction</code> node.</p>
     <p class="warning"> The <a data-link-type="dfn" href="#domcharacterdatamodified" id="ref-for-domcharacterdatamodified-4"><code>DOMCharacterDataModified</code></a> event type is defined in this			specification for reference and completeness, but this specification <a data-link-type="dfn" href="#deprecates" id="ref-for-deprecates-12">deprecates</a> the use of this event type. </p>
-    <h5 class="heading settled" data-level="9.4.2.3" id="event-type-DOMNodeInserted"><span class="secno">9.4.2.3. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domnodeinserted">DOMNodeInserted<span class="dfn-panel"><b><a href="#domnodeinserted">#domnodeinserted</a></b><b>Referenced in:</b><span><a href="#ref-for-domnodeinserted-1">9. Legacy Event Types</a></span><span><a href="#ref-for-domnodeinserted-2">9.4.2.3. DOMNodeInserted</a></span><span><a href="#ref-for-domnodeinserted-3">9.4.2.4. DOMNodeInsertedIntoDocument</a></span><span><a href="#ref-for-domnodeinserted-4">12.1.2. Changes to DOM Level 2 event types</a></span></span></dfn></span><a class="self-link" href="#event-type-DOMNodeInserted"></a></h5>
+    <h5 class="heading settled" data-level="9.4.2.3" id="event-type-DOMNodeInserted"><span class="secno">9.4.2.3. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domnodeinserted">DOMNodeInserted</dfn></span><a class="self-link" href="#event-type-DOMNodeInserted"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -6573,7 +6846,7 @@ completeness.</p>
 			event MUST be dispatched after the insertion has taken place. The <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-46">event target</a> of this event MUST be the node being inserted.</p>
     <p class="note" id="DOMNodeInserted-attr" role="note"><a class="self-link" href="#DOMNodeInserted-attr"></a> For detecting attribute insertion, use the <a data-link-type="dfn" href="#domattrmodified" id="ref-for-domattrmodified-8"><code>DOMAttrModified</code></a> event type instead. </p>
     <p class="warning"> The <a data-link-type="dfn" href="#domnodeinserted" id="ref-for-domnodeinserted-2"><code>DOMNodeInserted</code></a> event type is defined in this			specification for reference and completeness, but this specification <a data-link-type="dfn" href="#deprecates" id="ref-for-deprecates-13">deprecates</a> the use of this event type. </p>
-    <h5 class="heading settled" data-level="9.4.2.4" id="event-type-DOMNodeInsertedIntoDocument"><span class="secno">9.4.2.4. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domnodeinsertedintodocument">DOMNodeInsertedIntoDocument<span class="dfn-panel"><b><a href="#domnodeinsertedintodocument">#domnodeinsertedintodocument</a></b><b>Referenced in:</b><span><a href="#ref-for-domnodeinsertedintodocument-1">9. Legacy Event Types</a></span><span><a href="#ref-for-domnodeinsertedintodocument-2">9.4.2.4. DOMNodeInsertedIntoDocument</a></span></span></dfn></span><a class="self-link" href="#event-type-DOMNodeInsertedIntoDocument"></a></h5>
+    <h5 class="heading settled" data-level="9.4.2.4" id="event-type-DOMNodeInsertedIntoDocument"><span class="secno">9.4.2.4. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domnodeinsertedintodocument">DOMNodeInsertedIntoDocument</dfn></span><a class="self-link" href="#event-type-DOMNodeInsertedIntoDocument"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -6622,7 +6895,7 @@ completeness.</p>
 			MUST be the node being inserted. If the node is being directly
 			inserted, the event type <a data-link-type="dfn" href="#domnodeinserted" id="ref-for-domnodeinserted-3"><code>DOMNodeInserted</code></a> MUST occur before			this event type.</p>
     <p class="warning"> The <a data-link-type="dfn" href="#domnodeinsertedintodocument" id="ref-for-domnodeinsertedintodocument-2"><code>DOMNodeInsertedIntoDocument</code></a> event type is defined in this			specification for reference and completeness, but this specification <a data-link-type="dfn" href="#deprecates" id="ref-for-deprecates-14">deprecates</a> the use of this event type. </p>
-    <h5 class="heading settled" data-level="9.4.2.5" id="event-type-DOMNodeRemoved"><span class="secno">9.4.2.5. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domnoderemoved">DOMNodeRemoved<span class="dfn-panel"><b><a href="#domnoderemoved">#domnoderemoved</a></b><b>Referenced in:</b><span><a href="#ref-for-domnoderemoved-1">9. Legacy Event Types</a></span><span><a href="#ref-for-domnoderemoved-2">9.4.2.5. DOMNodeRemoved</a></span><span><a href="#ref-for-domnoderemoved-3">9.4.2.6. DOMNodeRemovedFromDocument</a></span><span><a href="#ref-for-domnoderemoved-4">12.1.2. Changes to DOM Level 2 event types</a></span></span></dfn></span><a class="self-link" href="#event-type-DOMNodeRemoved"></a></h5>
+    <h5 class="heading settled" data-level="9.4.2.5" id="event-type-DOMNodeRemoved"><span class="secno">9.4.2.5. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domnoderemoved">DOMNodeRemoved</dfn></span><a class="self-link" href="#event-type-DOMNodeRemoved"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -6668,7 +6941,7 @@ completeness.</p>
 			dispatched before the removal takes place. The <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-48">event target</a> of this event MUST be the node being removed.</p>
     <p class="note" id="DOMNodeRemoved-attr" role="note"><a class="self-link" href="#DOMNodeRemoved-attr"></a> For reliably detecting attribute removal, use the <a data-link-type="dfn" href="#domattrmodified" id="ref-for-domattrmodified-9"><code>DOMAttrModified</code></a> event type instead. </p>
     <p class="warning"> The <a data-link-type="dfn" href="#domnoderemoved" id="ref-for-domnoderemoved-2"><code>DOMNodeRemoved</code></a> event type is defined in this			specification for reference and completeness, but this specification <a data-link-type="dfn" href="#deprecates" id="ref-for-deprecates-15">deprecates</a> the use of this event type. </p>
-    <h5 class="heading settled" data-level="9.4.2.6" id="event-type-DOMNodeRemovedFromDocument"><span class="secno">9.4.2.6. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domnoderemovedfromdocument">DOMNodeRemovedFromDocument<span class="dfn-panel"><b><a href="#domnoderemovedfromdocument">#domnoderemovedfromdocument</a></b><b>Referenced in:</b><span><a href="#ref-for-domnoderemovedfromdocument-1">9. Legacy Event Types</a></span><span><a href="#ref-for-domnoderemovedfromdocument-2">9.4.2.6. DOMNodeRemovedFromDocument</a></span></span></dfn></span><a class="self-link" href="#event-type-DOMNodeRemovedFromDocument"></a></h5>
+    <h5 class="heading settled" data-level="9.4.2.6" id="event-type-DOMNodeRemovedFromDocument"><span class="secno">9.4.2.6. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domnoderemovedfromdocument">DOMNodeRemovedFromDocument</dfn></span><a class="self-link" href="#event-type-DOMNodeRemovedFromDocument"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -6718,7 +6991,7 @@ completeness.</p>
 			removed, the event type <a data-link-type="dfn" href="#domnoderemoved" id="ref-for-domnoderemoved-3"><code>DOMNodeRemoved</code></a> MUST occur before this			event type.</p>
     <p class="note" role="note"> For reliably detecting attribute removal, use the <a data-link-type="dfn" href="#domattrmodified" id="ref-for-domattrmodified-10"><code>DOMAttrModified</code></a> event type instead. </p>
     <p class="warning"> The <a data-link-type="dfn" href="#domnoderemovedfromdocument" id="ref-for-domnoderemovedfromdocument-2"><code>DOMNodeRemovedFromDocument</code></a> event type is defined in this			specification for reference and completeness, but this specification <a data-link-type="dfn" href="#deprecates" id="ref-for-deprecates-16">deprecates</a> the use of this event type. </p>
-    <h5 class="heading settled" data-level="9.4.2.7" id="event-type-DOMSubtreeModified"><span class="secno">9.4.2.7. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domsubtreemodified">DOMSubtreeModified<span class="dfn-panel"><b><a href="#domsubtreemodified">#domsubtreemodified</a></b><b>Referenced in:</b><span><a href="#ref-for-domsubtreemodified-1">9. Legacy Event Types</a></span><span><a href="#ref-for-domsubtreemodified-2">9.4.2.7. DOMSubtreeModified</a></span></span></dfn></span><a class="self-link" href="#event-type-DOMSubtreeModified"></a></h5>
+    <h5 class="heading settled" data-level="9.4.2.7" id="event-type-DOMSubtreeModified"><span class="secno">9.4.2.7. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domsubtreemodified">DOMSubtreeModified</dfn></span><a class="self-link" href="#event-type-DOMSubtreeModified"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -7131,6 +7404,7 @@ Alexey Proskuryakov,
 Arkadiusz Michalski,
 Brad Pettit,
 Cameron McCormack,
+Chris Rebert,
 Curt Arnold,
 David Flanagan,
 Dylan Schiemann,
@@ -7168,7 +7442,7 @@ similar definitions in other W3C or standards documents. See the links within
 the definitions for more information.</p>
     <dl>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="activation-behavior">activation behavior<span class="dfn-panel"><b><a href="#activation-behavior">#activation-behavior</a></b><b>Referenced in:</b><span><a href="#ref-for-activation-behavior-1">3.5. Activation triggers and behavior</a></span><span><a href="#ref-for-activation-behavior-2">4.1. List of Event Types</a> <a href="#ref-for-activation-behavior-3">(2)</a> <a href="#ref-for-activation-behavior-4">(3)</a></span><span><a href="#ref-for-activation-behavior-5">5.6.4.1. keydown</a></span><span><a href="#ref-for-activation-behavior-6">9.1.1.1. DOMActivate</a></span><span><a href="#ref-for-activation-behavior-7">9.1.2. Activation event order</a> <a href="#ref-for-activation-behavior-8">(2)</a></span><span><a href="#ref-for-activation-behavior-9">14. Glossary</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="activation-behavior">activation behavior</dfn></p>
      <dd data-md="">
       <p>The action taken when an <a data-link-type="dfn" href="#event" id="ref-for-event-2">event</a>, typically initiated by users through
 an input device, causes an element to fulfill a defined task.  The task MAY
@@ -7182,7 +7456,7 @@ window or tab, a named window, or a new window). The activation behavior of
 an HTML <code>&lt;input></code> element with the <code>type</code> attribute value <code>submit</code> is be to send the values of the form
 elements to an author-defined IRI by the author-defined HTTP method.  See <a href="#event-flow-activation">§3.5 Activation triggers and behavior</a> for more details.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="activation-trigger">activation trigger<span class="dfn-panel"><b><a href="#activation-trigger">#activation-trigger</a></b><b>Referenced in:</b><span><a href="#ref-for-activation-trigger-1">3.5. Activation triggers and behavior</a> <a href="#ref-for-activation-trigger-2">(2)</a> <a href="#ref-for-activation-trigger-3">(3)</a> <a href="#ref-for-activation-trigger-4">(4)</a> <a href="#ref-for-activation-trigger-5">(5)</a></span><span><a href="#ref-for-activation-trigger-6">9.1.1.1. DOMActivate</a> <a href="#ref-for-activation-trigger-7">(2)</a> <a href="#ref-for-activation-trigger-8">(3)</a></span><span><a href="#ref-for-activation-trigger-9">14. Glossary</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="activation-trigger">activation trigger</dfn></p>
      <dd data-md="">
       <p>An event which is defined to initiate an <a data-link-type="dfn" href="#activation-behavior" id="ref-for-activation-behavior-9">activation behavior</a>.  Refer
 to <a href="#event-flow-activation">§3.5 Activation triggers and behavior</a> for more details.</p>
@@ -7195,20 +7469,20 @@ other executable content that uses the interfaces, events, and event flow
 defined in this specification. See <a href="#conf-authors">§1.2.3 Content authors and content</a> conformance category
 for more details.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="body-element">body element<span class="dfn-panel"><b><a href="#body-element">#body-element</a></b><b>Referenced in:</b><span><a href="#ref-for-body-element-1">5.3.3. Mouse Event Order</a></span><span><a href="#ref-for-body-element-2">5.6.3. Keyboard Event Order</a></span><span><a href="#ref-for-body-element-3">5.6.4.1. keydown</a></span><span><a href="#ref-for-body-element-4">5.6.4.2. keyup</a></span><span><a href="#ref-for-body-element-5">9.3.1.1. keypress</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="body-element">body element</dfn></p>
      <dd data-md="">
       <p>In HTML or XHTML documents, the body element represents the contents of the
 document. In a well-formed HTML document, the body element is a first
 descendant of the <a data-link-type="dfn" href="#root-element" id="ref-for-root-element-7">root element</a>.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="bubble phase|bubbling phase" data-noexport="" id="bubble-phase">bubbling phase<span class="dfn-panel"><b><a href="#bubble-phase">#bubble-phase</a></b><b>Referenced in:</b><span><a href="#ref-for-bubble-phase-1">3.1. Event dispatch and DOM event flow</a></span><span><a href="#ref-for-bubble-phase-2">14. Glossary</a> <a href="#ref-for-bubble-phase-3">(2)</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="bubble phase|bubbling phase" data-noexport="" id="bubble-phase">bubbling phase</dfn></p>
      <dd data-md="">
       <p>The process by which an <a data-link-type="dfn" href="#event" id="ref-for-event-3">event</a> can be handled by one of the target’s
 ancestors <em>after</em> being handled by the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-50">event target</a>. See the
 description of the <a data-link-type="dfn" href="#bubble-phase" id="ref-for-bubble-phase-2">bubble phase</a> in the context of event flow for more
 details.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="capture-phase">capture phase<span class="dfn-panel"><b><a href="#capture-phase">#capture-phase</a></b><b>Referenced in:</b><span><a href="#ref-for-capture-phase-1">3.1. Event dispatch and DOM event flow</a></span><span><a href="#ref-for-capture-phase-2">14. Glossary</a> <a href="#ref-for-capture-phase-3">(2)</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="capture-phase">capture phase</dfn></p>
      <dd data-md="">
       <p>The process by which an <a data-link-type="dfn" href="#event" id="ref-for-event-4">event</a> can be handled by one of the target’s
 ancestors <em>before</em> being handled by the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-51">event target</a>. See the
@@ -7230,7 +7504,7 @@ dispatch begins will be removed.</p>
 listeners to be added prevents infinite loops of event listener dispatch on
 a given target object. </p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="character-value">character value<span class="dfn-panel"><b><a href="#character-value">#character-value</a></b><b>Referenced in:</b><span><a href="#ref-for-character-value-1">5.6.1. Interface KeyboardEvent</a></span><span><a href="#ref-for-character-value-2">5.6.3. Keyboard Event Order</a> <a href="#ref-for-character-value-3">(2)</a></span><span><a href="#ref-for-character-value-4">5.6.4.1. keydown</a></span><span><a href="#ref-for-character-value-5">5.6.4.2. keyup</a></span><span><a href="#ref-for-character-value-6">6.3. Keyboard Event key Values</a> <a href="#ref-for-character-value-7">(2)</a></span><span><a href="#ref-for-character-value-8">6.3.1. Key Values and Unicode</a></span><span><a href="#ref-for-character-value-9">9.3.1.1. keypress</a> <a href="#ref-for-character-value-10">(2)</a></span><span><a href="#ref-for-character-value-11">14. Glossary</a> <a href="#ref-for-character-value-12">(2)</a> <a href="#ref-for-character-value-13">(3)</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="character-value">character value</dfn></p>
      <dd data-md="">
       <p>In the context of key values, a character value is a string representing one
 or more Unicode characters, such as a letter or symbol, or a set of letters.
@@ -7240,7 +7514,7 @@ In this specification, character values are denoted as a unicode string
 represented using the character escape syntax of the programming language in
 use. </p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="current-event-target">current event target<span class="dfn-panel"><b><a href="#current-event-target">#current-event-target</a></b><b>Referenced in:</b><span><a href="#ref-for-current-event-target-1">3.1. Event dispatch and DOM event flow</a></span><span><a href="#ref-for-current-event-target-2">14. Glossary</a> <a href="#ref-for-current-event-target-3">(2)</a> <a href="#ref-for-current-event-target-4">(3)</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="current-event-target">current event target</dfn></p>
      <dd data-md="">
       <p>In an event flow, the current event target is the object associated with the <a data-link-type="dfn" href="#event-handler" id="ref-for-event-handler-1">event handler</a> that is currently being dispatched. This object MAY be
 the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-52">event target</a> itself or one of its ancestors. The current event
@@ -7248,13 +7522,13 @@ target changes as the <a data-link-type="dfn" href="#event" id="ref-for-event-5"
 the various <a data-link-type="dfn" href="#phase" id="ref-for-phase-1">phases</a> of the event flow. The current event target is the
 value of the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-currenttarget">currentTarget</a></code> attribute.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dead-key">dead key<span class="dfn-panel"><b><a href="#dead-key">#dead-key</a></b><b>Referenced in:</b><span><a href="#ref-for-dead-key-1">6. Keyboard events and key values</a></span><span><a href="#ref-for-dead-key-2">6.3. Keyboard Event key Values</a> <a href="#ref-for-dead-key-3">(2)</a></span><span><a href="#ref-for-dead-key-4">6.3.3. Dead keys</a> <a href="#ref-for-dead-key-5">(2)</a> <a href="#ref-for-dead-key-6">(3)</a> <a href="#ref-for-dead-key-7">(4)</a> <a href="#ref-for-dead-key-8">(5)</a></span><span><a href="#ref-for-dead-key-9">6.3.5. Default actions and cancelable keyboard events</a> <a href="#ref-for-dead-key-10">(2)</a></span><span><a href="#ref-for-dead-key-11">6.3.6. Guidelines for selecting key values</a></span><span><a href="#ref-for-dead-key-12">14. Glossary</a> <a href="#ref-for-dead-key-13">(2)</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dead-key">dead key</dfn></p>
      <dd data-md="">
       <p>A dead key is a key or combination of keys which produces no character by
 itself, but which in combination or sequence with another key produces a
 modified character, such as a character with diacritical marks (e.g., <code class="glyph">"ö"</code>, <code class="glyph">"é"</code>, <code class="glyph">"â"</code>).</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="default-action">default action<span class="dfn-panel"><b><a href="#default-action">#default-action</a></b><b>Referenced in:</b><span><a href="#ref-for-default-action-1">3.2. Default actions and cancelable events</a> <a href="#ref-for-default-action-2">(2)</a> <a href="#ref-for-default-action-3">(3)</a> <a href="#ref-for-default-action-4">(4)</a> <a href="#ref-for-default-action-5">(5)</a> <a href="#ref-for-default-action-6">(6)</a> <a href="#ref-for-default-action-7">(7)</a> <a href="#ref-for-default-action-8">(8)</a> <a href="#ref-for-default-action-9">(9)</a></span><span><a href="#ref-for-default-action-10">3.4. Trusted events</a> <a href="#ref-for-default-action-11">(2)</a></span><span><a href="#ref-for-default-action-12">5.3.1. Interface MouseEvent</a> <a href="#ref-for-default-action-13">(2)</a></span><span><a href="#ref-for-default-action-14">5.3.4.1. click</a> <a href="#ref-for-default-action-15">(2)</a> <a href="#ref-for-default-action-16">(3)</a> <a href="#ref-for-default-action-17">(4)</a></span><span><a href="#ref-for-default-action-18">5.3.4.2. dblclick</a> <a href="#ref-for-default-action-19">(2)</a> <a href="#ref-for-default-action-20">(3)</a></span><span><a href="#ref-for-default-action-21">5.3.4.3. mousedown</a></span><span><a href="#ref-for-default-action-22">5.4.2.1. wheel</a></span><span><a href="#ref-for-default-action-23">5.6.3. Keyboard Event Order</a> <a href="#ref-for-default-action-24">(2)</a> <a href="#ref-for-default-action-25">(3)</a></span><span><a href="#ref-for-default-action-26">5.7.4. Canceling Composition Events</a> <a href="#ref-for-default-action-27">(2)</a></span><span><a href="#ref-for-default-action-28">6.3.5. Default actions and cancelable keyboard events</a> <a href="#ref-for-default-action-29">(2)</a> <a href="#ref-for-default-action-30">(3)</a> <a href="#ref-for-default-action-31">(4)</a> <a href="#ref-for-default-action-32">(5)</a></span><span><a href="#ref-for-default-action-33">9.1.1.1. DOMActivate</a> <a href="#ref-for-default-action-34">(2)</a></span><span><a href="#ref-for-default-action-35">9.1.2. Activation event order</a> <a href="#ref-for-default-action-36">(2)</a> <a href="#ref-for-default-action-37">(3)</a> <a href="#ref-for-default-action-38">(4)</a> <a href="#ref-for-default-action-39">(5)</a></span><span><a href="#ref-for-default-action-40">9.3.1.1. keypress</a></span><span><a href="#ref-for-default-action-41">9.3.2. keypress event order</a></span><span><a href="#ref-for-default-action-42">14. Glossary</a> <a href="#ref-for-default-action-43">(2)</a> <a href="#ref-for-default-action-44">(3)</a> <a href="#ref-for-default-action-45">(4)</a> <a href="#ref-for-default-action-46">(5)</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="default-action">default action</dfn></p>
      <dd data-md="">
       <p>A <a data-link-type="dfn" href="#default-action" id="ref-for-default-action-42">default action</a> is an OPTIONAL supplementary behavior that an
 implementation MUST perform in combination with the dispatch of the event
@@ -7263,7 +7537,7 @@ event MAY have more than one <a data-link-type="dfn" href="#default-action" id="
 such as when associated with an <a data-link-type="dfn" href="#activation-trigger" id="ref-for-activation-trigger-9">activation trigger</a>.  A <a data-link-type="dfn" href="#default-action" id="ref-for-default-action-45">default
 action</a> MAY be cancelled through the invocation of the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-preventdefault">preventDefault()</a></code> method. For more details, see <a href="#event-flow-default-cancel">§3.2 Default actions and cancelable events</a>.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="delta">delta<span class="dfn-panel"><b><a href="#delta">#delta</a></b><b>Referenced in:</b><span><a href="#ref-for-delta-1">5.4. Wheel Events</a> <a href="#ref-for-delta-2">(2)</a> <a href="#ref-for-delta-3">(3)</a></span><span><a href="#ref-for-delta-4">5.4.1. Interface WheelEvent</a> <a href="#ref-for-delta-5">(2)</a> <a href="#ref-for-delta-6">(3)</a> <a href="#ref-for-delta-7">(4)</a> <a href="#ref-for-delta-8">(5)</a></span><span><a href="#ref-for-delta-9">5.4.2.1. wheel</a> <a href="#ref-for-delta-10">(2)</a> <a href="#ref-for-delta-11">(3)</a></span><span><a href="#ref-for-delta-12">14. Glossary</a> <a href="#ref-for-delta-13">(2)</a> <a href="#ref-for-delta-14">(3)</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="delta">delta</dfn></p>
      <dd data-md="">
       <p>The estimated scroll amount (in pixels, lines, or pages) that the user agent
 will scroll or zoom the page in response to the physical movement of an
@@ -7275,7 +7549,7 @@ agent scrolls as the <a data-link-type="dfn" href="#default-action" id="ref-for-
 are directed towards the right-most edge, bottom-most edge, and farthest
 depth (away from the user) of the document, respectively.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="deprecates|deprecated" data-noexport="" id="deprecates">deprecated<span class="dfn-panel"><b><a href="#deprecates">#deprecates</a></b><b>Referenced in:</b><span><a href="#ref-for-deprecates-1">1.2.1. Web browsers and other dynamic or interactive user agents</a> <a href="#ref-for-deprecates-2">(2)</a></span><span><a href="#ref-for-deprecates-3">1.2.2. Authoring tools</a></span><span><a href="#ref-for-deprecates-4">1.2.3. Content authors and content</a></span><span><a href="#ref-for-deprecates-5">1.2.4. Specifications and host languages</a></span><span><a href="#ref-for-deprecates-6">9.1.1.1. DOMActivate</a></span><span><a href="#ref-for-deprecates-7">9.2.1.1. DOMFocusIn</a></span><span><a href="#ref-for-deprecates-8">9.2.1.2. DOMFocusOut</a></span><span><a href="#ref-for-deprecates-9">9.3.1.1. keypress</a></span><span><a href="#ref-for-deprecates-10">9.4. Legacy MutationEvent events</a></span><span><a href="#ref-for-deprecates-11">9.4.2.1. DOMAttrModified</a></span><span><a href="#ref-for-deprecates-12">9.4.2.2. DOMCharacterDataModified</a></span><span><a href="#ref-for-deprecates-13">9.4.2.3. DOMNodeInserted</a></span><span><a href="#ref-for-deprecates-14">9.4.2.4. DOMNodeInsertedIntoDocument</a></span><span><a href="#ref-for-deprecates-15">9.4.2.5. DOMNodeRemoved</a></span><span><a href="#ref-for-deprecates-16">9.4.2.6. DOMNodeRemovedFromDocument</a></span><span><a href="#ref-for-deprecates-17">9.4.2.7. DOMSubtreeModified</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="deprecates|deprecated" data-noexport="" id="deprecates">deprecated</dfn></p>
      <dd data-md="">
       <p>Features marked as deprecated are included in the specification as reference
 to older implementations or specifications, but are OPTIONAL and
@@ -7290,7 +7564,7 @@ to the replacements of which the feature is deprecated in favor.  Features
 marked as deprecated in this specification are expected to be dropped from
 future specifications.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dispatch">dispatch<span class="dfn-panel"><b><a href="#dispatch">#dispatch</a></b><b>Referenced in:</b><span><a href="#ref-for-dispatch-1">1.2.1. Web browsers and other dynamic or interactive user agents</a></span><span><a href="#ref-for-dispatch-2">3.1. Event dispatch and DOM event flow</a></span><span><a href="#ref-for-dispatch-3">14. Glossary</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dispatch">dispatch</dfn></p>
      <dd data-md="">
       <p>To create an event with attributes and methods appropriate to its type and
 context, and propagate it through the DOM tree in the specified manner.
@@ -7303,7 +7577,7 @@ representing the entire HTML or XML text document.  Conceptually, it is the
 root of the document tree, and provides the primary access to the document’s
 data.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dom-application">DOM application<span class="dfn-panel"><b><a href="#dom-application">#dom-application</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-application-1">3.2. Default actions and cancelable events</a></span><span><a href="#ref-for-dom-application-2">11. Security Considerations</a> <a href="#ref-for-dom-application-3">(2)</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dom-application">DOM application</dfn></p>
      <dd data-md="">
       <p>A DOM application is script or code, written by a content author or
 automatically generated, which takes advantage of the interfaces, methods,
@@ -7311,7 +7585,7 @@ attributes, events, and other features described in this specification in
 order to make dynamic or interactive content, such as Web applications,
 exposed to users in a <a data-link-type="dfn" href="#user-agent" id="ref-for-user-agent-67">user agent</a>.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dom-level-0">DOM Level 0<span class="dfn-panel"><b><a href="#dom-level-0">#dom-level-0</a></b><b>Referenced in:</b><span><a href="#ref-for-dom-level-0-1">5.3.1. Interface MouseEvent</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dom-level-0">DOM Level 0</dfn></p>
      <dd data-md="">
       <p>The term <q>DOM Level 0</q> refers to a mix of HTML document functionalities,
 often not formally specified but traditionally supported as de facto
@@ -7320,12 +7594,12 @@ Microsoft Internet Explorer version 3.0.  In many cases, attributes or
 methods have been included for reasons of backward compatibility with <q>DOM
 Level 0</q>.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="empty-string">empty string<span class="dfn-panel"><b><a href="#empty-string">#empty-string</a></b><b>Referenced in:</b><span><a href="#ref-for-empty-string-1">5.5.1. Interface InputEvent</a></span><span><a href="#ref-for-empty-string-2">5.5.3.1. beforeinput</a></span><span><a href="#ref-for-empty-string-3">5.5.3.2. input</a></span><span><a href="#ref-for-empty-string-4">5.7. Composition Events</a></span><span><a href="#ref-for-empty-string-5">5.7.1. Interface CompositionEvent</a></span><span><a href="#ref-for-empty-string-6">5.7.7.1. compositionstart</a> <a href="#ref-for-empty-string-7">(2)</a></span><span><a href="#ref-for-empty-string-8">5.7.7.2. compositionupdate</a> <a href="#ref-for-empty-string-9">(2)</a></span><span><a href="#ref-for-empty-string-10">5.7.7.3. compositionend</a></span><span><a href="#ref-for-empty-string-11">6.3.4. Input Method Editors</a></span><span><a href="#ref-for-empty-string-12">9.4.1. Interface MutationEvent</a> <a href="#ref-for-empty-string-13">(2)</a> <a href="#ref-for-empty-string-14">(3)</a></span><span><a href="#ref-for-empty-string-15">9.4.2.2. DOMCharacterDataModified</a></span><span><a href="#ref-for-empty-string-16">9.4.2.3. DOMNodeInserted</a> <a href="#ref-for-empty-string-17">(2)</a> <a href="#ref-for-empty-string-18">(3)</a></span><span><a href="#ref-for-empty-string-19">9.4.2.4. DOMNodeInsertedIntoDocument</a> <a href="#ref-for-empty-string-20">(2)</a> <a href="#ref-for-empty-string-21">(3)</a></span><span><a href="#ref-for-empty-string-22">9.4.2.5. DOMNodeRemoved</a> <a href="#ref-for-empty-string-23">(2)</a> <a href="#ref-for-empty-string-24">(3)</a></span><span><a href="#ref-for-empty-string-25">9.4.2.6. DOMNodeRemovedFromDocument</a> <a href="#ref-for-empty-string-26">(2)</a> <a href="#ref-for-empty-string-27">(3)</a></span><span><a href="#ref-for-empty-string-28">9.4.2.7. DOMSubtreeModified</a> <a href="#ref-for-empty-string-29">(2)</a> <a href="#ref-for-empty-string-30">(3)</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="empty-string">empty string</dfn></p>
      <dd data-md="">
       <p>The empty string is a value of type <code>DOMString</code> of length <code>0</code>, i.e., a string which contains no characters (neither
 printing nor control characters).</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event">event<span class="dfn-panel"><b><a href="#event">#event</a></b><b>Referenced in:</b><span><a href="#ref-for-event-1">1.1. Overview</a></span><span><a href="#ref-for-event-2">14. Glossary</a> <a href="#ref-for-event-3">(2)</a> <a href="#ref-for-event-4">(3)</a> <a href="#ref-for-event-5">(4)</a> <a href="#ref-for-event-6">(5)</a> <a href="#ref-for-event-7">(6)</a> <a href="#ref-for-event-8">(7)</a> <a href="#ref-for-event-9">(8)</a> <a href="#ref-for-event-10">(9)</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event">event</dfn></p>
      <dd data-md="">
       <p>An event is the representation of some occurrence (such as a mouse click on
 the presentation of an element, the removal of child node from an element,
@@ -7333,7 +7607,7 @@ or any number of other possibilities) which is associated with its <a data-link-
 target</a>. Each event is an instantiation of one specific <a data-link-type="dfn" href="#event-type" id="ref-for-event-type-26">event
 type</a>.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-focus">event focus<span class="dfn-panel"><b><a href="#event-focus">#event-focus</a></b><b>Referenced in:</b><span><a href="#ref-for-event-focus-1">14. Glossary</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-focus">event focus</dfn></p>
      <dd data-md="">
       <p>Event focus is a special state of receptivity and concentration on a
 particular element or other <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-54">event target</a> within a document.  Each
@@ -7342,7 +7616,7 @@ such as priming the element for activation (as for a button or hyperlink) or
 toggling state (as for a checkbox), receiving text input (as for a text form
 field), or copying selected text.  For more details, see <a href="#events-focusevent-doc-focus">§5.2.3 Document Focus and Focus Context</a>.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="focus ring" data-noexport="" id="focus-ring">event focus ring<span class="dfn-panel"><b><a href="#focus-ring">#focus-ring</a></b><b>Referenced in:</b><span><a href="#ref-for-focus-ring-1">5.2.3. Document Focus and Focus Context</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="focus ring" data-noexport="" id="focus-ring">event focus ring</dfn></p>
      <dd data-md="">
       <p>An event focus ring is an ordered set of <a data-link-type="dfn" href="#event-focus" id="ref-for-event-focus-1">event focus</a> targets within a
 document.  A <a data-link-type="dfn" href="#host-language" id="ref-for-host-language-13">host language</a> MAY define one or more ways to determine
@@ -7353,9 +7627,9 @@ conditional focus rings.  Typically, for document-order or indexed focus
 rings, focus <q>wraps around</q> from the last focus target to the
 first.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-handler">event handler<span class="dfn-panel"><b><a href="#event-handler">#event-handler</a></b><b>Referenced in:</b><span><a href="#ref-for-event-handler-1">14. Glossary</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-handler">event handler</dfn></p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-listener">event listener<span class="dfn-panel"><b><a href="#event-listener">#event-listener</a></b><b>Referenced in:</b><span><a href="#ref-for-event-listener-1">14. Glossary</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-listener">event listener</dfn></p>
      <dd data-md="">
       <p>An object that implements the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#callbackdef-eventlistener">EventListener</a></code> interface and provides an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-eventlistener-handleevent">handleEvent()</a></code> callback method. Event handlers are
 language-specific. Event handlers are invoked in the context of a particular
@@ -7365,7 +7639,7 @@ object itself.</p>
 first parameter to the user-defined function when it is invoked.
 Additionally, JavaScript objects can also implement the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#callbackdef-eventlistener">EventListener</a></code> interface when they define a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-eventlistener-handleevent">handleEvent</a></code> method. </p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-order">event order<span class="dfn-panel"><b><a href="#event-order">#event-order</a></b><b>Referenced in:</b><span><a href="#ref-for-event-order-1">3.3. Synchronous and asynchronous events</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-order">event order</dfn></p>
      <dd data-md="">
       <p>The sequence in which events from the same event source or process occur,
 using the same or related event interfaces. For example, in an environment
@@ -7378,16 +7652,16 @@ user might change focus using the <code class="keycap">Tab</code> key, or by cli
 the state of the process, not on the state of the device that initiates the
 state change.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-phase">event phase<span class="dfn-panel"><b><a href="#event-phase">#event-phase</a></b><b>Referenced in:</b><span><a href="#ref-for-event-phase-1">3.1. Event dispatch and DOM event flow</a></span><span><a href="#ref-for-event-phase-2">14. Glossary</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-phase">event phase</dfn></p>
      <dd data-md="">
       <p>See <a data-link-type="dfn" href="#phase" id="ref-for-phase-2">phase</a>.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-target">event target<span class="dfn-panel"><b><a href="#event-target">#event-target</a></b><b>Referenced in:</b><span><a href="#ref-for-event-target-1">3.1. Event dispatch and DOM event flow</a> <a href="#ref-for-event-target-2">(2)</a> <a href="#ref-for-event-target-3">(3)</a></span><span><a href="#ref-for-event-target-4">3.5. Activation triggers and behavior</a></span><span><a href="#ref-for-event-target-5">4.1. List of Event Types</a></span><span><a href="#ref-for-event-target-6">5.2.3. Document Focus and Focus Context</a></span><span><a href="#ref-for-event-target-7">5.2.4.1. blur</a> <a href="#ref-for-event-target-8">(2)</a> <a href="#ref-for-event-target-9">(3)</a></span><span><a href="#ref-for-event-target-10">5.2.4.2. focus</a> <a href="#ref-for-event-target-11">(2)</a> <a href="#ref-for-event-target-12">(3)</a></span><span><a href="#ref-for-event-target-13">5.2.4.3. focusin</a> <a href="#ref-for-event-target-14">(2)</a> <a href="#ref-for-event-target-15">(3)</a> <a href="#ref-for-event-target-16">(4)</a> <a href="#ref-for-event-target-17">(5)</a></span><span><a href="#ref-for-event-target-18">5.2.4.4. focusout</a> <a href="#ref-for-event-target-19">(2)</a> <a href="#ref-for-event-target-20">(3)</a> <a href="#ref-for-event-target-21">(4)</a></span><span><a href="#ref-for-event-target-22">5.3.3. Mouse Event Order</a></span><span><a href="#ref-for-event-target-23">5.3.4.1. click</a> <a href="#ref-for-event-target-24">(2)</a> <a href="#ref-for-event-target-25">(3)</a></span><span><a href="#ref-for-event-target-26">5.3.4.2. dblclick</a> <a href="#ref-for-event-target-27">(2)</a></span><span><a href="#ref-for-event-target-28">5.3.4.4. mouseenter</a></span><span><a href="#ref-for-event-target-29">5.3.4.5. mouseleave</a></span><span><a href="#ref-for-event-target-30">5.3.4.7. mouseout</a></span><span><a href="#ref-for-event-target-31">5.3.4.8. mouseover</a> <a href="#ref-for-event-target-32">(2)</a></span><span><a href="#ref-for-event-target-33">5.4.2.1. wheel</a></span><span><a href="#ref-for-event-target-34">5.5.3.1. beforeinput</a></span><span><a href="#ref-for-event-target-35">5.5.3.2. input</a></span><span><a href="#ref-for-event-target-36">5.6.3. Keyboard Event Order</a> <a href="#ref-for-event-target-37">(2)</a> <a href="#ref-for-event-target-38">(3)</a></span><span><a href="#ref-for-event-target-39">9.1.1.1. DOMActivate</a></span><span><a href="#ref-for-event-target-40">9.2.1.1. DOMFocusIn</a> <a href="#ref-for-event-target-41">(2)</a></span><span><a href="#ref-for-event-target-42">9.2.1.2. DOMFocusOut</a> <a href="#ref-for-event-target-43">(2)</a></span><span><a href="#ref-for-event-target-44">9.4.2.1. DOMAttrModified</a></span><span><a href="#ref-for-event-target-45">9.4.2.2. DOMCharacterDataModified</a></span><span><a href="#ref-for-event-target-46">9.4.2.3. DOMNodeInserted</a></span><span><a href="#ref-for-event-target-47">9.4.2.4. DOMNodeInsertedIntoDocument</a></span><span><a href="#ref-for-event-target-48">9.4.2.5. DOMNodeRemoved</a></span><span><a href="#ref-for-event-target-49">9.4.2.6. DOMNodeRemovedFromDocument</a></span><span><a href="#ref-for-event-target-50">14. Glossary</a> <a href="#ref-for-event-target-51">(2)</a> <a href="#ref-for-event-target-52">(3)</a> <a href="#ref-for-event-target-53">(4)</a> <a href="#ref-for-event-target-54">(5)</a> <a href="#ref-for-event-target-55">(6)</a> <a href="#ref-for-event-target-56">(7)</a> <a href="#ref-for-event-target-57">(8)</a> <a href="#ref-for-event-target-58">(9)</a> <a href="#ref-for-event-target-59">(10)</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-target">event target</dfn></p>
      <dd data-md="">
       <p>The object to which an <a data-link-type="dfn" href="#event" id="ref-for-event-6">event</a> is targeted using the <a href="#event-flow">§3.1 Event dispatch and DOM event flow</a>.
 The event target is the value of the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-target">target</a></code> attribute.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-type">event type<span class="dfn-panel"><b><a href="#event-type">#event-type</a></b><b>Referenced in:</b><span><a href="#ref-for-event-type-1">1.2.1. Web browsers and other dynamic or interactive user agents</a> <a href="#ref-for-event-type-2">(2)</a> <a href="#ref-for-event-type-3">(3)</a> <a href="#ref-for-event-type-4">(4)</a></span><span><a href="#ref-for-event-type-5">1.2.2. Authoring tools</a> <a href="#ref-for-event-type-6">(2)</a></span><span><a href="#ref-for-event-type-7">1.2.3. Content authors and content</a> <a href="#ref-for-event-type-8">(2)</a></span><span><a href="#ref-for-event-type-9">1.2.4. Specifications and host languages</a> <a href="#ref-for-event-type-10">(2)</a> <a href="#ref-for-event-type-11">(3)</a> <a href="#ref-for-event-type-12">(4)</a></span><span><a href="#ref-for-event-type-13">3.1. Event dispatch and DOM event flow</a></span><span><a href="#ref-for-event-type-14">9.1.1.1. DOMActivate</a> <a href="#ref-for-event-type-15">(2)</a> <a href="#ref-for-event-type-16">(3)</a> <a href="#ref-for-event-type-17">(4)</a> <a href="#ref-for-event-type-18">(5)</a> <a href="#ref-for-event-type-19">(6)</a> <a href="#ref-for-event-type-20">(7)</a> <a href="#ref-for-event-type-21">(8)</a> <a href="#ref-for-event-type-22">(9)</a> <a href="#ref-for-event-type-23">(10)</a> <a href="#ref-for-event-type-24">(11)</a> <a href="#ref-for-event-type-25">(12)</a></span><span><a href="#ref-for-event-type-26">14. Glossary</a> <a href="#ref-for-event-type-27">(2)</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-type">event type</dfn></p>
      <dd data-md="">
       <p>An <em>event type</em> is an <a data-link-type="dfn" href="#event" id="ref-for-event-7">event</a> object with a particular name and
 which defines particular trigger conditions, properties, and other
@@ -7395,11 +7669,11 @@ characteristics which distinguish it from other event types.  For example,
 the <a data-link-type="dfn" href="#click" id="ref-for-click-48"><code>click</code></a> event type has different characteristics than the <a data-link-type="dfn" href="#mouseover" id="ref-for-mouseover-11"><code>mouseover</code></a> or <a data-link-type="dfn" href="#load" id="ref-for-load-10"><code>load</code></a> event types. The event type is exposed as	the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-type">type</a></code> attribute on the event object.  See <a href="#event-types">§5 Event Types</a> for
 more details.  Also loosely referred to as <em>"event"</em>, such as the <em><a data-link-type="dfn" href="#click" id="ref-for-click-49"><code>click</code></a> event</em>.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="fire">fire<span class="dfn-panel"><b><a href="#fire">#fire</a></b><b>Referenced in:</b><span><a href="#ref-for-fire-1">14. Glossary</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="fire">fire</dfn></p>
      <dd data-md="">
       <p>A synonym for <a data-link-type="dfn" href="#dispatch" id="ref-for-dispatch-3">dispatch</a>.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="host-language">host language<span class="dfn-panel"><b><a href="#host-language">#host-language</a></b><b>Referenced in:</b><span><a href="#ref-for-host-language-1">1.2.2. Authoring tools</a></span><span><a href="#ref-for-host-language-2">1.2.4. Specifications and host languages</a> <a href="#ref-for-host-language-3">(2)</a> <a href="#ref-for-host-language-4">(3)</a></span><span><a href="#ref-for-host-language-5">5.1.2.5. select</a> <a href="#ref-for-host-language-6">(2)</a></span><span><a href="#ref-for-host-language-7">5.2.3. Document Focus and Focus Context</a></span><span><a href="#ref-for-host-language-8">5.6.3. Keyboard Event Order</a></span><span><a href="#ref-for-host-language-9">6.3. Keyboard Event key Values</a> <a href="#ref-for-host-language-10">(2)</a></span><span><a href="#ref-for-host-language-11">9.1.1.1. DOMActivate</a></span><span><a href="#ref-for-host-language-12">14. Glossary</a> <a href="#ref-for-host-language-13">(2)</a> <a href="#ref-for-host-language-14">(3)</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="host-language">host language</dfn></p>
      <dd data-md="">
       <p>Any language which integrates the features of another language or API
 specification, while normatively referencing the origin specification rather
@@ -7410,7 +7684,7 @@ languages, not as a standalone language.  For example, XHTML, HTML, and SVG
 are host languages for UI Events, and they integrate and extend the objects
 and models defined in this specification.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="hysteresis">hysteresis<span class="dfn-panel"><b><a href="#hysteresis">#hysteresis</a></b><b>Referenced in:</b><span><a href="#ref-for-hysteresis-1">5.3.3. Mouse Event Order</a></span><span><a href="#ref-for-hysteresis-2">5.3.4.1. click</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="hysteresis">hysteresis</dfn></p>
      <dd data-md="">
       <p>A feature of human interface design to accept input values within a certain
 range of location or time, in order to improve the user experience.  For
@@ -7419,9 +7693,9 @@ double-click a mouse button is temporal hysteresis, and not immediately
 closing a nested menu if the user mouses out from the parent window when
 transitioning to the child menu is locative hysteresis.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="ime">IME<span class="dfn-panel"><b><a href="#ime">#ime</a></b><b>Referenced in:</b><span><a href="#ref-for-ime-1">5.6.1. Interface KeyboardEvent</a></span><span><a href="#ref-for-ime-2">5.7. Composition Events</a></span><span><a href="#ref-for-ime-3">5.7.7.1. compositionstart</a></span><span><a href="#ref-for-ime-4">5.7.7.3. compositionend</a></span><span><a href="#ref-for-ime-5">6.3.4. Input Method Editors</a> <a href="#ref-for-ime-6">(2)</a> <a href="#ref-for-ime-7">(3)</a> <a href="#ref-for-ime-8">(4)</a> <a href="#ref-for-ime-9">(5)</a></span><span><a href="#ref-for-ime-10">6.3.4.1. Input Method Editor mode keys</a> <a href="#ref-for-ime-11">(2)</a> <a href="#ref-for-ime-12">(3)</a> <a href="#ref-for-ime-13">(4)</a> <a href="#ref-for-ime-14">(5)</a></span><span><a href="#ref-for-ime-15">14. Glossary</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="ime">IME</dfn></p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="input-method-editor">input method editor<span class="dfn-panel"><b><a href="#input-method-editor">#input-method-editor</a></b><b>Referenced in:</b><span><a href="#ref-for-input-method-editor-1">5.5.3.1. beforeinput</a></span><span><a href="#ref-for-input-method-editor-2">5.5.3.2. input</a></span><span><a href="#ref-for-input-method-editor-3">6.3.1. Key Values and Unicode</a></span><span><a href="#ref-for-input-method-editor-4">6.3.4. Input Method Editors</a> <a href="#ref-for-input-method-editor-5">(2)</a></span><span><a href="#ref-for-input-method-editor-6">6.3.4.1. Input Method Editor mode keys</a> <a href="#ref-for-input-method-editor-7">(2)</a> <a href="#ref-for-input-method-editor-8">(3)</a> <a href="#ref-for-input-method-editor-9">(4)</a> <a href="#ref-for-input-method-editor-10">(5)</a></span><span><a href="#ref-for-input-method-editor-11">9.3.1.1. keypress</a></span><span><a href="#ref-for-input-method-editor-12">14. Glossary</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="input-method-editor">input method editor</dfn></p>
      <dd data-md="">
       <p>An <em>input method editor</em> (IME), also known as a <em>front end
 processor</em>, is an application that performs the conversion between
@@ -7431,7 +7705,7 @@ Japanese, Korean).  An <a data-link-type="dfn" href="#ime" id="ref-for-ime-15">I
 completion, such as on mobile devices.  See <a href="#keys-IME">§6.3.4 Input Method Editors</a> for treatment of
 IMEs in this specification.  See also <a data-link-type="dfn" href="#text-composition-system" id="ref-for-text-composition-system-19">text composition system</a>.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="key-mapping">key mapping<span class="dfn-panel"><b><a href="#key-mapping">#key-mapping</a></b><b>Referenced in:</b><span><a href="#ref-for-key-mapping-1">5.6.4.1. keydown</a></span><span><a href="#ref-for-key-mapping-2">5.6.4.2. keyup</a></span><span><a href="#ref-for-key-mapping-3">6.3. Keyboard Event key Values</a></span><span><a href="#ref-for-key-mapping-4">6.3.6. Guidelines for selecting key values</a></span><span><a href="#ref-for-key-mapping-5">9.3.1.1. keypress</a></span><span><a href="#ref-for-key-mapping-6">14. Glossary</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="key-mapping">key mapping</dfn></p>
      <dd data-md="">
       <p>Key mapping is the process of assigning a key value to a particular key, and
 is the result of a combination of several factors, including the operating
@@ -7439,7 +7713,7 @@ system and the keyboard layout (e.g., <a data-link-type="dfn" href="#qwerty" id=
 InScript, Chinese, etc.), and after taking into account all <a data-link-type="dfn" href="#modifier-key" id="ref-for-modifier-key-2">modifier
 key</a> (<code class="keycap">Shift</code>, <code class="keycap">Alt</code>, et al.) and <a data-link-type="dfn" href="#dead-key" id="ref-for-dead-key-12">dead key</a> states.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="key-value">key value<span class="dfn-panel"><b><a href="#key-value">#key-value</a></b><b>Referenced in:</b><span><a href="#ref-for-key-value-1">6.3. Keyboard Event key Values</a> <a href="#ref-for-key-value-2">(2)</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="key-value">key value</dfn></p>
      <dd data-md="">
       <p>A key value is a <a data-link-type="dfn" href="#character-value" id="ref-for-character-value-11">character value</a> or multi-character string (such as <code class="key">"<a href="http://www.w3.org/TR/uievents-key/#key-Enter">Enter</a>"</code>, <code class="key">"<a href="http://www.w3.org/TR/uievents-key/#key-Tab">Tab</a>"</code>, or <code class="key">"<a href="http://www.w3.org/TR/uievents-key/#key-MediaTrackNext">MediaTrackNext</a>"</code>) associated with a key in a	particular state. Every key has a key value, whether or not it has a <a data-link-type="dfn" href="#character-value" id="ref-for-character-value-12">character value</a>. This includes control keys, function keys, <a data-link-type="dfn" href="#modifier-key" id="ref-for-modifier-key-3">modifier keys</a>, <a data-link-type="dfn" href="#dead-key" id="ref-for-dead-key-13">dead keys</a>, and any other key. The key value of
 any given key at any given time depends upon the <a data-link-type="dfn" href="#key-mapping" id="ref-for-key-mapping-6">key mapping</a>.</p>
@@ -7448,24 +7722,24 @@ any given key at any given time depends upon the <a data-link-type="dfn" href="#
      <dd data-md="">
       <p>See local name in <a data-link-type="biblio" href="#biblio-xml-names11">[XML-Names11]</a>.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="modifier-key">modifier key<span class="dfn-panel"><b><a href="#modifier-key">#modifier-key</a></b><b>Referenced in:</b><span><a href="#ref-for-modifier-key-1">6.3.2. Modifier keys</a></span><span><a href="#ref-for-modifier-key-2">14. Glossary</a> <a href="#ref-for-modifier-key-3">(2)</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="modifier-key">modifier key</dfn></p>
      <dd data-md="">
       <p>A modifier key changes the normal behavior of a key, such as to produce a
 character of a different case (as with the <code class="keycap">Shift</code> key), or to alter	what functionality the key triggers (as with the <code class="keycap">Fn</code> or <code class="keycap">Alt</code> keys). Refer to <a href="#keys-modifiers">§6.3.2 Modifier keys</a> for a list of modifier keys.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="namespace URIs" data-noexport="" id="namespace-uris">namespace URI<span class="dfn-panel"><b><a href="#namespace-uris">#namespace-uris</a></b><b>Referenced in:</b><span><a href="#ref-for-namespace-uris-1">1.2. Conformance</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="namespace URIs" data-noexport="" id="namespace-uris">namespace URI</dfn></p>
      <dd data-md="">
       <p>A <em>namespace URI</em> is a URI that identifies an XML namespace. This is
 called the namespace name in <a data-link-type="biblio" href="#biblio-xml-names11">[XML-Names11]</a>. See also sections 1.3.2 <a class="normative" href="http://www.w3.org/TR/DOM-Level-3-Core/core.html#baseURIs-Considerations"><em>DOM URIs</em></a> and 1.3.3 <a class="normative" href="http://www.w3.org/TR/DOM-Level-3-Core/core.html#Namespaces-Considerations"><em>XML Namespaces</em></a> regarding URIs and namespace URIs handling and comparison in the DOM APIs.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="phase">phase<span class="dfn-panel"><b><a href="#phase">#phase</a></b><b>Referenced in:</b><span><a href="#ref-for-phase-1">14. Glossary</a> <a href="#ref-for-phase-2">(2)</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="phase">phase</dfn></p>
      <dd data-md="">
       <p>In the context of <a data-link-type="dfn" href="#event" id="ref-for-event-8">events</a>, a phase is set of logical traversals from
 node to node along the DOM tree, from the <a data-link-type="dfn" href="#window" id="ref-for-window-58">Window</a> to the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code> object, <a data-link-type="dfn" href="#root-element" id="ref-for-root-element-8">root element</a>, and down to the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-55">event target</a> (<a data-link-type="dfn" href="#capture-phase" id="ref-for-capture-phase-3">capture
 phase</a>), at the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-56">event target</a> itself (<a data-link-type="dfn" href="#target-phase" id="ref-for-target-phase-2">target phase</a>), and
 back up the same chain (<a data-link-type="dfn" href="#bubble-phase" id="ref-for-bubble-phase-3">bubbling phase</a>).</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="propagation-path">propagation path<span class="dfn-panel"><b><a href="#propagation-path">#propagation-path</a></b><b>Referenced in:</b><span><a href="#ref-for-propagation-path-1">3.1. Event dispatch and DOM event flow</a> <a href="#ref-for-propagation-path-2">(2)</a> <a href="#ref-for-propagation-path-3">(3)</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="propagation-path">propagation path</dfn></p>
      <dd data-md="">
       <p>The ordered set of <a data-link-type="dfn" href="#current-event-target" id="ref-for-current-event-target-3">current event targets</a> though which an <a data-link-type="dfn" href="#event" id="ref-for-event-9">event</a> object will pass sequentially on the way to and back from the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-57">event
 target</a>.  As the event propagates, each <a data-link-type="dfn" href="#current-event-target" id="ref-for-current-event-target-4">current event target</a> in
@@ -7473,7 +7747,7 @@ the propagation path is in turn set as the <code class="idl"><a data-link-type="
 propagation path is initially composed of one or more <a data-link-type="dfn" href="#event-phase" id="ref-for-event-phase-2">event phases</a> as
 defined by the <a data-link-type="dfn" href="#event-type" id="ref-for-event-type-27">event type</a>, but MAY be interrupted.  Also known as an <em>event target chain</em>.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="qwerty">QWERTY<span class="dfn-panel"><b><a href="#qwerty">#qwerty</a></b><b>Referenced in:</b><span><a href="#ref-for-qwerty-1">6.3. Keyboard Event key Values</a> <a href="#ref-for-qwerty-2">(2)</a></span><span><a href="#ref-for-qwerty-3">14. Glossary</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="qwerty">QWERTY</dfn></p>
      <dd data-md="">
       <p>QWERTY (pronounced <q>ˈkwɜrti</q>) is a common keyboard layout,
 so named because the first five character keys on the top row of letter keys
@@ -7481,29 +7755,29 @@ are Q, W, E, R, T, and Y.  There are many other popular keyboard layouts
 (including the Dvorak and Colemak layouts), most designed for localization
 or ergonomics.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="root-element">root element<span class="dfn-panel"><b><a href="#root-element">#root-element</a></b><b>Referenced in:</b><span><a href="#ref-for-root-element-1">5.3.3. Mouse Event Order</a> <a href="#ref-for-root-element-2">(2)</a></span><span><a href="#ref-for-root-element-3">5.6.3. Keyboard Event Order</a></span><span><a href="#ref-for-root-element-4">5.6.4.1. keydown</a></span><span><a href="#ref-for-root-element-5">5.6.4.2. keyup</a></span><span><a href="#ref-for-root-element-6">9.3.1.1. keypress</a></span><span><a href="#ref-for-root-element-7">14. Glossary</a> <a href="#ref-for-root-element-8">(2)</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="root-element">root element</dfn></p>
      <dd data-md="">
       <p>The first element node of a document, of which all other elements are
 children. The document element.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="rotation">rotation<span class="dfn-panel"><b><a href="#rotation">#rotation</a></b><b>Referenced in:</b><span><a href="#ref-for-rotation-1">5.4. Wheel Events</a> <a href="#ref-for-rotation-2">(2)</a></span><span><a href="#ref-for-rotation-3">5.4.1. Interface WheelEvent</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="rotation">rotation</dfn></p>
      <dd data-md="">
       <p>An indication of incremental change on an input device using the <code class="idl"><a data-link-type="idl" href="#wheelevent" id="ref-for-wheelevent-14">WheelEvent</a></code> interface. On some devices this MAY be a literal rotation of
 a wheel, while on others, it MAY be movement along a flat surface, or
 pressure on a particular button.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="target-phase">target phase<span class="dfn-panel"><b><a href="#target-phase">#target-phase</a></b><b>Referenced in:</b><span><a href="#ref-for-target-phase-1">3.1. Event dispatch and DOM event flow</a></span><span><a href="#ref-for-target-phase-2">14. Glossary</a> <a href="#ref-for-target-phase-3">(2)</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="target-phase">target phase</dfn></p>
      <dd data-md="">
       <p>The process by which an <a data-link-type="dfn" href="#event" id="ref-for-event-10">event</a> can be handled by the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-58">event
 target</a>. See the description of the <a data-link-type="dfn" href="#target-phase" id="ref-for-target-phase-3">target phase</a> in the context of
 event flow for more details.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="text-composition-system">text composition system<span class="dfn-panel"><b><a href="#text-composition-system">#text-composition-system</a></b><b>Referenced in:</b><span><a href="#ref-for-text-composition-system-1">4.1. List of Event Types</a> <a href="#ref-for-text-composition-system-2">(2)</a></span><span><a href="#ref-for-text-composition-system-3">5.6.4.1. keydown</a> <a href="#ref-for-text-composition-system-4">(2)</a></span><span><a href="#ref-for-text-composition-system-5">5.7.7.1. compositionstart</a> <a href="#ref-for-text-composition-system-6">(2)</a> <a href="#ref-for-text-composition-system-7">(3)</a> <a href="#ref-for-text-composition-system-8">(4)</a> <a href="#ref-for-text-composition-system-9">(5)</a> <a href="#ref-for-text-composition-system-10">(6)</a> <a href="#ref-for-text-composition-system-11">(7)</a></span><span><a href="#ref-for-text-composition-system-12">5.7.7.2. compositionupdate</a> <a href="#ref-for-text-composition-system-13">(2)</a> <a href="#ref-for-text-composition-system-14">(3)</a></span><span><a href="#ref-for-text-composition-system-15">5.7.7.3. compositionend</a> <a href="#ref-for-text-composition-system-16">(2)</a></span><span><a href="#ref-for-text-composition-system-17">9. Legacy Event Types</a></span><span><a href="#ref-for-text-composition-system-18">9.3.1.1. keypress</a></span><span><a href="#ref-for-text-composition-system-19">14. Glossary</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="text-composition-system">text composition system</dfn></p>
      <dd data-md="">
       <p>A software component that interprets some form of alternate input (such as a <a data-link-type="dfn" href="#input-method-editor" id="ref-for-input-method-editor-12">input method editor</a>, a speech processor, or a handwriting recognition
 system) and converts it to text.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="topmost-event-target">topmost event target<span class="dfn-panel"><b><a href="#topmost-event-target">#topmost-event-target</a></b><b>Referenced in:</b><span><a href="#ref-for-topmost-event-target-1">5.3.4.1. click</a> <a href="#ref-for-topmost-event-target-2">(2)</a></span><span><a href="#ref-for-topmost-event-target-3">5.3.4.2. dblclick</a></span><span><a href="#ref-for-topmost-event-target-4">5.3.4.3. mousedown</a></span><span><a href="#ref-for-topmost-event-target-5">5.3.4.4. mouseenter</a></span><span><a href="#ref-for-topmost-event-target-6">5.3.4.5. mouseleave</a></span><span><a href="#ref-for-topmost-event-target-7">5.3.4.6. mousemove</a></span><span><a href="#ref-for-topmost-event-target-8">5.3.4.7. mouseout</a></span><span><a href="#ref-for-topmost-event-target-9">5.3.4.8. mouseover</a></span><span><a href="#ref-for-topmost-event-target-10">5.3.4.9. mouseup</a></span><span><a href="#ref-for-topmost-event-target-11">5.4.2.1. wheel</a></span><span><a href="#ref-for-topmost-event-target-12">14. Glossary</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="topmost-event-target">topmost event target</dfn></p>
      <dd data-md="">
       <p>The <a data-link-type="dfn" href="#topmost-event-target" id="ref-for-topmost-event-target-12">topmost event target</a> MUST be the element highest in the rendering
 order which is capable of being an <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-59">event target</a>. In graphical user
@@ -7530,7 +7804,7 @@ Punctuation (<abbr title="Punctuation, Connector">Pc</abbr>, <abbr title="Punctu
 and Symbol (<abbr title="Symbol, Currency">Sc</abbr>, <abbr title="Symbol, Modifier">Sk</abbr>, <abbr title="Symbol, Math">Sm</abbr>, <abbr title="Symbol, Other">So</abbr>)
 category values.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="unicode-code-point">Unicode code point<span class="dfn-panel"><b><a href="#unicode-code-point">#unicode-code-point</a></b><b>Referenced in:</b><span><a href="#ref-for-unicode-code-point-1">6.1.1. Key Legends</a> <a href="#ref-for-unicode-code-point-2">(2)</a></span><span><a href="#ref-for-unicode-code-point-3">6.3.2. Modifier keys</a></span><span><a href="#ref-for-unicode-code-point-4">6.3.6. Guidelines for selecting key values</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="unicode-code-point">Unicode code point</dfn></p>
      <dd data-md="">
       <p>A Unicode code point is a unique hexadecimal number signifying a character
 by its index in the Unicode codespace (or library of characters).  In the
@@ -7539,12 +7813,12 @@ format <code>\u</code> followed by a hexadecimal character index in the
 range <code>0000</code> to <code>10FFFF</code>, using at least four digits.
 See also <a data-link-type="dfn" href="#character-value" id="ref-for-character-value-13">character value</a>.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="un-initialized-value">un-initialized value<span class="dfn-panel"><b><a href="#un-initialized-value">#un-initialized-value</a></b><b>Referenced in:</b><span><a href="#ref-for-un-initialized-value-1">5.1.1. Interface UIEvent</a> <a href="#ref-for-un-initialized-value-2">(2)</a></span><span><a href="#ref-for-un-initialized-value-3">5.2.1. Interface FocusEvent</a></span><span><a href="#ref-for-un-initialized-value-4">5.3.1. Interface MouseEvent</a> <a href="#ref-for-un-initialized-value-5">(2)</a> <a href="#ref-for-un-initialized-value-6">(3)</a> <a href="#ref-for-un-initialized-value-7">(4)</a> <a href="#ref-for-un-initialized-value-8">(5)</a> <a href="#ref-for-un-initialized-value-9">(6)</a> <a href="#ref-for-un-initialized-value-10">(7)</a> <a href="#ref-for-un-initialized-value-11">(8)</a> <a href="#ref-for-un-initialized-value-12">(9)</a> <a href="#ref-for-un-initialized-value-13">(10)</a> <a href="#ref-for-un-initialized-value-14">(11)</a> <a href="#ref-for-un-initialized-value-15">(12)</a></span><span><a href="#ref-for-un-initialized-value-16">5.4.1. Interface WheelEvent</a> <a href="#ref-for-un-initialized-value-17">(2)</a> <a href="#ref-for-un-initialized-value-18">(3)</a> <a href="#ref-for-un-initialized-value-19">(4)</a></span><span><a href="#ref-for-un-initialized-value-20">5.5.1. Interface InputEvent</a> <a href="#ref-for-un-initialized-value-21">(2)</a></span><span><a href="#ref-for-un-initialized-value-22">5.6.1. Interface KeyboardEvent</a> <a href="#ref-for-un-initialized-value-23">(2)</a> <a href="#ref-for-un-initialized-value-24">(3)</a> <a href="#ref-for-un-initialized-value-25">(4)</a> <a href="#ref-for-un-initialized-value-26">(5)</a> <a href="#ref-for-un-initialized-value-27">(6)</a> <a href="#ref-for-un-initialized-value-28">(7)</a> <a href="#ref-for-un-initialized-value-29">(8)</a> <a href="#ref-for-un-initialized-value-30">(9)</a></span><span><a href="#ref-for-un-initialized-value-31">5.7.1. Interface CompositionEvent</a></span><span><a href="#ref-for-un-initialized-value-32">9.4.1. Interface MutationEvent</a> <a href="#ref-for-un-initialized-value-33">(2)</a> <a href="#ref-for-un-initialized-value-34">(3)</a> <a href="#ref-for-un-initialized-value-35">(4)</a> <a href="#ref-for-un-initialized-value-36">(5)</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="un-initialized-value">un-initialized value</dfn></p>
      <dd data-md="">
       <p>The value of any event attribute (such as <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-bubbles">bubbles</a></code> or <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-currenttarget">currentTarget</a></code>) before the event has been initialized with <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-initevent">initEvent()</a></code>. The un-initialized values of an event apply
 immediately after a new event has been created using the method <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-document-createevent">createEvent()</a></code>.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="user-agent">user agent<span class="dfn-panel"><b><a href="#user-agent">#user-agent</a></b><b>Referenced in:</b><span><a href="#ref-for-user-agent-1">1.2. Conformance</a> <a href="#ref-for-user-agent-2">(2)</a> <a href="#ref-for-user-agent-3">(3)</a></span><span><a href="#ref-for-user-agent-4">1.2.1. Web browsers and other dynamic or interactive user agents</a> <a href="#ref-for-user-agent-5">(2)</a></span><span><a href="#ref-for-user-agent-6">2. Stylistic Conventions</a></span><span><a href="#ref-for-user-agent-7">3.4. Trusted events</a> <a href="#ref-for-user-agent-8">(2)</a></span><span><a href="#ref-for-user-agent-9">5.1.2.1. load</a></span><span><a href="#ref-for-user-agent-10">5.1.2.2. unload</a></span><span><a href="#ref-for-user-agent-11">5.1.2.3. abort</a></span><span><a href="#ref-for-user-agent-12">5.1.2.4. error</a></span><span><a href="#ref-for-user-agent-13">5.1.2.5. select</a></span><span><a href="#ref-for-user-agent-14">5.2.4.1. blur</a></span><span><a href="#ref-for-user-agent-15">5.2.4.2. focus</a></span><span><a href="#ref-for-user-agent-16">5.2.4.3. focusin</a></span><span><a href="#ref-for-user-agent-17">5.2.4.4. focusout</a></span><span><a href="#ref-for-user-agent-18">5.3.4.2. dblclick</a></span><span><a href="#ref-for-user-agent-19">5.3.4.3. mousedown</a></span><span><a href="#ref-for-user-agent-20">5.3.4.4. mouseenter</a></span><span><a href="#ref-for-user-agent-21">5.3.4.5. mouseleave</a></span><span><a href="#ref-for-user-agent-22">5.3.4.6. mousemove</a></span><span><a href="#ref-for-user-agent-23">5.3.4.7. mouseout</a></span><span><a href="#ref-for-user-agent-24">5.3.4.8. mouseover</a></span><span><a href="#ref-for-user-agent-25">5.3.4.9. mouseup</a></span><span><a href="#ref-for-user-agent-26">5.4.2.1. wheel</a> <a href="#ref-for-user-agent-27">(2)</a></span><span><a href="#ref-for-user-agent-28">5.5.3.1. beforeinput</a></span><span><a href="#ref-for-user-agent-29">5.5.3.2. input</a></span><span><a href="#ref-for-user-agent-30">5.6.1. Interface KeyboardEvent</a></span><span><a href="#ref-for-user-agent-31">5.6.4.1. keydown</a> <a href="#ref-for-user-agent-32">(2)</a></span><span><a href="#ref-for-user-agent-33">5.6.4.2. keyup</a></span><span><a href="#ref-for-user-agent-34">5.7.7.1. compositionstart</a></span><span><a href="#ref-for-user-agent-35">5.7.7.2. compositionupdate</a></span><span><a href="#ref-for-user-agent-36">5.7.7.3. compositionend</a> <a href="#ref-for-user-agent-37">(2)</a></span><span><a href="#ref-for-user-agent-38">7. Legacy Event Initializers</a></span><span><a href="#ref-for-user-agent-39">8. Legacy Key Attributes</a> <a href="#ref-for-user-agent-40">(2)</a> <a href="#ref-for-user-agent-41">(3)</a></span><span><a href="#ref-for-user-agent-42">8.1. Legacy KeyboardEvent supplemental interface</a></span><span><a href="#ref-for-user-agent-43">9. Legacy Event Types</a></span><span><a href="#ref-for-user-agent-44">9.1.1.1. DOMActivate</a> <a href="#ref-for-user-agent-45">(2)</a> <a href="#ref-for-user-agent-46">(3)</a> <a href="#ref-for-user-agent-47">(4)</a> <a href="#ref-for-user-agent-48">(5)</a></span><span><a href="#ref-for-user-agent-49">9.1.2. Activation event order</a> <a href="#ref-for-user-agent-50">(2)</a> <a href="#ref-for-user-agent-51">(3)</a></span><span><a href="#ref-for-user-agent-52">9.2.1.1. DOMFocusIn</a></span><span><a href="#ref-for-user-agent-53">9.2.1.2. DOMFocusOut</a></span><span><a href="#ref-for-user-agent-54">9.3.1.1. keypress</a></span><span><a href="#ref-for-user-agent-55">9.4. Legacy MutationEvent events</a></span><span><a href="#ref-for-user-agent-56">9.4.2.1. DOMAttrModified</a></span><span><a href="#ref-for-user-agent-57">9.4.2.2. DOMCharacterDataModified</a></span><span><a href="#ref-for-user-agent-58">9.4.2.3. DOMNodeInserted</a> <a href="#ref-for-user-agent-59">(2)</a></span><span><a href="#ref-for-user-agent-60">9.4.2.4. DOMNodeInsertedIntoDocument</a> <a href="#ref-for-user-agent-61">(2)</a></span><span><a href="#ref-for-user-agent-62">9.4.2.5. DOMNodeRemoved</a> <a href="#ref-for-user-agent-63">(2)</a></span><span><a href="#ref-for-user-agent-64">9.4.2.6. DOMNodeRemovedFromDocument</a> <a href="#ref-for-user-agent-65">(2)</a></span><span><a href="#ref-for-user-agent-66">14. Glossary</a> <a href="#ref-for-user-agent-67">(2)</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="user-agent">user agent</dfn></p>
      <dd data-md="">
       <p>A program, such as a browser or content authoring tool, normally running on
 a client machine, which acts on a user’s behalf in retrieving, interpreting,
@@ -7553,7 +7827,7 @@ using different user agents at different times, for different purposes.  See
 the <a href="#conf-interactive-ua">§1.2.1 Web browsers and other dynamic or interactive user agents</a> and <a href="#conf-author-tools">§1.2.2 Authoring tools</a> for details on the
 requirements for a <em>conforming</em> user agent.</p>
      <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="window">Window<span class="dfn-panel"><b><a href="#window">#window</a></b><b>Referenced in:</b><span><a href="#ref-for-window-1">3.1. Event dispatch and DOM event flow</a> <a href="#ref-for-window-2">(2)</a></span><span><a href="#ref-for-window-3">4.1. List of Event Types</a> <a href="#ref-for-window-4">(2)</a> <a href="#ref-for-window-5">(3)</a> <a href="#ref-for-window-6">(4)</a> <a href="#ref-for-window-7">(5)</a> <a href="#ref-for-window-8">(6)</a> <a href="#ref-for-window-9">(7)</a> <a href="#ref-for-window-10">(8)</a> <a href="#ref-for-window-11">(9)</a></span><span><a href="#ref-for-window-12">5.1.2.1. load</a> <a href="#ref-for-window-13">(2)</a> <a href="#ref-for-window-14">(3)</a></span><span><a href="#ref-for-window-15">5.1.2.2. unload</a> <a href="#ref-for-window-16">(2)</a></span><span><a href="#ref-for-window-17">5.1.2.3. abort</a> <a href="#ref-for-window-18">(2)</a></span><span><a href="#ref-for-window-19">5.1.2.4. error</a> <a href="#ref-for-window-20">(2)</a></span><span><a href="#ref-for-window-21">5.1.2.5. select</a></span><span><a href="#ref-for-window-22">5.2.4.1. blur</a> <a href="#ref-for-window-23">(2)</a></span><span><a href="#ref-for-window-24">5.2.4.2. focus</a> <a href="#ref-for-window-25">(2)</a></span><span><a href="#ref-for-window-26">5.2.4.3. focusin</a> <a href="#ref-for-window-27">(2)</a></span><span><a href="#ref-for-window-28">5.2.4.4. focusout</a> <a href="#ref-for-window-29">(2)</a></span><span><a href="#ref-for-window-30">5.3.4.1. click</a></span><span><a href="#ref-for-window-31">5.3.4.2. dblclick</a></span><span><a href="#ref-for-window-32">5.3.4.3. mousedown</a></span><span><a href="#ref-for-window-33">5.3.4.4. mouseenter</a></span><span><a href="#ref-for-window-34">5.3.4.5. mouseleave</a></span><span><a href="#ref-for-window-35">5.3.4.6. mousemove</a></span><span><a href="#ref-for-window-36">5.3.4.7. mouseout</a></span><span><a href="#ref-for-window-37">5.3.4.8. mouseover</a></span><span><a href="#ref-for-window-38">5.3.4.9. mouseup</a></span><span><a href="#ref-for-window-39">5.4.2.1. wheel</a></span><span><a href="#ref-for-window-40">5.5.3.1. beforeinput</a></span><span><a href="#ref-for-window-41">5.5.3.2. input</a></span><span><a href="#ref-for-window-42">5.6.4.1. keydown</a></span><span><a href="#ref-for-window-43">5.6.4.2. keyup</a></span><span><a href="#ref-for-window-44">5.7.7.1. compositionstart</a></span><span><a href="#ref-for-window-45">5.7.7.2. compositionupdate</a></span><span><a href="#ref-for-window-46">5.7.7.3. compositionend</a></span><span><a href="#ref-for-window-47">9. Legacy Event Types</a> <a href="#ref-for-window-48">(2)</a> <a href="#ref-for-window-49">(3)</a></span><span><a href="#ref-for-window-50">9.1.1.1. DOMActivate</a></span><span><a href="#ref-for-window-51">9.2.1.1. DOMFocusIn</a> <a href="#ref-for-window-52">(2)</a></span><span><a href="#ref-for-window-53">9.2.1.2. DOMFocusOut</a> <a href="#ref-for-window-54">(2)</a></span><span><a href="#ref-for-window-55">9.3.1.1. keypress</a></span><span><a href="#ref-for-window-56">9.4.2.7. DOMSubtreeModified</a></span><span><a href="#ref-for-window-57">12.1.1. Changes to DOM Level 2 event flow</a></span><span><a href="#ref-for-window-58">14. Glossary</a></span></span></dfn></p>
+      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="window">Window</dfn></p>
      <dd data-md="">
       <p>The <code>Window</code> is the object referred to by the current document’s
 browsing context’s Window Proxy object as defined in <a href="http://dev.w3.org/html5/spec/single-page.html#windowproxy" title="HTML5 WindowProxy description">HTML5</a> <a data-link-type="biblio" href="#biblio-html5">[HTML5]</a>.</p>
@@ -7607,6 +7881,7 @@ browsing context’s Window Proxy object as defined in <a href="http://dev.w3.or
    <li><a href="#compositionend">compositionend</a><span>, in §5.7.7.3</span>
    <li><a href="#compositionevent">CompositionEvent</a><span>, in §5.7.1</span>
    <li><a href="#dictdef-compositioneventinit">CompositionEventInit</a><span>, in §5.7.1</span>
+   <li><a href="#dom-compositionevent-compositionevent">CompositionEvent(type)</a><span>, in §5.7.1</span>
    <li><a href="#dom-compositionevent-compositionevent">CompositionEvent(type, eventInitDict)</a><span>, in §5.7.1</span>
    <li><a href="#compositionstart">compositionstart</a><span>, in §5.7.7.1</span>
    <li><a href="#compositionupdate">compositionupdate</a><span>, in §5.7.7.2</span>
@@ -7698,6 +7973,7 @@ browsing context’s Window Proxy object as defined in <a href="http://dev.w3.or
    <li><a href="#focus">focus</a><span>, in §5.2.4.2</span>
    <li><a href="#focusevent">FocusEvent</a><span>, in §5.2.1</span>
    <li><a href="#dictdef-focuseventinit">FocusEventInit</a><span>, in §5.2.1</span>
+   <li><a href="#dom-focusevent-focusevent">FocusEvent(type)</a><span>, in §5.2.1</span>
    <li><a href="#dom-focusevent-focusevent">FocusEvent(type, eventInitDict)</a><span>, in §5.2.1</span>
    <li><a href="#focusin">focusin</a><span>, in §5.2.4.3</span>
    <li><a href="#focusout">focusout</a><span>, in §5.2.4.4</span>
@@ -7714,6 +7990,7 @@ browsing context’s Window Proxy object as defined in <a href="http://dev.w3.or
    <li><a href="#input">input</a><span>, in §5.5.3.2</span>
    <li><a href="#inputevent">InputEvent</a><span>, in §5.5.1</span>
    <li><a href="#dictdef-inputeventinit">InputEventInit</a><span>, in §5.5.1</span>
+   <li><a href="#dom-inputevent-inputevent">InputEvent(type)</a><span>, in §5.5.1</span>
    <li><a href="#dom-inputevent-inputevent">InputEvent(type, eventInitDict)</a><span>, in §5.5.1</span>
    <li><a href="#input-method-editor">input method editor</a><span>, in §14</span>
    <li><a href="#internal-key-modifier-state">internal key modifier state</a><span>, in §3.6</span>
@@ -7733,6 +8010,7 @@ browsing context’s Window Proxy object as defined in <a href="http://dev.w3.or
     </ul>
    <li><a href="#keyboardevent-keyboardevent">KeyboardEvent</a><span>, in §5.6.1</span>
    <li><a href="#dictdef-keyboardeventinit">KeyboardEventInit</a><span>, in §5.6.1</span>
+   <li><a href="#dom-keyboardevent-keyboardevent">KeyboardEvent(type)</a><span>, in §5.6.1</span>
    <li><a href="#dom-keyboardevent-keyboardevent">KeyboardEvent(type, eventInitDict)</a><span>, in §5.6.1</span>
    <li><a href="#dom-keyboardevent-keycode">keyCode</a><span>, in §8.1.1</span>
    <li><a href="#keydown">keydown</a><span>, in §5.6.4.1</span>
@@ -7770,6 +8048,7 @@ browsing context’s Window Proxy object as defined in <a href="http://dev.w3.or
    <li><a href="#mousedown">mousedown</a><span>, in §5.3.4.3</span>
    <li><a href="#mouseenter">mouseenter</a><span>, in §5.3.4.4</span>
    <li><a href="#mouseevent">MouseEvent</a><span>, in §5.3.1</span>
+   <li><a href="#dom-mouseevent-mouseevent">MouseEvent(type)</a><span>, in §5.3.1</span>
    <li><a href="#dom-mouseevent-mouseevent">MouseEvent(type, eventInitDict)</a><span>, in §5.3.1</span>
    <li><a href="#mouseleave">mouseleave</a><span>, in §5.3.4.5</span>
    <li><a href="#mousemove">mousemove</a><span>, in §5.3.4.6</span>
@@ -7810,6 +8089,7 @@ browsing context’s Window Proxy object as defined in <a href="http://dev.w3.or
    <li><a href="#tree">tree</a><span>, in §14</span>
    <li><a href="#uievent-uievent">UIEvent</a><span>, in §5.1.1</span>
    <li><a href="#dictdef-uieventinit-uieventinit">UIEventInit</a><span>, in §5.1.1</span>
+   <li><a href="#dom-uievent-uievent">UIEvent(type)</a><span>, in §5.1.1</span>
    <li><a href="#dom-uievent-uievent">UIEvent(type, eventInitDict)</a><span>, in §5.1.1</span>
    <li><a href="#unicode-character-categories">Unicode character categories</a><span>, in §14</span>
    <li><a href="#unicode-code-point">Unicode code point</a><span>, in §14</span>
@@ -7825,6 +8105,7 @@ browsing context’s Window Proxy object as defined in <a href="http://dev.w3.or
    <li><a href="#wheel">wheel</a><span>, in §5.4.2.1</span>
    <li><a href="#wheelevent">WheelEvent</a><span>, in §5.4.1</span>
    <li><a href="#dictdef-wheeleventinit">WheelEventInit</a><span>, in §5.4.1</span>
+   <li><a href="#dom-wheelevent-wheelevent">WheelEvent(type)</a><span>, in §5.4.1</span>
    <li><a href="#dom-wheelevent-wheelevent">WheelEvent(type, eventInitDict)</a><span>, in §5.4.1</span>
    <li><a href="#dom-keyboardevent-which">which</a><span>, in §8.1.1</span>
    <li><a href="#window">Window</a><span>, in §14</span>
@@ -7832,21 +8113,21 @@ browsing context’s Window Proxy object as defined in <a href="http://dev.w3.or
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
    <li>
-    <a data-link-type="biblio" href="#biblio-css-syntax-3">[css-syntax-3]</a> defines the following terms:
+    <a data-link-type="biblio">[css-syntax-3]</a> defines the following terms:
     <ul>
      <li><a href="https://www.w3.org/TR/css-syntax-3/#code-point">code point</a>
     </ul>
    <li>
-    <a data-link-type="biblio" href="#biblio-cssom-view-1">[cssom-view]</a> defines the following terms:
+    <a data-link-type="biblio">[cssom-view-1]</a> defines the following terms:
     <ul>
-     <li><a href="https://drafts.csswg.org/cssom-view-1/#dictdef-mouseeventinit">MouseEventInit</a>
-     <li><a href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clientx">clientX</a>
-     <li><a href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clienty">clientY</a>
-     <li><a href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screenx">screenX</a>
-     <li><a href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screeny">screenY</a>
+     <li><a href="https://www.w3.org/TR/cssom-view/#dictdef-mouseeventinit">MouseEventInit</a>
+     <li><a href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clientx">clientX</a>
+     <li><a href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clienty">clientY</a>
+     <li><a href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screenx">screenX</a>
+     <li><a href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screeny">screenY</a>
     </ul>
    <li>
-    <a data-link-type="biblio" href="#biblio-dom">[dom]</a> defines the following terms:
+    <a data-link-type="biblio">[DOM]</a> defines the following terms:
     <ul>
      <li><a href="https://dom.spec.whatwg.org/#dom-event-at_target">AT_TARGET</a>
      <li><a href="https://dom.spec.whatwg.org/#dom-event-bubbling_phase">BUBBLING_PHASE</a>
@@ -7862,6 +8143,7 @@ browsing context’s Window Proxy object as defined in <a href="http://dev.w3.or
      <li><a href="https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener">addEventListener(type, callback)</a>
      <li><a href="https://dom.spec.whatwg.org/#dom-event-bubbles">bubbles</a>
      <li><a href="https://dom.spec.whatwg.org/#dom-event-cancelable">cancelable</a>
+     <li><a href="https://dom.spec.whatwg.org/#dom-event-composed">composed</a>
      <li><a href="https://dom.spec.whatwg.org/#dom-document-createevent">createEvent(interface)</a>
      <li><a href="https://dom.spec.whatwg.org/#dom-event-currenttarget">currentTarget</a>
      <li><a href="https://dom.spec.whatwg.org/#dom-event-defaultprevented">defaultPrevented</a>
@@ -7882,14 +8164,14 @@ browsing context’s Window Proxy object as defined in <a href="http://dev.w3.or
      <li><a href="https://dom.spec.whatwg.org/#dom-event-type">type</a>
     </ul>
    <li>
-    <a data-link-type="biblio" href="#biblio-html">[HTML]</a> defines the following terms:
+    <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a>
      <li><a href="https://html.spec.whatwg.org/multipage/forms.html#the-input-element">input</a>
      <li><a href="https://html.spec.whatwg.org/multipage/forms.html#the-textarea-element">textarea</a>
     </ul>
    <li>
-    <a data-link-type="biblio" href="#biblio-svg2">[SVG2]</a> defines the following terms:
+    <a data-link-type="biblio">[SVG2]</a> defines the following terms:
     <ul>
      <li><a href="https://www.w3.org/TR/svg2/geometry.html#XProperty">x</a>
     </ul>
@@ -7897,225 +8179,1903 @@ browsing context’s Window Proxy object as defined in <a href="http://dev.w3.or
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
-   <dt id="biblio-dom-level-2-events"><a class="self-link" href="#biblio-dom-level-2-events"></a>[DOM-Level-2-Events]
-   <dd>Tom Pixley. <a href="http://www.w3.org/TR/DOM-Level-2-Events/">Document Object Model (DOM) Level 2 Events Specification</a>. 13 November 2000. REC. URL: <a href="http://www.w3.org/TR/DOM-Level-2-Events/">http://www.w3.org/TR/DOM-Level-2-Events/</a>
-   <dt id="biblio-dom-level-3-core"><a class="self-link" href="#biblio-dom-level-3-core"></a>[DOM-Level-3-Core]
-   <dd>Arnaud Le Hors; et al. <a href="http://www.w3.org/TR/DOM-Level-3-Core/">Document Object Model (DOM) Level 3 Core Specification</a>. 7 April 2004. REC. URL: <a href="http://www.w3.org/TR/DOM-Level-3-Core/">http://www.w3.org/TR/DOM-Level-3-Core/</a>
-   <dt id="biblio-html"><a class="self-link" href="#biblio-html"></a>[HTML]
+   <dt id="biblio-css-syntax-3">[CSS-SYNTAX-3]
+   <dd>Tab Atkins Jr.; Simon Sapin. <a href="https://www.w3.org/TR/css-syntax-3/">CSS Syntax Module Level 3</a>. 20 February 2014. CR. URL: <a href="https://www.w3.org/TR/css-syntax-3/">https://www.w3.org/TR/css-syntax-3/</a>
+   <dt id="biblio-cssom-view-1">[CSSOM-VIEW-1]
+   <dd>Simon Pieters. <a href="https://www.w3.org/TR/cssom-view-1/">CSSOM View Module</a>. 17 March 2016. WD. URL: <a href="https://www.w3.org/TR/cssom-view-1/">https://www.w3.org/TR/cssom-view-1/</a>
+   <dt id="biblio-dom">[DOM]
+   <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/">DOM Standard</a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
+   <dt id="biblio-dom-level-2-events">[DOM-Level-2-Events]
+   <dd>Tom Pixley. <a href="https://www.w3.org/TR/DOM-Level-2-Events/">Document Object Model (DOM) Level 2 Events Specification</a>. 13 November 2000. REC. URL: <a href="https://www.w3.org/TR/DOM-Level-2-Events/">https://www.w3.org/TR/DOM-Level-2-Events/</a>
+   <dt id="biblio-dom-level-3-core">[DOM-Level-3-Core]
+   <dd>Arnaud Le Hors; et al. <a href="https://www.w3.org/TR/DOM-Level-3-Core/">Document Object Model (DOM) Level 3 Core Specification</a>. 7 April 2004. REC. URL: <a href="https://www.w3.org/TR/DOM-Level-3-Core/">https://www.w3.org/TR/DOM-Level-3-Core/</a>
+   <dt id="biblio-html">[HTML]
    <dd>Ian Hickson. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
-   <dt id="biblio-svg2"><a class="self-link" href="#biblio-svg2"></a>[SVG2]
-   <dd>Nikos Andronikos; et al. <a href="https://svgwg.org/svg2-draft/">Scalable Vector Graphics (SVG) 2</a>. 15 September 2015. WD. URL: <a href="https://svgwg.org/svg2-draft/">https://svgwg.org/svg2-draft/</a>
-   <dt id="biblio-css-syntax-3"><a class="self-link" href="#biblio-css-syntax-3"></a>[CSS-SYNTAX-3]
-   <dd>Tab Atkins Jr.; Simon Sapin. <a href="http://dev.w3.org/csswg/css-syntax/">CSS Syntax Module Level 3</a>. 20 February 2014. CR. URL: <a href="http://dev.w3.org/csswg/css-syntax/">http://dev.w3.org/csswg/css-syntax/</a>
-   <dt id="biblio-cssom-view"><a class="self-link" href="#biblio-cssom-view"></a>[CSSOM-VIEW]
-   <dd>Simon Pieters; Glenn Adams. <a href="http://dev.w3.org/csswg/cssom-view/">CSSOM View Module</a>. 17 December 2013. WD. URL: <a href="http://dev.w3.org/csswg/cssom-view/">http://dev.w3.org/csswg/cssom-view/</a>
-   <dt id="biblio-dom"><a class="self-link" href="#biblio-dom"></a>[DOM]
-   <dd>Anne van Kesteren; et al. <a href="http://www.w3.org/TR/dom/">W3C DOM4</a>. 19 November 2015. REC. URL: <a href="http://www.w3.org/TR/dom/">http://www.w3.org/TR/dom/</a>
-   <dt id="biblio-html5"><a class="self-link" href="#biblio-html5"></a>[HTML5]
-   <dd>Ian Hickson; et al. <a href="http://www.w3.org/TR/html5/">HTML5</a>. 28 October 2014. REC. URL: <a href="http://www.w3.org/TR/html5/">http://www.w3.org/TR/html5/</a>
-   <dt id="biblio-rfc2119"><a class="self-link" href="#biblio-rfc2119"></a>[RFC2119]
+   <dt id="biblio-html5">[HTML5]
+   <dd>Ian Hickson; et al. <a href="https://www.w3.org/TR/html5/">HTML5</a>. 28 October 2014. REC. URL: <a href="https://www.w3.org/TR/html5/">https://www.w3.org/TR/html5/</a>
+   <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
-   <dt id="biblio-uievents-code"><a class="self-link" href="#biblio-uievents-code"></a>[UIEVENTS-CODE]
-   <dd>Gary Kacmarcik; Travis Leithead. <a href="http://www.w3.org/TR/uievents-code/">UI Events KeyboardEvent code Values</a>. 15 December 2015. WD. URL: <a href="http://www.w3.org/TR/uievents-code/">http://www.w3.org/TR/uievents-code/</a>
-   <dt id="biblio-uievents-key"><a class="self-link" href="#biblio-uievents-key"></a>[UIEVENTS-KEY]
-   <dd>Gary Kacmarcik; Travis Leithead. <a href="http://www.w3.org/TR/uievents-key/">UI Events KeyboardEvent key Values</a>. 15 December 2015. WD. URL: <a href="http://www.w3.org/TR/uievents-key/">http://www.w3.org/TR/uievents-key/</a>
+   <dt id="biblio-svg2">[SVG2]
+   <dd>Nikos Andronikos; et al. <a href="https://www.w3.org/TR/SVG2/">Scalable Vector Graphics (SVG) 2</a>. 15 September 2015. WD. URL: <a href="https://www.w3.org/TR/SVG2/">https://www.w3.org/TR/SVG2/</a>
+   <dt id="biblio-uievents-code">[UIEvents-Code]
+   <dd>Gary Kacmarcik; Travis Leithead. <a href="https://www.w3.org/TR/uievents-code/">UI Events KeyboardEvent code Values</a>. 15 December 2015. WD. URL: <a href="https://www.w3.org/TR/uievents-code/">https://www.w3.org/TR/uievents-code/</a>
+   <dt id="biblio-uievents-key">[UIEvents-Key]
+   <dd>Gary Kacmarcik; Travis Leithead. <a href="https://www.w3.org/TR/uievents-key/">UI Events KeyboardEvent key Values</a>. 15 December 2015. WD. URL: <a href="https://www.w3.org/TR/uievents-key/">https://www.w3.org/TR/uievents-key/</a>
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
-   <dt id="biblio-css2"><a class="self-link" href="#biblio-css2"></a>[CSS2]
-   <dd>Bert Bos; et al. <a href="http://www.w3.org/TR/CSS2">Cascading Style Sheets Level 2 Revision 1 (CSS 2.1) Specification</a>. 7 June 2011. REC. URL: <a href="http://www.w3.org/TR/CSS2">http://www.w3.org/TR/CSS2</a>
-   <dt id="biblio-dom4"><a class="self-link" href="#biblio-dom4"></a>[DOM4]
-   <dd>Anne van Kesteren; et al. <a href="http://www.w3.org/TR/dom/">W3C DOM4</a>. 19 November 2015. REC. URL: <a href="http://www.w3.org/TR/dom/">http://www.w3.org/TR/dom/</a>
-   <dt id="biblio-dww95"><a class="self-link" href="#biblio-dww95"></a>[DWW95]
+   <dt id="biblio-css2">[CSS2]
+   <dd>Bert Bos; et al. <a href="https://www.w3.org/TR/CSS2">Cascading Style Sheets Level 2 Revision 1 (CSS 2.1) Specification</a>. 7 June 2011. REC. URL: <a href="https://www.w3.org/TR/CSS2">https://www.w3.org/TR/CSS2</a>
+   <dt id="biblio-dww95">[DWW95]
    <dd>N. Kano. Developing International Software for Windows 95 and Windows NT: A Handbook for International Software Design. 1995. 
-   <dt id="biblio-editing"><a class="self-link" href="#biblio-editing"></a>[EDITING]
-   <dd><cite><a href="https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html">HTML Editing APIs</a></cite>, A. Gregor. W3C Editing APIs CG.
-   <dt id="biblio-pcre"><a class="self-link" href="#biblio-pcre"></a>[PCRE]
+   <dt id="biblio-editing">[Editing]
+   <dd>A. Gregor. <a href="https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html">HTML Editing APIs</a>. URL: <a href="https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html">https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html</a>
+   <dt id="biblio-html40">[HTML40]
+   <dd>Dave Raggett; Arnaud Le Hors; Ian Jacobs. <a href="https://www.w3.org/TR/html40">HTML 4.0 Recommendation</a>. 24 April 1998. REC. URL: <a href="https://www.w3.org/TR/html40">https://www.w3.org/TR/html40</a>
+   <dt id="biblio-pcre">[PCRE]
    <dd><a href="http://www.pcre.org/">Perl Compatible Regular Expressions library</a>. URL: <a href="http://www.pcre.org/">http://www.pcre.org/</a>
-   <dt id="biblio-uaag20"><a class="self-link" href="#biblio-uaag20"></a>[UAAG20]
-   <dd>James Allan; et al. <a href="http://www.w3.org/TR/UAAG20/">User Agent Accessibility Guidelines (UAAG) 2.0</a>. 15 December 2015. NOTE. URL: <a href="http://www.w3.org/TR/UAAG20/">http://www.w3.org/TR/UAAG20/</a>
-   <dt id="biblio-uax15"><a class="self-link" href="#biblio-uax15"></a>[UAX15]
-   <dd>Mark Davis; Ken Whistler. <a href="http://www.unicode.org/reports/tr15">Unicode Normalization Forms</a>. 31 August 2012. Unicode Standard Annex #15. URL: <a href="http://www.unicode.org/reports/tr15">http://www.unicode.org/reports/tr15</a>
-   <dt id="biblio-unicode"><a class="self-link" href="#biblio-unicode"></a>[UNICODE]
-   <dd><a href="http://www.unicode.org/versions/latest/">The Unicode Standard</a>. URL: <a href="http://www.unicode.org/versions/latest/">http://www.unicode.org/versions/latest/</a>
-   <dt id="biblio-us-ascii"><a class="self-link" href="#biblio-us-ascii"></a>[US-ASCII]
-   <dd>Coded Character Set - 7-Bit American Standard Code for Information Interchange. 1986. 
-   <dt id="biblio-win1252"><a class="self-link" href="#biblio-win1252"></a>[WIN1252]
-   <dd><a href="http://www.microsoft.com/globaldev/reference/sbcs/1252.htm">Windows 1252 a Coded Character Set - 8-Bit</a>. URL: <a href="http://www.microsoft.com/globaldev/reference/sbcs/1252.htm">http://www.microsoft.com/globaldev/reference/sbcs/1252.htm</a>
-   <dt id="biblio-webidl"><a class="self-link" href="#biblio-webidl"></a>[WebIDL]
-   <dd>Cameron McCormack; Boris Zbarsky. <a href="http://www.w3.org/TR/WebIDL-1/">WebIDL Level 1</a>. 4 August 2015. WD. URL: <a href="http://www.w3.org/TR/WebIDL-1/">http://www.w3.org/TR/WebIDL-1/</a>
-   <dt id="biblio-html40"><a class="self-link" href="#biblio-html40"></a>[HTML40]
-   <dd>Dave Raggett; Arnaud Le Hors; Ian Jacobs. <a href="http://www.w3.org/TR/html40">HTML 4.0 Recommendation</a>. 24 April 1998. REC. URL: <a href="http://www.w3.org/TR/html40">http://www.w3.org/TR/html40</a>
-   <dt id="biblio-rfc20"><a class="self-link" href="#biblio-rfc20"></a>[RFC20]
+   <dt id="biblio-rfc20">[RFC20]
    <dd>V.G. Cerf. <a href="https://tools.ietf.org/html/rfc20">ASCII format for network interchange</a>. October 1969. Internet Standard. URL: <a href="https://tools.ietf.org/html/rfc20">https://tools.ietf.org/html/rfc20</a>
-   <dt id="biblio-xforms"><a class="self-link" href="#biblio-xforms"></a>[XFORMS]
-   <dd>John Boyer. <a href="http://www.w3.org/TR/xforms/">XForms 1.0 (Third Edition)</a>. 29 October 2007. REC. URL: <a href="http://www.w3.org/TR/xforms/">http://www.w3.org/TR/xforms/</a>
-   <dt id="biblio-xml"><a class="self-link" href="#biblio-xml"></a>[XML]
-   <dd>Tim Bray; et al. <a href="http://www.w3.org/TR/xml">Extensible Markup Language (XML) 1.0 (Fifth Edition)</a>. 26 November 2008. REC. URL: <a href="http://www.w3.org/TR/xml">http://www.w3.org/TR/xml</a>
-   <dt id="biblio-xml-names11"><a class="self-link" href="#biblio-xml-names11"></a>[XML-NAMES11]
-   <dd>Tim Bray; et al. <a href="http://www.w3.org/TR/xml-names11/">Namespaces in XML 1.1 (Second Edition)</a>. 16 August 2006. REC. URL: <a href="http://www.w3.org/TR/xml-names11/">http://www.w3.org/TR/xml-names11/</a>
+   <dt id="biblio-uaag20">[UAAG20]
+   <dd>James Allan; et al. <a href="https://www.w3.org/TR/UAAG20/">User Agent Accessibility Guidelines (UAAG) 2.0</a>. 15 December 2015. NOTE. URL: <a href="https://www.w3.org/TR/UAAG20/">https://www.w3.org/TR/UAAG20/</a>
+   <dt id="biblio-uax15">[UAX15]
+   <dd>Mark Davis; Ken Whistler. <a href="http://www.unicode.org/reports/tr15">Unicode Normalization Forms</a>. 31 August 2012. Unicode Standard Annex #15. URL: <a href="http://www.unicode.org/reports/tr15">http://www.unicode.org/reports/tr15</a>
+   <dt id="biblio-unicode">[Unicode]
+   <dd><a href="http://www.unicode.org/versions/latest/">The Unicode Standard</a>. URL: <a href="http://www.unicode.org/versions/latest/">http://www.unicode.org/versions/latest/</a>
+   <dt id="biblio-us-ascii">[US-ASCII]
+   <dd>Coded Character Set - 7-Bit American Standard Code for Information Interchange. 1986. 
+   <dt id="biblio-webidl">[WebIDL]
+   <dd>Cameron McCormack; Boris Zbarsky. <a href="https://www.w3.org/TR/WebIDL-1/">WebIDL Level 1</a>. 8 March 2016. CR. URL: <a href="https://www.w3.org/TR/WebIDL-1/">https://www.w3.org/TR/WebIDL-1/</a>
+   <dt id="biblio-win1252">[WIN1252]
+   <dd><a href="http://www.microsoft.com/globaldev/reference/sbcs/1252.htm">Windows 1252 a Coded Character Set - 8-Bit</a>. URL: <a href="http://www.microsoft.com/globaldev/reference/sbcs/1252.htm">http://www.microsoft.com/globaldev/reference/sbcs/1252.htm</a>
+   <dt id="biblio-xforms">[XFORMS]
+   <dd>John Boyer. <a href="https://www.w3.org/TR/xforms/">XForms 1.0 (Third Edition)</a>. 29 October 2007. REC. URL: <a href="https://www.w3.org/TR/xforms/">https://www.w3.org/TR/xforms/</a>
+   <dt id="biblio-xml">[XML]
+   <dd>Tim Bray; et al. <a href="https://www.w3.org/TR/xml">Extensible Markup Language (XML) 1.0 (Fifth Edition)</a>. 26 November 2008. REC. URL: <a href="https://www.w3.org/TR/xml">https://www.w3.org/TR/xml</a>
+   <dt id="biblio-xml-names11">[XML-Names11]
+   <dd>Tim Bray; et al. <a href="https://www.w3.org/TR/xml-names11/">Namespaces in XML 1.1 (Second Edition)</a>. 16 August 2006. REC. URL: <a href="https://www.w3.org/TR/xml-names11/">https://www.w3.org/TR/xml-names11/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl def">[<a href="#dom-uievent-uievent">Constructor</a>(DOMString <a href="#dom-uievent-uievent-type-eventinitdict-type">type</a>, optional <a data-link-type="idl-name" href="#dictdef-uieventinit-uieventinit">UIEventInit</a> <a href="#dom-uievent-uievent-type-eventinitdict-eventinitdict">eventInitDict</a>)]
-interface <a href="#uievent-uievent">UIEvent</a> : <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event">Event</a> {
-  readonly attribute <a data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a>? <a data-readonly="" data-type="Window? " href="#dom-uievent-view">view</a>;
-  readonly attribute long <a data-readonly="" data-type="long " href="#dom-uievent-detail">detail</a>;
+<pre class="idl def">[<a class="nv" href="#dom-uievent-uievent">Constructor</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-uievent-uievent-type-eventinitdict-type">type</a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit-uieventinit">UIEventInit</a> <a class="nv" href="#dom-uievent-uievent-type-eventinitdict-eventinitdict">eventInitDict</a>)]
+<span class="kt">interface</span> <a class="nv" href="#uievent-uievent">UIEvent</a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event">Event</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a>? <a class="nv" data-readonly="" data-type="Window?" href="#dom-uievent-view">view</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">long</span> <a class="nv" data-readonly="" data-type="long" href="#dom-uievent-detail">detail</a>;
 };
 
-dictionary <a href="#dictdef-uieventinit-uieventinit">UIEventInit</a> : <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit">EventInit</a> {
-  <a data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a>? <a data-default="null" data-type="Window? " href="#dom-uieventinit-view">view</a> = null;
-  long <a data-default="0" data-type="long " href="#dom-uieventinit-detail">detail</a> = 0;
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-uieventinit-uieventinit">UIEventInit</a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit">EventInit</a> {
+  <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a>? <a class="nv" data-default="null" data-type="Window? " href="#dom-uieventinit-view">view</a> = <span class="kt">null</span>;
+  <span class="kt">long</span> <a class="nv" data-default="0" data-type="long " href="#dom-uieventinit-detail">detail</a> = 0;
 };
 
-[<a href="#dom-focusevent-focusevent">Constructor</a>(DOMString <a href="#dom-focusevent-focusevent-type-eventinitdict-type">type</a>, optional <a data-link-type="idl-name" href="#dictdef-focuseventinit">FocusEventInit</a> <a href="#dom-focusevent-focusevent-type-eventinitdict-eventinitdict">eventInitDict</a>)]
-interface <a href="#focusevent">FocusEvent</a> : <a data-link-type="idl-name" href="#uievent-uievent">UIEvent</a> {
-  readonly attribute <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <a data-readonly="" data-type="EventTarget? " href="#dom-focusevent-relatedtarget">relatedTarget</a>;
+[<a class="nv" href="#dom-focusevent-focusevent">Constructor</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-focusevent-focusevent-type-eventinitdict-type">type</a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-focuseventinit">FocusEventInit</a> <a class="nv" href="#dom-focusevent-focusevent-type-eventinitdict-eventinitdict">eventInitDict</a>)]
+<span class="kt">interface</span> <a class="nv" href="#focusevent">FocusEvent</a> : <a class="n" data-link-type="idl-name" href="#uievent-uievent">UIEvent</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <a class="nv" data-readonly="" data-type="EventTarget?" href="#dom-focusevent-relatedtarget">relatedTarget</a>;
 };
 
-dictionary <a href="#dictdef-focuseventinit">FocusEventInit</a> : <a data-link-type="idl-name" href="#dictdef-uieventinit-uieventinit">UIEventInit</a> {
-  <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <a data-default="null" data-type="EventTarget? " href="#dom-focuseventinit-relatedtarget">relatedTarget</a> = null;
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-focuseventinit">FocusEventInit</a> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit-uieventinit">UIEventInit</a> {
+  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <a class="nv" data-default="null" data-type="EventTarget? " href="#dom-focuseventinit-relatedtarget">relatedTarget</a> = <span class="kt">null</span>;
 };
 
-[<a href="#dom-mouseevent-mouseevent">Constructor</a>(DOMString <a href="#dom-mouseevent-mouseevent-type-eventinitdict-type">type</a>, optional <a data-link-type="idl-name" href="https://drafts.csswg.org/cssom-view-1/#dictdef-mouseeventinit">MouseEventInit</a> <a href="#dom-mouseevent-mouseevent-type-eventinitdict-eventinitdict">eventInitDict</a>)]
-interface <a href="#mouseevent">MouseEvent</a> : <a data-link-type="idl-name" href="#uievent-uievent">UIEvent</a> {
-  readonly attribute long <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="long " href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screenx">screenX</a>;
-  readonly attribute long <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="long " href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-screeny">screenY</a>;
-  readonly attribute long <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="long " href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clientx">clientX</a>;
-  readonly attribute long <a class="idl-code" data-link-type="attribute" data-readonly="" data-type="long " href="https://drafts.csswg.org/cssom-view-1/#dom-mouseevent-clienty">clientY</a>;
+[<a class="nv" href="#dom-mouseevent-mouseevent">Constructor</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-mouseevent-mouseevent-type-eventinitdict-type">type</a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/cssom-view/#dictdef-mouseeventinit">MouseEventInit</a> <a class="nv" href="#dom-mouseevent-mouseevent-type-eventinitdict-eventinitdict">eventInitDict</a>)]
+<span class="kt">interface</span> <a class="nv" href="#mouseevent">MouseEvent</a> : <a class="n" data-link-type="idl-name" href="#uievent-uievent">UIEvent</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screenx">screenX</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-screeny">screenY</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clientx">clientX</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="https://www.w3.org/TR/cssom-view/#dom-mouseevent-clienty">clientY</a>;
 
-  readonly attribute boolean <a data-readonly="" data-type="boolean " href="#dom-mouseevent-ctrlkey">ctrlKey</a>;
-  readonly attribute boolean <a data-readonly="" data-type="boolean " href="#dom-mouseevent-shiftkey">shiftKey</a>;
-  readonly attribute boolean <a data-readonly="" data-type="boolean " href="#dom-mouseevent-altkey">altKey</a>;
-  readonly attribute boolean <a data-readonly="" data-type="boolean " href="#dom-mouseevent-metakey">metaKey</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv" data-readonly="" data-type="boolean" href="#dom-mouseevent-ctrlkey">ctrlKey</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv" data-readonly="" data-type="boolean" href="#dom-mouseevent-shiftkey">shiftKey</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv" data-readonly="" data-type="boolean" href="#dom-mouseevent-altkey">altKey</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv" data-readonly="" data-type="boolean" href="#dom-mouseevent-metakey">metaKey</a>;
 
-  readonly attribute short <a data-readonly="" data-type="short " href="#dom-mouseevent-button">button</a>;
-  readonly attribute unsigned short <a data-readonly="" data-type="unsigned short " href="#dom-mouseevent-buttons">buttons</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">short</span> <a class="nv" data-readonly="" data-type="short" href="#dom-mouseevent-button">button</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv" data-readonly="" data-type="unsigned short" href="#dom-mouseevent-buttons">buttons</a>;
 
-  readonly attribute <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <a data-readonly="" data-type="EventTarget? " href="#dom-mouseevent-relatedtarget">relatedTarget</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <a class="nv" data-readonly="" data-type="EventTarget?" href="#dom-mouseevent-relatedtarget">relatedTarget</a>;
 
-  boolean <a href="#dom-mouseevent-getmodifierstate">getModifierState</a>(DOMString <a href="#dom-mouseevent-getmodifierstate-keyarg-keyarg">keyArg</a>);
+  <span class="kt">boolean</span> <a class="nv" href="#dom-mouseevent-getmodifierstate">getModifierState</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-mouseevent-getmodifierstate-keyarg-keyarg">keyArg</a>);
 };
 
-dictionary <a class="idl-code" data-link-type="dictionary" href="https://drafts.csswg.org/cssom-view-1/#dictdef-mouseeventinit">MouseEventInit</a> : <a data-link-type="idl-name" href="#dictdef-eventmodifierinit">EventModifierInit</a> {
-  long <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="https://drafts.csswg.org/cssom-view-1/#dom-mouseeventinit-screenx">screenX</a> = 0;
-  long <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="https://drafts.csswg.org/cssom-view-1/#dom-mouseeventinit-screeny">screenY</a> = 0;
-  long <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="https://drafts.csswg.org/cssom-view-1/#dom-mouseeventinit-clientx">clientX</a> = 0;
-  long <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="https://drafts.csswg.org/cssom-view-1/#dom-mouseeventinit-clienty">clientY</a> = 0;
+<span class="kt">dictionary</span> <a class="nv idl-code" data-link-type="dictionary" href="https://www.w3.org/TR/cssom-view/#dictdef-mouseeventinit">MouseEventInit</a> : <a class="n" data-link-type="idl-name" href="#dictdef-eventmodifierinit">EventModifierInit</a> {
+  <span class="kt">long</span> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="https://www.w3.org/TR/cssom-view/#dom-mouseeventinit-screenx">screenX</a> = 0;
+  <span class="kt">long</span> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="https://www.w3.org/TR/cssom-view/#dom-mouseeventinit-screeny">screenY</a> = 0;
+  <span class="kt">long</span> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="https://www.w3.org/TR/cssom-view/#dom-mouseeventinit-clientx">clientX</a> = 0;
+  <span class="kt">long</span> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="https://www.w3.org/TR/cssom-view/#dom-mouseeventinit-clienty">clientY</a> = 0;
 
-  short <a data-default="0" data-type="short " href="#dom-mouseeventinit-button">button</a> = 0;
-  unsigned short <a data-default="0" data-type="unsigned short " href="#dom-mouseeventinit-buttons">buttons</a> = 0;
-  <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <a data-default="null" data-type="EventTarget? " href="#dom-mouseeventinit-relatedtarget">relatedTarget</a> = null;
+  <span class="kt">short</span> <a class="nv" data-default="0" data-type="short " href="#dom-mouseeventinit-button">button</a> = 0;
+  <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv" data-default="0" data-type="unsigned short " href="#dom-mouseeventinit-buttons">buttons</a> = 0;
+  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <a class="nv" data-default="null" data-type="EventTarget? " href="#dom-mouseeventinit-relatedtarget">relatedTarget</a> = <span class="kt">null</span>;
 };
 
-dictionary <a href="#dictdef-eventmodifierinit">EventModifierInit</a> : <a data-link-type="idl-name" href="#dictdef-uieventinit-uieventinit">UIEventInit</a> {
-  boolean <a data-default="false" data-type="boolean " href="#dom-eventmodifierinit-ctrlkey">ctrlKey</a> = false;
-  boolean <a data-default="false" data-type="boolean " href="#dom-eventmodifierinit-shiftkey">shiftKey</a> = false;
-  boolean <a data-default="false" data-type="boolean " href="#dom-eventmodifierinit-altkey">altKey</a> = false;
-  boolean <a data-default="false" data-type="boolean " href="#dom-eventmodifierinit-metakey">metaKey</a> = false;
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-eventmodifierinit">EventModifierInit</a> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit-uieventinit">UIEventInit</a> {
+  <span class="kt">boolean</span> <a class="nv" data-default="false" data-type="boolean " href="#dom-eventmodifierinit-ctrlkey">ctrlKey</a> = <span class="kt">false</span>;
+  <span class="kt">boolean</span> <a class="nv" data-default="false" data-type="boolean " href="#dom-eventmodifierinit-shiftkey">shiftKey</a> = <span class="kt">false</span>;
+  <span class="kt">boolean</span> <a class="nv" data-default="false" data-type="boolean " href="#dom-eventmodifierinit-altkey">altKey</a> = <span class="kt">false</span>;
+  <span class="kt">boolean</span> <a class="nv" data-default="false" data-type="boolean " href="#dom-eventmodifierinit-metakey">metaKey</a> = <span class="kt">false</span>;
 
-  boolean <a data-default="false" data-type="boolean " href="#dom-eventmodifierinit-modifieraltgraph">modifierAltGraph</a> = false;
-  boolean <a data-default="false" data-type="boolean " href="#dom-eventmodifierinit-modifiercapslock">modifierCapsLock</a> = false;
-  boolean <a data-default="false" data-type="boolean " href="#dom-eventmodifierinit-modifierfn">modifierFn</a> = false;
-  boolean <a data-default="false" data-type="boolean " href="#dom-eventmodifierinit-modifierfnlock">modifierFnLock</a> = false;
-  boolean <a data-default="false" data-type="boolean " href="#dom-eventmodifierinit-modifierhyper">modifierHyper</a> = false;
-  boolean <a data-default="false" data-type="boolean " href="#dom-eventmodifierinit-modifiernumlock">modifierNumLock</a> = false;
-  boolean <a data-default="false" data-type="boolean " href="#dom-eventmodifierinit-modifierscrolllock">modifierScrollLock</a> = false;
-  boolean <a data-default="false" data-type="boolean " href="#dom-eventmodifierinit-modifiersuper">modifierSuper</a> = false;
-  boolean <a data-default="false" data-type="boolean " href="#dom-eventmodifierinit-modifiersymbol">modifierSymbol</a> = false;
-  boolean <a data-default="false" data-type="boolean " href="#dom-eventmodifierinit-modifiersymbollock">modifierSymbolLock</a> = false;
+  <span class="kt">boolean</span> <a class="nv" data-default="false" data-type="boolean " href="#dom-eventmodifierinit-modifieraltgraph">modifierAltGraph</a> = <span class="kt">false</span>;
+  <span class="kt">boolean</span> <a class="nv" data-default="false" data-type="boolean " href="#dom-eventmodifierinit-modifiercapslock">modifierCapsLock</a> = <span class="kt">false</span>;
+  <span class="kt">boolean</span> <a class="nv" data-default="false" data-type="boolean " href="#dom-eventmodifierinit-modifierfn">modifierFn</a> = <span class="kt">false</span>;
+  <span class="kt">boolean</span> <a class="nv" data-default="false" data-type="boolean " href="#dom-eventmodifierinit-modifierfnlock">modifierFnLock</a> = <span class="kt">false</span>;
+  <span class="kt">boolean</span> <a class="nv" data-default="false" data-type="boolean " href="#dom-eventmodifierinit-modifierhyper">modifierHyper</a> = <span class="kt">false</span>;
+  <span class="kt">boolean</span> <a class="nv" data-default="false" data-type="boolean " href="#dom-eventmodifierinit-modifiernumlock">modifierNumLock</a> = <span class="kt">false</span>;
+  <span class="kt">boolean</span> <a class="nv" data-default="false" data-type="boolean " href="#dom-eventmodifierinit-modifierscrolllock">modifierScrollLock</a> = <span class="kt">false</span>;
+  <span class="kt">boolean</span> <a class="nv" data-default="false" data-type="boolean " href="#dom-eventmodifierinit-modifiersuper">modifierSuper</a> = <span class="kt">false</span>;
+  <span class="kt">boolean</span> <a class="nv" data-default="false" data-type="boolean " href="#dom-eventmodifierinit-modifiersymbol">modifierSymbol</a> = <span class="kt">false</span>;
+  <span class="kt">boolean</span> <a class="nv" data-default="false" data-type="boolean " href="#dom-eventmodifierinit-modifiersymbollock">modifierSymbolLock</a> = <span class="kt">false</span>;
 };
 
-[<a href="#dom-wheelevent-wheelevent">Constructor</a>(DOMString <a href="#dom-wheelevent-wheelevent-type-eventinitdict-type">type</a>, optional <a data-link-type="idl-name" href="#dictdef-wheeleventinit">WheelEventInit</a> <a href="#dom-wheelevent-wheelevent-type-eventinitdict-eventinitdict">eventInitDict</a>)]
-interface <a href="#wheelevent">WheelEvent</a> : <a data-link-type="idl-name" href="#mouseevent">MouseEvent</a> {
+[<a class="nv" href="#dom-wheelevent-wheelevent">Constructor</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-wheelevent-wheelevent-type-eventinitdict-type">type</a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-wheeleventinit">WheelEventInit</a> <a class="nv" href="#dom-wheelevent-wheelevent-type-eventinitdict-eventinitdict">eventInitDict</a>)]
+<span class="kt">interface</span> <a class="nv" href="#wheelevent">WheelEvent</a> : <a class="n" data-link-type="idl-name" href="#mouseevent">MouseEvent</a> {
   // DeltaModeCode
-  const unsigned long <a href="#dom-wheelevent-dom_delta_pixel">DOM_DELTA_PIXEL</a> = 0x00;
-  const unsigned long <a href="#dom-wheelevent-dom_delta_line">DOM_DELTA_LINE</a>  = 0x01;
-  const unsigned long <a href="#dom-wheelevent-dom_delta_page">DOM_DELTA_PAGE</a>  = 0x02;
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv" href="#dom-wheelevent-dom_delta_pixel">DOM_DELTA_PIXEL</a> = 0x00;
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv" href="#dom-wheelevent-dom_delta_line">DOM_DELTA_LINE</a>  = 0x01;
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv" href="#dom-wheelevent-dom_delta_page">DOM_DELTA_PAGE</a>  = 0x02;
 
-  readonly attribute double <a data-readonly="" data-type="double " href="#dom-wheelevent-deltax">deltaX</a>;
-  readonly attribute double <a data-readonly="" data-type="double " href="#dom-wheelevent-deltay">deltaY</a>;
-  readonly attribute double <a data-readonly="" data-type="double " href="#dom-wheelevent-deltaz">deltaZ</a>;
-  readonly attribute unsigned long <a data-readonly="" data-type="unsigned long " href="#dom-wheelevent-deltamode">deltaMode</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">double</span> <a class="nv" data-readonly="" data-type="double" href="#dom-wheelevent-deltax">deltaX</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">double</span> <a class="nv" data-readonly="" data-type="double" href="#dom-wheelevent-deltay">deltaY</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">double</span> <a class="nv" data-readonly="" data-type="double" href="#dom-wheelevent-deltaz">deltaZ</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv" data-readonly="" data-type="unsigned long" href="#dom-wheelevent-deltamode">deltaMode</a>;
 };
 
-dictionary <a href="#dictdef-wheeleventinit">WheelEventInit</a> : <a data-link-type="idl-name" href="https://drafts.csswg.org/cssom-view-1/#dictdef-mouseeventinit">MouseEventInit</a> {
-  double <a data-default="0.0" data-type="double " href="#dom-wheeleventinit-deltax">deltaX</a> = 0.0;
-  double <a data-default="0.0" data-type="double " href="#dom-wheeleventinit-deltay">deltaY</a> = 0.0;
-  double <a data-default="0.0" data-type="double " href="#dom-wheeleventinit-deltaz">deltaZ</a> = 0.0;
-  unsigned long <a data-default="0" data-type="unsigned long " href="#dom-wheeleventinit-deltamode">deltaMode</a> = 0;
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-wheeleventinit">WheelEventInit</a> : <a class="n" data-link-type="idl-name" href="https://www.w3.org/TR/cssom-view/#dictdef-mouseeventinit">MouseEventInit</a> {
+  <span class="kt">double</span> <a class="nv" data-default="0.0" data-type="double " href="#dom-wheeleventinit-deltax">deltaX</a> = 0.0;
+  <span class="kt">double</span> <a class="nv" data-default="0.0" data-type="double " href="#dom-wheeleventinit-deltay">deltaY</a> = 0.0;
+  <span class="kt">double</span> <a class="nv" data-default="0.0" data-type="double " href="#dom-wheeleventinit-deltaz">deltaZ</a> = 0.0;
+  <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv" data-default="0" data-type="unsigned long " href="#dom-wheeleventinit-deltamode">deltaMode</a> = 0;
 };
 
-[<a href="#dom-inputevent-inputevent">Constructor</a>(DOMString <a href="#dom-inputevent-inputevent-type-eventinitdict-type">type</a>, optional <a data-link-type="idl-name" href="#dictdef-inputeventinit">InputEventInit</a> <a href="#dom-inputevent-inputevent-type-eventinitdict-eventinitdict">eventInitDict</a>)]
-interface <a href="#inputevent">InputEvent</a> : <a data-link-type="idl-name" href="#uievent-uievent">UIEvent</a> {
-  readonly attribute DOMString <a data-readonly="" data-type="DOMString " href="#dom-inputevent-data">data</a>;
-  readonly attribute boolean <a data-readonly="" data-type="boolean " href="#dom-inputevent-iscomposing">isComposing</a>;
+[<a class="nv" href="#dom-inputevent-inputevent">Constructor</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-inputevent-inputevent-type-eventinitdict-type">type</a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-inputeventinit">InputEventInit</a> <a class="nv" href="#dom-inputevent-inputevent-type-eventinitdict-eventinitdict">eventInitDict</a>)]
+<span class="kt">interface</span> <a class="nv" href="#inputevent">InputEvent</a> : <a class="n" data-link-type="idl-name" href="#uievent-uievent">UIEvent</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv" data-readonly="" data-type="DOMString" href="#dom-inputevent-data">data</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv" data-readonly="" data-type="boolean" href="#dom-inputevent-iscomposing">isComposing</a>;
 };
 
-dictionary <a href="#dictdef-inputeventinit">InputEventInit</a> : <a data-link-type="idl-name" href="#dictdef-uieventinit-uieventinit">UIEventInit</a> {
-  DOMString <a data-default="&quot;&quot;" data-type="DOMString " href="#dom-inputeventinit-data">data</a> = "";
-  boolean <a data-default="false" data-type="boolean " href="#dom-inputeventinit-iscomposing">isComposing</a> = false;
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-inputeventinit">InputEventInit</a> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit-uieventinit">UIEventInit</a> {
+  <span class="kt">DOMString</span> <a class="nv" data-default="&quot;&quot;" data-type="DOMString " href="#dom-inputeventinit-data">data</a> = "";
+  <span class="kt">boolean</span> <a class="nv" data-default="false" data-type="boolean " href="#dom-inputeventinit-iscomposing">isComposing</a> = <span class="kt">false</span>;
 };
 
-[<a href="#dom-keyboardevent-keyboardevent">Constructor</a>(DOMString <a href="#dom-keyboardevent-keyboardevent-type-eventinitdict-type">type</a>, optional <a data-link-type="idl-name" href="#dictdef-keyboardeventinit">KeyboardEventInit</a> <a href="#dom-keyboardevent-keyboardevent-type-eventinitdict-eventinitdict">eventInitDict</a>)]
-interface <a href="#keyboardevent-keyboardevent">KeyboardEvent</a> : <a data-link-type="idl-name" href="#uievent-uievent">UIEvent</a> {
+[<a class="nv" href="#dom-keyboardevent-keyboardevent">Constructor</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-keyboardevent-keyboardevent-type-eventinitdict-type">type</a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-keyboardeventinit">KeyboardEventInit</a> <a class="nv" href="#dom-keyboardevent-keyboardevent-type-eventinitdict-eventinitdict">eventInitDict</a>)]
+<span class="kt">interface</span> <a class="nv" href="#keyboardevent-keyboardevent">KeyboardEvent</a> : <a class="n" data-link-type="idl-name" href="#uievent-uievent">UIEvent</a> {
   // KeyLocationCode
-  const unsigned long <a href="#dom-keyboardevent-dom_key_location_standard">DOM_KEY_LOCATION_STANDARD</a> = 0x00;
-  const unsigned long <a href="#dom-keyboardevent-dom_key_location_left">DOM_KEY_LOCATION_LEFT</a> = 0x01;
-  const unsigned long <a href="#dom-keyboardevent-dom_key_location_right">DOM_KEY_LOCATION_RIGHT</a> = 0x02;
-  const unsigned long <a href="#dom-keyboardevent-dom_key_location_numpad">DOM_KEY_LOCATION_NUMPAD</a> = 0x03;
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv" href="#dom-keyboardevent-dom_key_location_standard">DOM_KEY_LOCATION_STANDARD</a> = 0x00;
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv" href="#dom-keyboardevent-dom_key_location_left">DOM_KEY_LOCATION_LEFT</a> = 0x01;
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv" href="#dom-keyboardevent-dom_key_location_right">DOM_KEY_LOCATION_RIGHT</a> = 0x02;
+  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv" href="#dom-keyboardevent-dom_key_location_numpad">DOM_KEY_LOCATION_NUMPAD</a> = 0x03;
 
-  readonly attribute DOMString <a data-readonly="" data-type="DOMString " href="#dom-keyboardevent-key">key</a>;
-  readonly attribute DOMString <a data-readonly="" data-type="DOMString " href="#dom-keyboardevent-code">code</a>;
-  readonly attribute unsigned long <a data-readonly="" data-type="unsigned long " href="#dom-keyboardevent-location">location</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv" data-readonly="" data-type="DOMString" href="#dom-keyboardevent-key">key</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv" data-readonly="" data-type="DOMString" href="#dom-keyboardevent-code">code</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv" data-readonly="" data-type="unsigned long" href="#dom-keyboardevent-location">location</a>;
 
-  readonly attribute boolean <a data-readonly="" data-type="boolean " href="#dom-keyboardevent-ctrlkey">ctrlKey</a>;
-  readonly attribute boolean <a data-readonly="" data-type="boolean " href="#dom-keyboardevent-shiftkey">shiftKey</a>;
-  readonly attribute boolean <a data-readonly="" data-type="boolean " href="#dom-keyboardevent-altkey">altKey</a>;
-  readonly attribute boolean <a data-readonly="" data-type="boolean " href="#dom-keyboardevent-metakey">metaKey</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv" data-readonly="" data-type="boolean" href="#dom-keyboardevent-ctrlkey">ctrlKey</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv" data-readonly="" data-type="boolean" href="#dom-keyboardevent-shiftkey">shiftKey</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv" data-readonly="" data-type="boolean" href="#dom-keyboardevent-altkey">altKey</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv" data-readonly="" data-type="boolean" href="#dom-keyboardevent-metakey">metaKey</a>;
 
-  readonly attribute boolean <a data-readonly="" data-type="boolean " href="#dom-keyboardevent-repeat">repeat</a>;
-  readonly attribute boolean <a data-readonly="" data-type="boolean " href="#dom-keyboardevent-iscomposing">isComposing</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv" data-readonly="" data-type="boolean" href="#dom-keyboardevent-repeat">repeat</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv" data-readonly="" data-type="boolean" href="#dom-keyboardevent-iscomposing">isComposing</a>;
 
-  boolean <a href="#dom-keyboardevent-getmodifierstate">getModifierState</a>(DOMString <a href="#dom-keyboardevent-getmodifierstate-keyarg-keyarg">keyArg</a>);
+  <span class="kt">boolean</span> <a class="nv" href="#dom-keyboardevent-getmodifierstate">getModifierState</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-keyboardevent-getmodifierstate-keyarg-keyarg">keyArg</a>);
 };
 
-dictionary <a href="#dictdef-keyboardeventinit">KeyboardEventInit</a> : <a data-link-type="idl-name" href="#dictdef-eventmodifierinit">EventModifierInit</a> {
-  DOMString <a data-default="&quot;&quot;" data-type="DOMString " href="#dom-keyboardeventinit-key">key</a> = "";
-  DOMString <a data-default="&quot;&quot;" data-type="DOMString " href="#dom-keyboardeventinit-code">code</a> = "";
-  unsigned long <a data-default="0" data-type="unsigned long " href="#dom-keyboardeventinit-location">location</a> = 0;
-  boolean <a data-default="false" data-type="boolean " href="#dom-keyboardeventinit-repeat">repeat</a> = false;
-  boolean <a data-default="false" data-type="boolean " href="#dom-keyboardeventinit-iscomposing">isComposing</a> = false;
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-keyboardeventinit">KeyboardEventInit</a> : <a class="n" data-link-type="idl-name" href="#dictdef-eventmodifierinit">EventModifierInit</a> {
+  <span class="kt">DOMString</span> <a class="nv" data-default="&quot;&quot;" data-type="DOMString " href="#dom-keyboardeventinit-key">key</a> = "";
+  <span class="kt">DOMString</span> <a class="nv" data-default="&quot;&quot;" data-type="DOMString " href="#dom-keyboardeventinit-code">code</a> = "";
+  <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv" data-default="0" data-type="unsigned long " href="#dom-keyboardeventinit-location">location</a> = 0;
+  <span class="kt">boolean</span> <a class="nv" data-default="false" data-type="boolean " href="#dom-keyboardeventinit-repeat">repeat</a> = <span class="kt">false</span>;
+  <span class="kt">boolean</span> <a class="nv" data-default="false" data-type="boolean " href="#dom-keyboardeventinit-iscomposing">isComposing</a> = <span class="kt">false</span>;
 };
 
-[<a href="#dom-compositionevent-compositionevent">Constructor</a>(DOMString <a href="#dom-compositionevent-compositionevent-type-eventinitdict-type">type</a>, optional <a data-link-type="idl-name" href="#dictdef-compositioneventinit">CompositionEventInit</a> <a href="#dom-compositionevent-compositionevent-type-eventinitdict-eventinitdict">eventInitDict</a>)]
-interface <a href="#compositionevent">CompositionEvent</a> : <a data-link-type="idl-name" href="#uievent-uievent">UIEvent</a> {
-  readonly attribute DOMString <a data-readonly="" data-type="DOMString " href="#dom-compositionevent-data">data</a>;
+[<a class="nv" href="#dom-compositionevent-compositionevent">Constructor</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-compositionevent-compositionevent-type-eventinitdict-type">type</a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-compositioneventinit">CompositionEventInit</a> <a class="nv" href="#dom-compositionevent-compositionevent-type-eventinitdict-eventinitdict">eventInitDict</a>)]
+<span class="kt">interface</span> <a class="nv" href="#compositionevent">CompositionEvent</a> : <a class="n" data-link-type="idl-name" href="#uievent-uievent">UIEvent</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv" data-readonly="" data-type="DOMString" href="#dom-compositionevent-data">data</a>;
 };
 
-dictionary <a href="#dictdef-compositioneventinit">CompositionEventInit</a> : <a data-link-type="idl-name" href="#dictdef-uieventinit-uieventinit">UIEventInit</a> {
-  DOMString <a data-default="&quot;&quot;" data-type="DOMString " href="#dom-compositioneventinit-data">data</a> = "";
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-compositioneventinit">CompositionEventInit</a> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit-uieventinit">UIEventInit</a> {
+  <span class="kt">DOMString</span> <a class="nv" data-default="&quot;&quot;" data-type="DOMString " href="#dom-compositioneventinit-data">data</a> = "";
 };
 
-partial interface <a class="idl-code" data-link-type="interface" href="#keyboardevent-keyboardevent">KeyboardEvent</a> {
+<span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="#keyboardevent-keyboardevent">KeyboardEvent</a> {
   // The following support legacy user agents
-  readonly attribute unsigned long <a data-readonly="" data-type="unsigned long " href="#dom-keyboardevent-charcode">charCode</a>;
-  readonly attribute unsigned long <a data-readonly="" data-type="unsigned long " href="#dom-keyboardevent-keycode">keyCode</a>;
-  readonly attribute unsigned long <a data-readonly="" data-type="unsigned long " href="#dom-keyboardevent-which">which</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv" data-readonly="" data-type="unsigned long" href="#dom-keyboardevent-charcode">charCode</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv" data-readonly="" data-type="unsigned long" href="#dom-keyboardevent-keycode">keyCode</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv" data-readonly="" data-type="unsigned long" href="#dom-keyboardevent-which">which</a>;
 };
 
 </pre>
-<script>
+  <aside class="dfn-panel" data-for="internal-key-modifier-state">
+   <b><a href="#internal-key-modifier-state">#internal-key-modifier-state</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-internal-key-modifier-state-1">3.6. Constructing Mouse and Keyboard Events</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="modifier-key-name">
+   <b><a href="#modifier-key-name">#modifier-key-name</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-modifier-key-name-1">3.6. Constructing Mouse and Keyboard Events</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="uievent-uievent">
+   <b><a href="#uievent-uievent">#uievent-uievent</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-uievent-uievent-1">5.1.1. Interface UIEvent</a> <a href="#ref-for-uievent-uievent-2">(2)</a>
+    <li><a href="#ref-for-uievent-uievent-3">5.1.2. UI Event Types</a>
+    <li><a href="#ref-for-uievent-uievent-4">5.1.2.1. load</a> <a href="#ref-for-uievent-uievent-5">(2)</a> <a href="#ref-for-uievent-uievent-6">(3)</a>
+    <li><a href="#ref-for-uievent-uievent-7">5.1.2.2. unload</a> <a href="#ref-for-uievent-uievent-8">(2)</a> <a href="#ref-for-uievent-uievent-9">(3)</a>
+    <li><a href="#ref-for-uievent-uievent-10">5.1.2.3. abort</a> <a href="#ref-for-uievent-uievent-11">(2)</a> <a href="#ref-for-uievent-uievent-12">(3)</a>
+    <li><a href="#ref-for-uievent-uievent-13">5.1.2.4. error</a> <a href="#ref-for-uievent-uievent-14">(2)</a> <a href="#ref-for-uievent-uievent-15">(3)</a>
+    <li><a href="#ref-for-uievent-uievent-16">5.1.2.5. select</a> <a href="#ref-for-uievent-uievent-17">(2)</a> <a href="#ref-for-uievent-uievent-18">(3)</a>
+    <li><a href="#ref-for-uievent-uievent-19">5.2.1. Interface FocusEvent</a>
+    <li><a href="#ref-for-uievent-uievent-20">5.2.4.1. blur</a> <a href="#ref-for-uievent-uievent-21">(2)</a>
+    <li><a href="#ref-for-uievent-uievent-22">5.2.4.2. focus</a> <a href="#ref-for-uievent-uievent-23">(2)</a>
+    <li><a href="#ref-for-uievent-uievent-24">5.2.4.3. focusin</a> <a href="#ref-for-uievent-uievent-25">(2)</a>
+    <li><a href="#ref-for-uievent-uievent-26">5.2.4.4. focusout</a> <a href="#ref-for-uievent-uievent-27">(2)</a>
+    <li><a href="#ref-for-uievent-uievent-28">5.3.1. Interface MouseEvent</a>
+    <li><a href="#ref-for-uievent-uievent-29">5.3.4.1. click</a> <a href="#ref-for-uievent-uievent-30">(2)</a>
+    <li><a href="#ref-for-uievent-uievent-31">5.3.4.2. dblclick</a> <a href="#ref-for-uievent-uievent-32">(2)</a>
+    <li><a href="#ref-for-uievent-uievent-33">5.3.4.3. mousedown</a> <a href="#ref-for-uievent-uievent-34">(2)</a>
+    <li><a href="#ref-for-uievent-uievent-35">5.3.4.4. mouseenter</a> <a href="#ref-for-uievent-uievent-36">(2)</a>
+    <li><a href="#ref-for-uievent-uievent-37">5.3.4.5. mouseleave</a> <a href="#ref-for-uievent-uievent-38">(2)</a>
+    <li><a href="#ref-for-uievent-uievent-39">5.3.4.6. mousemove</a> <a href="#ref-for-uievent-uievent-40">(2)</a>
+    <li><a href="#ref-for-uievent-uievent-41">5.3.4.7. mouseout</a> <a href="#ref-for-uievent-uievent-42">(2)</a>
+    <li><a href="#ref-for-uievent-uievent-43">5.3.4.8. mouseover</a> <a href="#ref-for-uievent-uievent-44">(2)</a>
+    <li><a href="#ref-for-uievent-uievent-45">5.3.4.9. mouseup</a> <a href="#ref-for-uievent-uievent-46">(2)</a>
+    <li><a href="#ref-for-uievent-uievent-47">5.4.2.1. wheel</a> <a href="#ref-for-uievent-uievent-48">(2)</a>
+    <li><a href="#ref-for-uievent-uievent-49">5.5.1. Interface InputEvent</a>
+    <li><a href="#ref-for-uievent-uievent-50">5.5.3.1. beforeinput</a> <a href="#ref-for-uievent-uievent-51">(2)</a>
+    <li><a href="#ref-for-uievent-uievent-52">5.5.3.2. input</a> <a href="#ref-for-uievent-uievent-53">(2)</a>
+    <li><a href="#ref-for-uievent-uievent-54">5.6.1. Interface KeyboardEvent</a>
+    <li><a href="#ref-for-uievent-uievent-55">5.6.4.1. keydown</a> <a href="#ref-for-uievent-uievent-56">(2)</a>
+    <li><a href="#ref-for-uievent-uievent-57">5.6.4.2. keyup</a> <a href="#ref-for-uievent-uievent-58">(2)</a>
+    <li><a href="#ref-for-uievent-uievent-59">5.7.1. Interface CompositionEvent</a>
+    <li><a href="#ref-for-uievent-uievent-60">5.7.7.1. compositionstart</a> <a href="#ref-for-uievent-uievent-61">(2)</a>
+    <li><a href="#ref-for-uievent-uievent-62">5.7.7.2. compositionupdate</a> <a href="#ref-for-uievent-uievent-63">(2)</a>
+    <li><a href="#ref-for-uievent-uievent-64">5.7.7.3. compositionend</a> <a href="#ref-for-uievent-uievent-65">(2)</a>
+    <li><a href="#ref-for-uievent-uievent-66">7.1.1. Initializers for interface UIEvent</a>
+    <li><a href="#ref-for-uievent-uievent-67">9. Legacy Event Types</a>
+    <li><a href="#ref-for-uievent-uievent-68">9.1. Legacy UIEvent events</a>
+    <li><a href="#ref-for-uievent-uievent-69">9.1.1. Legacy UIEvent event types</a>
+    <li><a href="#ref-for-uievent-uievent-70">9.1.1.1. DOMActivate</a> <a href="#ref-for-uievent-uievent-71">(2)</a> <a href="#ref-for-uievent-uievent-72">(3)</a>
+    <li><a href="#ref-for-uievent-uievent-73">9.2.1.1. DOMFocusIn</a> <a href="#ref-for-uievent-uievent-74">(2)</a>
+    <li><a href="#ref-for-uievent-uievent-75">9.2.1.2. DOMFocusOut</a> <a href="#ref-for-uievent-uievent-76">(2)</a>
+    <li><a href="#ref-for-uievent-uievent-77">9.3.1.1. keypress</a> <a href="#ref-for-uievent-uievent-78">(2)</a>
+    <li><a href="#ref-for-uievent-uievent-79">12.1. Changes between DOM Level 2 Events and UI Events</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-uievent-view">
+   <b><a href="#dom-uievent-view">#dom-uievent-view</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-uievent-view-1">5.1.2.1. load</a>
+    <li><a href="#ref-for-dom-uievent-view-2">5.1.2.2. unload</a>
+    <li><a href="#ref-for-dom-uievent-view-3">5.1.2.3. abort</a>
+    <li><a href="#ref-for-dom-uievent-view-4">5.1.2.4. error</a>
+    <li><a href="#ref-for-dom-uievent-view-5">5.1.2.5. select</a>
+    <li><a href="#ref-for-dom-uievent-view-6">5.2.4.1. blur</a>
+    <li><a href="#ref-for-dom-uievent-view-7">5.2.4.2. focus</a>
+    <li><a href="#ref-for-dom-uievent-view-8">5.2.4.3. focusin</a>
+    <li><a href="#ref-for-dom-uievent-view-9">5.2.4.4. focusout</a>
+    <li><a href="#ref-for-dom-uievent-view-10">5.3.4.1. click</a>
+    <li><a href="#ref-for-dom-uievent-view-11">5.3.4.2. dblclick</a>
+    <li><a href="#ref-for-dom-uievent-view-12">5.3.4.3. mousedown</a>
+    <li><a href="#ref-for-dom-uievent-view-13">5.3.4.4. mouseenter</a>
+    <li><a href="#ref-for-dom-uievent-view-14">5.3.4.5. mouseleave</a>
+    <li><a href="#ref-for-dom-uievent-view-15">5.3.4.6. mousemove</a>
+    <li><a href="#ref-for-dom-uievent-view-16">5.3.4.7. mouseout</a>
+    <li><a href="#ref-for-dom-uievent-view-17">5.3.4.8. mouseover</a>
+    <li><a href="#ref-for-dom-uievent-view-18">5.3.4.9. mouseup</a>
+    <li><a href="#ref-for-dom-uievent-view-19">5.4.2.1. wheel</a>
+    <li><a href="#ref-for-dom-uievent-view-20">5.5.3.1. beforeinput</a>
+    <li><a href="#ref-for-dom-uievent-view-21">5.5.3.2. input</a>
+    <li><a href="#ref-for-dom-uievent-view-22">5.6.4.1. keydown</a>
+    <li><a href="#ref-for-dom-uievent-view-23">5.6.4.2. keyup</a>
+    <li><a href="#ref-for-dom-uievent-view-24">5.7.7.1. compositionstart</a>
+    <li><a href="#ref-for-dom-uievent-view-25">5.7.7.2. compositionupdate</a>
+    <li><a href="#ref-for-dom-uievent-view-26">5.7.7.3. compositionend</a>
+    <li><a href="#ref-for-dom-uievent-view-27">7.1.1. Initializers for interface UIEvent</a>
+    <li><a href="#ref-for-dom-uievent-view-28">7.1.2. Initializers for interface MouseEvent</a>
+    <li><a href="#ref-for-dom-uievent-view-29">7.1.3. Initializers for interface WheelEvent</a>
+    <li><a href="#ref-for-dom-uievent-view-30">7.1.4. Initializers for interface KeyboardEvent</a>
+    <li><a href="#ref-for-dom-uievent-view-31">7.1.5. Initializers for interface CompositionEvent</a>
+    <li><a href="#ref-for-dom-uievent-view-32">9.1.1.1. DOMActivate</a>
+    <li><a href="#ref-for-dom-uievent-view-33">9.2.1.1. DOMFocusIn</a>
+    <li><a href="#ref-for-dom-uievent-view-34">9.2.1.2. DOMFocusOut</a>
+    <li><a href="#ref-for-dom-uievent-view-35">9.3.1.1. keypress</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-uievent-detail">
+   <b><a href="#dom-uievent-detail">#dom-uievent-detail</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-uievent-detail-1">5.1.2.1. load</a>
+    <li><a href="#ref-for-dom-uievent-detail-2">5.1.2.2. unload</a>
+    <li><a href="#ref-for-dom-uievent-detail-3">5.1.2.3. abort</a>
+    <li><a href="#ref-for-dom-uievent-detail-4">5.1.2.4. error</a>
+    <li><a href="#ref-for-dom-uievent-detail-5">5.1.2.5. select</a>
+    <li><a href="#ref-for-dom-uievent-detail-6">5.2.4.1. blur</a>
+    <li><a href="#ref-for-dom-uievent-detail-7">5.2.4.2. focus</a>
+    <li><a href="#ref-for-dom-uievent-detail-8">5.2.4.3. focusin</a>
+    <li><a href="#ref-for-dom-uievent-detail-9">5.2.4.4. focusout</a>
+    <li><a href="#ref-for-dom-uievent-detail-10">5.3.4.1. click</a>
+    <li><a href="#ref-for-dom-uievent-detail-11">5.3.4.2. dblclick</a>
+    <li><a href="#ref-for-dom-uievent-detail-12">5.3.4.3. mousedown</a> <a href="#ref-for-dom-uievent-detail-13">(2)</a>
+    <li><a href="#ref-for-dom-uievent-detail-14">5.3.4.4. mouseenter</a>
+    <li><a href="#ref-for-dom-uievent-detail-15">5.3.4.5. mouseleave</a>
+    <li><a href="#ref-for-dom-uievent-detail-16">5.3.4.6. mousemove</a>
+    <li><a href="#ref-for-dom-uievent-detail-17">5.3.4.7. mouseout</a>
+    <li><a href="#ref-for-dom-uievent-detail-18">5.3.4.8. mouseover</a>
+    <li><a href="#ref-for-dom-uievent-detail-19">5.3.4.9. mouseup</a>
+    <li><a href="#ref-for-dom-uievent-detail-20">5.4.2.1. wheel</a>
+    <li><a href="#ref-for-dom-uievent-detail-21">5.5.3.1. beforeinput</a>
+    <li><a href="#ref-for-dom-uievent-detail-22">5.5.3.2. input</a>
+    <li><a href="#ref-for-dom-uievent-detail-23">5.6.4.1. keydown</a>
+    <li><a href="#ref-for-dom-uievent-detail-24">5.6.4.2. keyup</a>
+    <li><a href="#ref-for-dom-uievent-detail-25">5.7.7.1. compositionstart</a>
+    <li><a href="#ref-for-dom-uievent-detail-26">5.7.7.2. compositionupdate</a>
+    <li><a href="#ref-for-dom-uievent-detail-27">5.7.7.3. compositionend</a>
+    <li><a href="#ref-for-dom-uievent-detail-28">7.1.1. Initializers for interface UIEvent</a>
+    <li><a href="#ref-for-dom-uievent-detail-29">7.1.2. Initializers for interface MouseEvent</a>
+    <li><a href="#ref-for-dom-uievent-detail-30">7.1.3. Initializers for interface WheelEvent</a>
+    <li><a href="#ref-for-dom-uievent-detail-31">7.1.4. Initializers for interface KeyboardEvent</a>
+    <li><a href="#ref-for-dom-uievent-detail-32">7.1.5. Initializers for interface CompositionEvent</a>
+    <li><a href="#ref-for-dom-uievent-detail-33">9.1.1.1. DOMActivate</a>
+    <li><a href="#ref-for-dom-uievent-detail-34">9.2.1.1. DOMFocusIn</a>
+    <li><a href="#ref-for-dom-uievent-detail-35">9.2.1.2. DOMFocusOut</a>
+    <li><a href="#ref-for-dom-uievent-detail-36">9.3.1.1. keypress</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-uieventinit-uieventinit">
+   <b><a href="#dictdef-uieventinit-uieventinit">#dictdef-uieventinit-uieventinit</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-uieventinit-uieventinit-1">5.1.1. Interface UIEvent</a> <a href="#ref-for-dictdef-uieventinit-uieventinit-2">(2)</a>
+    <li><a href="#ref-for-dictdef-uieventinit-uieventinit-3">5.2.1. Interface FocusEvent</a>
+    <li><a href="#ref-for-dictdef-uieventinit-uieventinit-4">5.3.2. Event Modifier Initializers</a>
+    <li><a href="#ref-for-dictdef-uieventinit-uieventinit-5">5.5.1. Interface InputEvent</a>
+    <li><a href="#ref-for-dictdef-uieventinit-uieventinit-6">5.7.1. Interface CompositionEvent</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="load">
+   <b><a href="#load">#load</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-load-1">3.3. Synchronous and asynchronous events</a>
+    <li><a href="#ref-for-load-2">4.1. List of Event Types</a> <a href="#ref-for-load-3">(2)</a> <a href="#ref-for-load-4">(3)</a> <a href="#ref-for-load-5">(4)</a>
+    <li><a href="#ref-for-load-6">5.1.2.1. load</a>
+    <li><a href="#ref-for-load-7">11. Security Considerations</a> <a href="#ref-for-load-8">(2)</a>
+    <li><a href="#ref-for-load-9">14. Glossary</a> <a href="#ref-for-load-10">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="unload">
+   <b><a href="#unload">#unload</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-unload-1">4.1. List of Event Types</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="abort">
+   <b><a href="#abort">#abort</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-abort-1">4.1. List of Event Types</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="error">
+   <b><a href="#error">#error</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-error-1">4.1. List of Event Types</a>
+    <li><a href="#ref-for-error-2">11. Security Considerations</a> <a href="#ref-for-error-3">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="select">
+   <b><a href="#select">#select</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-select-1">4.1. List of Event Types</a>
+    <li><a href="#ref-for-select-2">5.1.2.5. select</a> <a href="#ref-for-select-3">(2)</a> <a href="#ref-for-select-4">(3)</a> <a href="#ref-for-select-5">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="focusevent">
+   <b><a href="#focusevent">#focusevent</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-focusevent-1">4.1. List of Event Types</a> <a href="#ref-for-focusevent-2">(2)</a> <a href="#ref-for-focusevent-3">(3)</a> <a href="#ref-for-focusevent-4">(4)</a>
+    <li><a href="#ref-for-focusevent-5">5.2.1. Interface FocusEvent</a> <a href="#ref-for-focusevent-6">(2)</a>
+    <li><a href="#ref-for-focusevent-7">5.2.4.1. blur</a> <a href="#ref-for-focusevent-8">(2)</a>
+    <li><a href="#ref-for-focusevent-9">5.2.4.2. focus</a> <a href="#ref-for-focusevent-10">(2)</a>
+    <li><a href="#ref-for-focusevent-11">5.2.4.3. focusin</a> <a href="#ref-for-focusevent-12">(2)</a>
+    <li><a href="#ref-for-focusevent-13">5.2.4.4. focusout</a> <a href="#ref-for-focusevent-14">(2)</a>
+    <li><a href="#ref-for-focusevent-15">9. Legacy Event Types</a> <a href="#ref-for-focusevent-16">(2)</a>
+    <li><a href="#ref-for-focusevent-17">9.2. Legacy FocusEvent events</a>
+    <li><a href="#ref-for-focusevent-18">9.2.1. Legacy FocusEvent event types</a>
+    <li><a href="#ref-for-focusevent-19">9.2.1.1. DOMFocusIn</a> <a href="#ref-for-focusevent-20">(2)</a>
+    <li><a href="#ref-for-focusevent-21">9.2.1.2. DOMFocusOut</a> <a href="#ref-for-focusevent-22">(2)</a>
+    <li><a href="#ref-for-focusevent-23">12.1.4. New Interfaces</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-focusevent-relatedtarget">
+   <b><a href="#dom-focusevent-relatedtarget">#dom-focusevent-relatedtarget</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-focusevent-relatedtarget-1">5.2.4.1. blur</a>
+    <li><a href="#ref-for-dom-focusevent-relatedtarget-2">5.2.4.2. focus</a>
+    <li><a href="#ref-for-dom-focusevent-relatedtarget-3">5.2.4.3. focusin</a> <a href="#ref-for-dom-focusevent-relatedtarget-4">(2)</a>
+    <li><a href="#ref-for-dom-focusevent-relatedtarget-5">5.2.4.4. focusout</a>
+    <li><a href="#ref-for-dom-focusevent-relatedtarget-6">9.2.1.1. DOMFocusIn</a>
+    <li><a href="#ref-for-dom-focusevent-relatedtarget-7">9.2.1.2. DOMFocusOut</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-focuseventinit">
+   <b><a href="#dictdef-focuseventinit">#dictdef-focuseventinit</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-focuseventinit-1">5.2.1. Interface FocusEvent</a> <a href="#ref-for-dictdef-focuseventinit-2">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-focuseventinit-relatedtarget">
+   <b><a href="#dom-focuseventinit-relatedtarget">#dom-focuseventinit-relatedtarget</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-focuseventinit-relatedtarget-1">5.2.1. Interface FocusEvent</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="blur">
+   <b><a href="#blur">#blur</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-blur-1">4.1. List of Event Types</a> <a href="#ref-for-blur-2">(2)</a>
+    <li><a href="#ref-for-blur-3">5.2.1. Interface FocusEvent</a>
+    <li><a href="#ref-for-blur-4">5.2.2. Focus Event Order</a>
+    <li><a href="#ref-for-blur-5">5.2.4.3. focusin</a>
+    <li><a href="#ref-for-blur-6">5.2.4.4. focusout</a>
+    <li><a href="#ref-for-blur-7">5.6.4.1. keydown</a>
+    <li><a href="#ref-for-blur-8">9. Legacy Event Types</a>
+    <li><a href="#ref-for-blur-9">9.2.1.2. DOMFocusOut</a> <a href="#ref-for-blur-10">(2)</a>
+    <li><a href="#ref-for-blur-11">9.2.2. Legacy FocusEvent event order</a>
+    <li><a href="#ref-for-blur-12">9.3.1.1. keypress</a>
+    <li><a href="#ref-for-blur-13">12.1. Changes between DOM Level 2 Events and UI Events</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="focus">
+   <b><a href="#focus">#focus</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-focus-1">4.1. List of Event Types</a> <a href="#ref-for-focus-2">(2)</a>
+    <li><a href="#ref-for-focus-3">5.2.1. Interface FocusEvent</a>
+    <li><a href="#ref-for-focus-4">5.2.2. Focus Event Order</a> <a href="#ref-for-focus-5">(2)</a>
+    <li><a href="#ref-for-focus-6">5.2.3. Document Focus and Focus Context</a>
+    <li><a href="#ref-for-focus-7">5.2.4.3. focusin</a>
+    <li><a href="#ref-for-focus-8">5.6.4.1. keydown</a>
+    <li><a href="#ref-for-focus-9">9. Legacy Event Types</a>
+    <li><a href="#ref-for-focus-10">9.2.1.1. DOMFocusIn</a> <a href="#ref-for-focus-11">(2)</a>
+    <li><a href="#ref-for-focus-12">9.2.2. Legacy FocusEvent event order</a> <a href="#ref-for-focus-13">(2)</a>
+    <li><a href="#ref-for-focus-14">9.3.1.1. keypress</a>
+    <li><a href="#ref-for-focus-15">12.1. Changes between DOM Level 2 Events and UI Events</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="focusin">
+   <b><a href="#focusin">#focusin</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-focusin-1">4.1. List of Event Types</a>
+    <li><a href="#ref-for-focusin-2">5.2.1. Interface FocusEvent</a>
+    <li><a href="#ref-for-focusin-3">5.2.2. Focus Event Order</a> <a href="#ref-for-focusin-4">(2)</a>
+    <li><a href="#ref-for-focusin-5">5.2.4.2. focus</a>
+    <li><a href="#ref-for-focusin-6">9.2.1.1. DOMFocusIn</a>
+    <li><a href="#ref-for-focusin-7">9.2.2. Legacy FocusEvent event order</a> <a href="#ref-for-focusin-8">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="focusout">
+   <b><a href="#focusout">#focusout</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-focusout-1">4.1. List of Event Types</a>
+    <li><a href="#ref-for-focusout-2">5.2.1. Interface FocusEvent</a>
+    <li><a href="#ref-for-focusout-3">5.2.2. Focus Event Order</a>
+    <li><a href="#ref-for-focusout-4">5.2.4.1. blur</a>
+    <li><a href="#ref-for-focusout-5">5.2.4.3. focusin</a>
+    <li><a href="#ref-for-focusout-6">9.2.1.2. DOMFocusOut</a>
+    <li><a href="#ref-for-focusout-7">9.2.2. Legacy FocusEvent event order</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="mouseevent">
+   <b><a href="#mouseevent">#mouseevent</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-mouseevent-1">3.6. Constructing Mouse and Keyboard Events</a> <a href="#ref-for-mouseevent-2">(2)</a> <a href="#ref-for-mouseevent-3">(3)</a> <a href="#ref-for-mouseevent-4">(4)</a>
+    <li><a href="#ref-for-mouseevent-5">4.1. List of Event Types</a> <a href="#ref-for-mouseevent-6">(2)</a> <a href="#ref-for-mouseevent-7">(3)</a> <a href="#ref-for-mouseevent-8">(4)</a> <a href="#ref-for-mouseevent-9">(5)</a> <a href="#ref-for-mouseevent-10">(6)</a> <a href="#ref-for-mouseevent-11">(7)</a> <a href="#ref-for-mouseevent-12">(8)</a> <a href="#ref-for-mouseevent-13">(9)</a>
+    <li><a href="#ref-for-mouseevent-14">5.3.1. Interface MouseEvent</a> <a href="#ref-for-mouseevent-15">(2)</a> <a href="#ref-for-mouseevent-16">(3)</a> <a href="#ref-for-mouseevent-17">(4)</a> <a href="#ref-for-mouseevent-18">(5)</a>
+    <li><a href="#ref-for-mouseevent-19">5.3.2. Event Modifier Initializers</a> <a href="#ref-for-mouseevent-20">(2)</a> <a href="#ref-for-mouseevent-21">(3)</a> <a href="#ref-for-mouseevent-22">(4)</a> <a href="#ref-for-mouseevent-23">(5)</a> <a href="#ref-for-mouseevent-24">(6)</a>
+    <li><a href="#ref-for-mouseevent-25">5.3.4.1. click</a> <a href="#ref-for-mouseevent-26">(2)</a> <a href="#ref-for-mouseevent-27">(3)</a> <a href="#ref-for-mouseevent-28">(4)</a> <a href="#ref-for-mouseevent-29">(5)</a> <a href="#ref-for-mouseevent-30">(6)</a> <a href="#ref-for-mouseevent-31">(7)</a> <a href="#ref-for-mouseevent-32">(8)</a> <a href="#ref-for-mouseevent-33">(9)</a> <a href="#ref-for-mouseevent-34">(10)</a> <a href="#ref-for-mouseevent-35">(11)</a> <a href="#ref-for-mouseevent-36">(12)</a>
+    <li><a href="#ref-for-mouseevent-37">5.3.4.2. dblclick</a> <a href="#ref-for-mouseevent-38">(2)</a> <a href="#ref-for-mouseevent-39">(3)</a> <a href="#ref-for-mouseevent-40">(4)</a> <a href="#ref-for-mouseevent-41">(5)</a> <a href="#ref-for-mouseevent-42">(6)</a> <a href="#ref-for-mouseevent-43">(7)</a> <a href="#ref-for-mouseevent-44">(8)</a> <a href="#ref-for-mouseevent-45">(9)</a> <a href="#ref-for-mouseevent-46">(10)</a> <a href="#ref-for-mouseevent-47">(11)</a> <a href="#ref-for-mouseevent-48">(12)</a>
+    <li><a href="#ref-for-mouseevent-49">5.3.4.3. mousedown</a> <a href="#ref-for-mouseevent-50">(2)</a> <a href="#ref-for-mouseevent-51">(3)</a> <a href="#ref-for-mouseevent-52">(4)</a> <a href="#ref-for-mouseevent-53">(5)</a> <a href="#ref-for-mouseevent-54">(6)</a> <a href="#ref-for-mouseevent-55">(7)</a> <a href="#ref-for-mouseevent-56">(8)</a> <a href="#ref-for-mouseevent-57">(9)</a> <a href="#ref-for-mouseevent-58">(10)</a> <a href="#ref-for-mouseevent-59">(11)</a> <a href="#ref-for-mouseevent-60">(12)</a>
+    <li><a href="#ref-for-mouseevent-61">5.3.4.4. mouseenter</a> <a href="#ref-for-mouseevent-62">(2)</a> <a href="#ref-for-mouseevent-63">(3)</a> <a href="#ref-for-mouseevent-64">(4)</a> <a href="#ref-for-mouseevent-65">(5)</a> <a href="#ref-for-mouseevent-66">(6)</a> <a href="#ref-for-mouseevent-67">(7)</a> <a href="#ref-for-mouseevent-68">(8)</a> <a href="#ref-for-mouseevent-69">(9)</a> <a href="#ref-for-mouseevent-70">(10)</a> <a href="#ref-for-mouseevent-71">(11)</a> <a href="#ref-for-mouseevent-72">(12)</a>
+    <li><a href="#ref-for-mouseevent-73">5.3.4.5. mouseleave</a> <a href="#ref-for-mouseevent-74">(2)</a> <a href="#ref-for-mouseevent-75">(3)</a> <a href="#ref-for-mouseevent-76">(4)</a> <a href="#ref-for-mouseevent-77">(5)</a> <a href="#ref-for-mouseevent-78">(6)</a> <a href="#ref-for-mouseevent-79">(7)</a> <a href="#ref-for-mouseevent-80">(8)</a> <a href="#ref-for-mouseevent-81">(9)</a> <a href="#ref-for-mouseevent-82">(10)</a> <a href="#ref-for-mouseevent-83">(11)</a> <a href="#ref-for-mouseevent-84">(12)</a>
+    <li><a href="#ref-for-mouseevent-85">5.3.4.6. mousemove</a> <a href="#ref-for-mouseevent-86">(2)</a> <a href="#ref-for-mouseevent-87">(3)</a> <a href="#ref-for-mouseevent-88">(4)</a> <a href="#ref-for-mouseevent-89">(5)</a> <a href="#ref-for-mouseevent-90">(6)</a> <a href="#ref-for-mouseevent-91">(7)</a> <a href="#ref-for-mouseevent-92">(8)</a> <a href="#ref-for-mouseevent-93">(9)</a> <a href="#ref-for-mouseevent-94">(10)</a> <a href="#ref-for-mouseevent-95">(11)</a> <a href="#ref-for-mouseevent-96">(12)</a>
+    <li><a href="#ref-for-mouseevent-97">5.3.4.7. mouseout</a> <a href="#ref-for-mouseevent-98">(2)</a> <a href="#ref-for-mouseevent-99">(3)</a> <a href="#ref-for-mouseevent-100">(4)</a> <a href="#ref-for-mouseevent-101">(5)</a> <a href="#ref-for-mouseevent-102">(6)</a> <a href="#ref-for-mouseevent-103">(7)</a> <a href="#ref-for-mouseevent-104">(8)</a> <a href="#ref-for-mouseevent-105">(9)</a> <a href="#ref-for-mouseevent-106">(10)</a> <a href="#ref-for-mouseevent-107">(11)</a> <a href="#ref-for-mouseevent-108">(12)</a>
+    <li><a href="#ref-for-mouseevent-109">5.3.4.8. mouseover</a> <a href="#ref-for-mouseevent-110">(2)</a> <a href="#ref-for-mouseevent-111">(3)</a> <a href="#ref-for-mouseevent-112">(4)</a> <a href="#ref-for-mouseevent-113">(5)</a> <a href="#ref-for-mouseevent-114">(6)</a> <a href="#ref-for-mouseevent-115">(7)</a> <a href="#ref-for-mouseevent-116">(8)</a> <a href="#ref-for-mouseevent-117">(9)</a> <a href="#ref-for-mouseevent-118">(10)</a> <a href="#ref-for-mouseevent-119">(11)</a> <a href="#ref-for-mouseevent-120">(12)</a>
+    <li><a href="#ref-for-mouseevent-121">5.3.4.9. mouseup</a> <a href="#ref-for-mouseevent-122">(2)</a> <a href="#ref-for-mouseevent-123">(3)</a> <a href="#ref-for-mouseevent-124">(4)</a> <a href="#ref-for-mouseevent-125">(5)</a> <a href="#ref-for-mouseevent-126">(6)</a> <a href="#ref-for-mouseevent-127">(7)</a> <a href="#ref-for-mouseevent-128">(8)</a> <a href="#ref-for-mouseevent-129">(9)</a> <a href="#ref-for-mouseevent-130">(10)</a> <a href="#ref-for-mouseevent-131">(11)</a> <a href="#ref-for-mouseevent-132">(12)</a>
+    <li><a href="#ref-for-mouseevent-133">5.4.1. Interface WheelEvent</a>
+    <li><a href="#ref-for-mouseevent-134">5.4.2.1. wheel</a> <a href="#ref-for-mouseevent-135">(2)</a> <a href="#ref-for-mouseevent-136">(3)</a> <a href="#ref-for-mouseevent-137">(4)</a> <a href="#ref-for-mouseevent-138">(5)</a> <a href="#ref-for-mouseevent-139">(6)</a> <a href="#ref-for-mouseevent-140">(7)</a> <a href="#ref-for-mouseevent-141">(8)</a> <a href="#ref-for-mouseevent-142">(9)</a> <a href="#ref-for-mouseevent-143">(10)</a> <a href="#ref-for-mouseevent-144">(11)</a>
+    <li><a href="#ref-for-mouseevent-145">7.1.2. Initializers for interface MouseEvent</a>
+    <li><a href="#ref-for-mouseevent-146">12.1. Changes between DOM Level 2 Events and UI Events</a>
+    <li><a href="#ref-for-mouseevent-147">12.1.3. Changes to DOM Level 2 Events interfaces</a> <a href="#ref-for-mouseevent-148">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-mouseevent-ctrlkey">
+   <b><a href="#dom-mouseevent-ctrlkey">#dom-mouseevent-ctrlkey</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-mouseevent-ctrlkey-1">5.3.4.1. click</a>
+    <li><a href="#ref-for-dom-mouseevent-ctrlkey-2">5.3.4.2. dblclick</a>
+    <li><a href="#ref-for-dom-mouseevent-ctrlkey-3">5.3.4.3. mousedown</a>
+    <li><a href="#ref-for-dom-mouseevent-ctrlkey-4">5.3.4.4. mouseenter</a>
+    <li><a href="#ref-for-dom-mouseevent-ctrlkey-5">5.3.4.5. mouseleave</a>
+    <li><a href="#ref-for-dom-mouseevent-ctrlkey-6">5.3.4.6. mousemove</a>
+    <li><a href="#ref-for-dom-mouseevent-ctrlkey-7">5.3.4.7. mouseout</a>
+    <li><a href="#ref-for-dom-mouseevent-ctrlkey-8">5.3.4.8. mouseover</a>
+    <li><a href="#ref-for-dom-mouseevent-ctrlkey-9">5.3.4.9. mouseup</a>
+    <li><a href="#ref-for-dom-mouseevent-ctrlkey-10">5.4.2.1. wheel</a>
+    <li><a href="#ref-for-dom-mouseevent-ctrlkey-11">7.1.2. Initializers for interface MouseEvent</a>
+    <li><a href="#ref-for-dom-mouseevent-ctrlkey-12">7.1.3. Initializers for interface WheelEvent</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-mouseevent-shiftkey">
+   <b><a href="#dom-mouseevent-shiftkey">#dom-mouseevent-shiftkey</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-mouseevent-shiftkey-1">5.3.4.1. click</a>
+    <li><a href="#ref-for-dom-mouseevent-shiftkey-2">5.3.4.2. dblclick</a>
+    <li><a href="#ref-for-dom-mouseevent-shiftkey-3">5.3.4.3. mousedown</a>
+    <li><a href="#ref-for-dom-mouseevent-shiftkey-4">5.3.4.4. mouseenter</a>
+    <li><a href="#ref-for-dom-mouseevent-shiftkey-5">5.3.4.5. mouseleave</a>
+    <li><a href="#ref-for-dom-mouseevent-shiftkey-6">5.3.4.6. mousemove</a>
+    <li><a href="#ref-for-dom-mouseevent-shiftkey-7">5.3.4.7. mouseout</a>
+    <li><a href="#ref-for-dom-mouseevent-shiftkey-8">5.3.4.8. mouseover</a>
+    <li><a href="#ref-for-dom-mouseevent-shiftkey-9">5.3.4.9. mouseup</a>
+    <li><a href="#ref-for-dom-mouseevent-shiftkey-10">5.4.2.1. wheel</a>
+    <li><a href="#ref-for-dom-mouseevent-shiftkey-11">7.1.2. Initializers for interface MouseEvent</a>
+    <li><a href="#ref-for-dom-mouseevent-shiftkey-12">7.1.3. Initializers for interface WheelEvent</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-mouseevent-altkey">
+   <b><a href="#dom-mouseevent-altkey">#dom-mouseevent-altkey</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-mouseevent-altkey-1">5.3.4.1. click</a>
+    <li><a href="#ref-for-dom-mouseevent-altkey-2">5.3.4.2. dblclick</a>
+    <li><a href="#ref-for-dom-mouseevent-altkey-3">5.3.4.3. mousedown</a>
+    <li><a href="#ref-for-dom-mouseevent-altkey-4">5.3.4.4. mouseenter</a>
+    <li><a href="#ref-for-dom-mouseevent-altkey-5">5.3.4.5. mouseleave</a>
+    <li><a href="#ref-for-dom-mouseevent-altkey-6">5.3.4.6. mousemove</a>
+    <li><a href="#ref-for-dom-mouseevent-altkey-7">5.3.4.7. mouseout</a>
+    <li><a href="#ref-for-dom-mouseevent-altkey-8">5.3.4.8. mouseover</a>
+    <li><a href="#ref-for-dom-mouseevent-altkey-9">5.3.4.9. mouseup</a>
+    <li><a href="#ref-for-dom-mouseevent-altkey-10">5.4.2.1. wheel</a>
+    <li><a href="#ref-for-dom-mouseevent-altkey-11">7.1.2. Initializers for interface MouseEvent</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-mouseevent-metakey">
+   <b><a href="#dom-mouseevent-metakey">#dom-mouseevent-metakey</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-mouseevent-metakey-1">5.3.4.1. click</a>
+    <li><a href="#ref-for-dom-mouseevent-metakey-2">5.3.4.2. dblclick</a>
+    <li><a href="#ref-for-dom-mouseevent-metakey-3">5.3.4.3. mousedown</a>
+    <li><a href="#ref-for-dom-mouseevent-metakey-4">5.3.4.4. mouseenter</a>
+    <li><a href="#ref-for-dom-mouseevent-metakey-5">5.3.4.5. mouseleave</a>
+    <li><a href="#ref-for-dom-mouseevent-metakey-6">5.3.4.6. mousemove</a>
+    <li><a href="#ref-for-dom-mouseevent-metakey-7">5.3.4.7. mouseout</a>
+    <li><a href="#ref-for-dom-mouseevent-metakey-8">5.3.4.8. mouseover</a>
+    <li><a href="#ref-for-dom-mouseevent-metakey-9">5.3.4.9. mouseup</a>
+    <li><a href="#ref-for-dom-mouseevent-metakey-10">5.4.2.1. wheel</a>
+    <li><a href="#ref-for-dom-mouseevent-metakey-11">7.1.2. Initializers for interface MouseEvent</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-mouseevent-button">
+   <b><a href="#dom-mouseevent-button">#dom-mouseevent-button</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-mouseevent-button-1">5.3.1. Interface MouseEvent</a> <a href="#ref-for-dom-mouseevent-button-2">(2)</a> <a href="#ref-for-dom-mouseevent-button-3">(3)</a> <a href="#ref-for-dom-mouseevent-button-4">(4)</a>
+    <li><a href="#ref-for-dom-mouseevent-button-5">5.3.4.1. click</a> <a href="#ref-for-dom-mouseevent-button-6">(2)</a> <a href="#ref-for-dom-mouseevent-button-7">(3)</a>
+    <li><a href="#ref-for-dom-mouseevent-button-8">5.3.4.2. dblclick</a> <a href="#ref-for-dom-mouseevent-button-9">(2)</a>
+    <li><a href="#ref-for-dom-mouseevent-button-10">5.3.4.3. mousedown</a>
+    <li><a href="#ref-for-dom-mouseevent-button-11">5.3.4.4. mouseenter</a>
+    <li><a href="#ref-for-dom-mouseevent-button-12">5.3.4.5. mouseleave</a>
+    <li><a href="#ref-for-dom-mouseevent-button-13">5.3.4.6. mousemove</a>
+    <li><a href="#ref-for-dom-mouseevent-button-14">5.3.4.7. mouseout</a>
+    <li><a href="#ref-for-dom-mouseevent-button-15">5.3.4.8. mouseover</a>
+    <li><a href="#ref-for-dom-mouseevent-button-16">5.3.4.9. mouseup</a>
+    <li><a href="#ref-for-dom-mouseevent-button-17">5.4.2.1. wheel</a>
+    <li><a href="#ref-for-dom-mouseevent-button-18">7.1.2. Initializers for interface MouseEvent</a>
+    <li><a href="#ref-for-dom-mouseevent-button-19">7.1.3. Initializers for interface WheelEvent</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-mouseevent-buttons">
+   <b><a href="#dom-mouseevent-buttons">#dom-mouseevent-buttons</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-mouseevent-buttons-1">5.3.1. Interface MouseEvent</a> <a href="#ref-for-dom-mouseevent-buttons-2">(2)</a> <a href="#ref-for-dom-mouseevent-buttons-3">(3)</a>
+    <li><a href="#ref-for-dom-mouseevent-buttons-4">5.3.4.1. click</a> <a href="#ref-for-dom-mouseevent-buttons-5">(2)</a> <a href="#ref-for-dom-mouseevent-buttons-6">(3)</a>
+    <li><a href="#ref-for-dom-mouseevent-buttons-7">5.3.4.2. dblclick</a> <a href="#ref-for-dom-mouseevent-buttons-8">(2)</a>
+    <li><a href="#ref-for-dom-mouseevent-buttons-9">5.3.4.3. mousedown</a>
+    <li><a href="#ref-for-dom-mouseevent-buttons-10">5.3.4.4. mouseenter</a>
+    <li><a href="#ref-for-dom-mouseevent-buttons-11">5.3.4.5. mouseleave</a>
+    <li><a href="#ref-for-dom-mouseevent-buttons-12">5.3.4.6. mousemove</a>
+    <li><a href="#ref-for-dom-mouseevent-buttons-13">5.3.4.7. mouseout</a>
+    <li><a href="#ref-for-dom-mouseevent-buttons-14">5.3.4.8. mouseover</a>
+    <li><a href="#ref-for-dom-mouseevent-buttons-15">5.3.4.9. mouseup</a>
+    <li><a href="#ref-for-dom-mouseevent-buttons-16">5.4.2.1. wheel</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-mouseevent-relatedtarget">
+   <b><a href="#dom-mouseevent-relatedtarget">#dom-mouseevent-relatedtarget</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-mouseevent-relatedtarget-1">5.3.4.1. click</a>
+    <li><a href="#ref-for-dom-mouseevent-relatedtarget-2">5.3.4.2. dblclick</a>
+    <li><a href="#ref-for-dom-mouseevent-relatedtarget-3">5.3.4.3. mousedown</a>
+    <li><a href="#ref-for-dom-mouseevent-relatedtarget-4">5.3.4.4. mouseenter</a>
+    <li><a href="#ref-for-dom-mouseevent-relatedtarget-5">5.3.4.5. mouseleave</a>
+    <li><a href="#ref-for-dom-mouseevent-relatedtarget-6">5.3.4.6. mousemove</a>
+    <li><a href="#ref-for-dom-mouseevent-relatedtarget-7">5.3.4.7. mouseout</a>
+    <li><a href="#ref-for-dom-mouseevent-relatedtarget-8">5.3.4.8. mouseover</a>
+    <li><a href="#ref-for-dom-mouseevent-relatedtarget-9">5.3.4.9. mouseup</a>
+    <li><a href="#ref-for-dom-mouseevent-relatedtarget-10">5.4.2.1. wheel</a>
+    <li><a href="#ref-for-dom-mouseevent-relatedtarget-11">7.1.2. Initializers for interface MouseEvent</a>
+    <li><a href="#ref-for-dom-mouseevent-relatedtarget-12">7.1.3. Initializers for interface WheelEvent</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-mouseevent-getmodifierstate">
+   <b><a href="#dom-mouseevent-getmodifierstate">#dom-mouseevent-getmodifierstate</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-mouseevent-getmodifierstate-1">3.6. Constructing Mouse and Keyboard Events</a>
+    <li><a href="#ref-for-dom-mouseevent-getmodifierstate-2">5.3.2. Event Modifier Initializers</a> <a href="#ref-for-dom-mouseevent-getmodifierstate-3">(2)</a> <a href="#ref-for-dom-mouseevent-getmodifierstate-4">(3)</a> <a href="#ref-for-dom-mouseevent-getmodifierstate-5">(4)</a> <a href="#ref-for-dom-mouseevent-getmodifierstate-6">(5)</a> <a href="#ref-for-dom-mouseevent-getmodifierstate-7">(6)</a> <a href="#ref-for-dom-mouseevent-getmodifierstate-8">(7)</a> <a href="#ref-for-dom-mouseevent-getmodifierstate-9">(8)</a> <a href="#ref-for-dom-mouseevent-getmodifierstate-10">(9)</a> <a href="#ref-for-dom-mouseevent-getmodifierstate-11">(10)</a> <a href="#ref-for-dom-mouseevent-getmodifierstate-12">(11)</a> <a href="#ref-for-dom-mouseevent-getmodifierstate-13">(12)</a> <a href="#ref-for-dom-mouseevent-getmodifierstate-14">(13)</a> <a href="#ref-for-dom-mouseevent-getmodifierstate-15">(14)</a>
+    <li><a href="#ref-for-dom-mouseevent-getmodifierstate-16">12.1.3. Changes to DOM Level 2 Events interfaces</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-eventmodifierinit">
+   <b><a href="#dictdef-eventmodifierinit">#dictdef-eventmodifierinit</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-eventmodifierinit-1">3.6. Constructing Mouse and Keyboard Events</a> <a href="#ref-for-dictdef-eventmodifierinit-2">(2)</a>
+    <li><a href="#ref-for-dictdef-eventmodifierinit-3">5.3.1. Interface MouseEvent</a>
+    <li><a href="#ref-for-dictdef-eventmodifierinit-4">5.6.1. Interface KeyboardEvent</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="click">
+   <b><a href="#click">#click</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-click-1">3.2. Default actions and cancelable events</a> <a href="#ref-for-click-2">(2)</a>
+    <li><a href="#ref-for-click-3">3.4. Trusted events</a>
+    <li><a href="#ref-for-click-4">3.5. Activation triggers and behavior</a>
+    <li><a href="#ref-for-click-5">4.1. List of Event Types</a>
+    <li><a href="#ref-for-click-6">5.3.3. Mouse Event Order</a> <a href="#ref-for-click-7">(2)</a> <a href="#ref-for-click-8">(3)</a> <a href="#ref-for-click-9">(4)</a> <a href="#ref-for-click-10">(5)</a> <a href="#ref-for-click-11">(6)</a> <a href="#ref-for-click-12">(7)</a> <a href="#ref-for-click-13">(8)</a>
+    <li><a href="#ref-for-click-14">5.3.4.1. click</a> <a href="#ref-for-click-15">(2)</a> <a href="#ref-for-click-16">(3)</a> <a href="#ref-for-click-17">(4)</a> <a href="#ref-for-click-18">(5)</a> <a href="#ref-for-click-19">(6)</a> <a href="#ref-for-click-20">(7)</a> <a href="#ref-for-click-21">(8)</a> <a href="#ref-for-click-22">(9)</a> <a href="#ref-for-click-23">(10)</a> <a href="#ref-for-click-24">(11)</a> <a href="#ref-for-click-25">(12)</a> <a href="#ref-for-click-26">(13)</a>
+    <li><a href="#ref-for-click-27">5.3.4.2. dblclick</a> <a href="#ref-for-click-28">(2)</a> <a href="#ref-for-click-29">(3)</a> <a href="#ref-for-click-30">(4)</a> <a href="#ref-for-click-31">(5)</a>
+    <li><a href="#ref-for-click-32">5.6.4.1. keydown</a>
+    <li><a href="#ref-for-click-33">9.1.1.1. DOMActivate</a> <a href="#ref-for-click-34">(2)</a> <a href="#ref-for-click-35">(3)</a> <a href="#ref-for-click-36">(4)</a> <a href="#ref-for-click-37">(5)</a> <a href="#ref-for-click-38">(6)</a> <a href="#ref-for-click-39">(7)</a> <a href="#ref-for-click-40">(8)</a> <a href="#ref-for-click-41">(9)</a>
+    <li><a href="#ref-for-click-42">9.1.2. Activation event order</a> <a href="#ref-for-click-43">(2)</a>
+    <li><a href="#ref-for-click-44">14. Glossary</a> <a href="#ref-for-click-45">(2)</a> <a href="#ref-for-click-46">(3)</a> <a href="#ref-for-click-47">(4)</a> <a href="#ref-for-click-48">(5)</a> <a href="#ref-for-click-49">(6)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dblclick">
+   <b><a href="#dblclick">#dblclick</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dblclick-1">4.1. List of Event Types</a>
+    <li><a href="#ref-for-dblclick-2">5.3.3. Mouse Event Order</a> <a href="#ref-for-dblclick-3">(2)</a> <a href="#ref-for-dblclick-4">(3)</a> <a href="#ref-for-dblclick-5">(4)</a> <a href="#ref-for-dblclick-6">(5)</a>
+    <li><a href="#ref-for-dblclick-7">5.3.4.1. click</a>
+    <li><a href="#ref-for-dblclick-8">5.3.4.2. dblclick</a> <a href="#ref-for-dblclick-9">(2)</a> <a href="#ref-for-dblclick-10">(3)</a> <a href="#ref-for-dblclick-11">(4)</a> <a href="#ref-for-dblclick-12">(5)</a> <a href="#ref-for-dblclick-13">(6)</a>
+    <li><a href="#ref-for-dblclick-14">12.1. Changes between DOM Level 2 Events and UI Events</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="mousedown">
+   <b><a href="#mousedown">#mousedown</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-mousedown-1">3.2. Default actions and cancelable events</a> <a href="#ref-for-mousedown-2">(2)</a>
+    <li><a href="#ref-for-mousedown-3">4.1. List of Event Types</a>
+    <li><a href="#ref-for-mousedown-4">5.3.1. Interface MouseEvent</a> <a href="#ref-for-mousedown-5">(2)</a> <a href="#ref-for-mousedown-6">(3)</a>
+    <li><a href="#ref-for-mousedown-7">5.3.3. Mouse Event Order</a> <a href="#ref-for-mousedown-8">(2)</a> <a href="#ref-for-mousedown-9">(3)</a> <a href="#ref-for-mousedown-10">(4)</a> <a href="#ref-for-mousedown-11">(5)</a> <a href="#ref-for-mousedown-12">(6)</a> <a href="#ref-for-mousedown-13">(7)</a>
+    <li><a href="#ref-for-mousedown-14">5.3.4.1. click</a> <a href="#ref-for-mousedown-15">(2)</a>
+    <li><a href="#ref-for-mousedown-16">5.3.4.2. dblclick</a>
+    <li><a href="#ref-for-mousedown-17">5.3.4.3. mousedown</a> <a href="#ref-for-mousedown-18">(2)</a> <a href="#ref-for-mousedown-19">(3)</a>
+    <li><a href="#ref-for-mousedown-20">9.1.1.1. DOMActivate</a>
+    <li><a href="#ref-for-mousedown-21">14. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="mouseenter">
+   <b><a href="#mouseenter">#mouseenter</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-mouseenter-1">4.1. List of Event Types</a>
+    <li><a href="#ref-for-mouseenter-2">5.3.3. Mouse Event Order</a> <a href="#ref-for-mouseenter-3">(2)</a> <a href="#ref-for-mouseenter-4">(3)</a> <a href="#ref-for-mouseenter-5">(4)</a> <a href="#ref-for-mouseenter-6">(5)</a> <a href="#ref-for-mouseenter-7">(6)</a> <a href="#ref-for-mouseenter-8">(7)</a>
+    <li><a href="#ref-for-mouseenter-9">5.3.4.5. mouseleave</a>
+    <li><a href="#ref-for-mouseenter-10">5.3.4.8. mouseover</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="mouseleave">
+   <b><a href="#mouseleave">#mouseleave</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-mouseleave-1">4.1. List of Event Types</a>
+    <li><a href="#ref-for-mouseleave-2">5.3.3. Mouse Event Order</a> <a href="#ref-for-mouseleave-3">(2)</a> <a href="#ref-for-mouseleave-4">(3)</a> <a href="#ref-for-mouseleave-5">(4)</a> <a href="#ref-for-mouseleave-6">(5)</a> <a href="#ref-for-mouseleave-7">(6)</a> <a href="#ref-for-mouseleave-8">(7)</a> <a href="#ref-for-mouseleave-9">(8)</a>
+    <li><a href="#ref-for-mouseleave-10">5.3.4.4. mouseenter</a>
+    <li><a href="#ref-for-mouseleave-11">5.3.4.7. mouseout</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="mousemove">
+   <b><a href="#mousemove">#mousemove</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-mousemove-1">4.1. List of Event Types</a>
+    <li><a href="#ref-for-mousemove-2">5.3.3. Mouse Event Order</a> <a href="#ref-for-mousemove-3">(2)</a> <a href="#ref-for-mousemove-4">(3)</a> <a href="#ref-for-mousemove-5">(4)</a> <a href="#ref-for-mousemove-6">(5)</a> <a href="#ref-for-mousemove-7">(6)</a> <a href="#ref-for-mousemove-8">(7)</a> <a href="#ref-for-mousemove-9">(8)</a> <a href="#ref-for-mousemove-10">(9)</a> <a href="#ref-for-mousemove-11">(10)</a> <a href="#ref-for-mousemove-12">(11)</a> <a href="#ref-for-mousemove-13">(12)</a> <a href="#ref-for-mousemove-14">(13)</a> <a href="#ref-for-mousemove-15">(14)</a> <a href="#ref-for-mousemove-16">(15)</a> <a href="#ref-for-mousemove-17">(16)</a> <a href="#ref-for-mousemove-18">(17)</a>
+    <li><a href="#ref-for-mousemove-19">5.3.4.1. click</a>
+    <li><a href="#ref-for-mousemove-20">5.3.4.6. mousemove</a> <a href="#ref-for-mousemove-21">(2)</a>
+    <li><a href="#ref-for-mousemove-22">12.1.2. Changes to DOM Level 2 event types</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="mouseout">
+   <b><a href="#mouseout">#mouseout</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-mouseout-1">4.1. List of Event Types</a>
+    <li><a href="#ref-for-mouseout-2">5.3.3. Mouse Event Order</a> <a href="#ref-for-mouseout-3">(2)</a> <a href="#ref-for-mouseout-4">(3)</a> <a href="#ref-for-mouseout-5">(4)</a> <a href="#ref-for-mouseout-6">(5)</a> <a href="#ref-for-mouseout-7">(6)</a> <a href="#ref-for-mouseout-8">(7)</a>
+    <li><a href="#ref-for-mouseout-9">5.3.4.1. click</a>
+    <li><a href="#ref-for-mouseout-10">5.3.4.5. mouseleave</a>
+    <li><a href="#ref-for-mouseout-11">5.3.4.8. mouseover</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="mouseover">
+   <b><a href="#mouseover">#mouseover</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-mouseover-1">4.1. List of Event Types</a>
+    <li><a href="#ref-for-mouseover-2">5.3.3. Mouse Event Order</a> <a href="#ref-for-mouseover-3">(2)</a> <a href="#ref-for-mouseover-4">(3)</a> <a href="#ref-for-mouseover-5">(4)</a> <a href="#ref-for-mouseover-6">(5)</a> <a href="#ref-for-mouseover-7">(6)</a>
+    <li><a href="#ref-for-mouseover-8">5.3.4.1. click</a>
+    <li><a href="#ref-for-mouseover-9">5.3.4.4. mouseenter</a>
+    <li><a href="#ref-for-mouseover-10">5.3.4.7. mouseout</a>
+    <li><a href="#ref-for-mouseover-11">14. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="mouseup">
+   <b><a href="#mouseup">#mouseup</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-mouseup-1">4.1. List of Event Types</a>
+    <li><a href="#ref-for-mouseup-2">5.3.1. Interface MouseEvent</a> <a href="#ref-for-mouseup-3">(2)</a> <a href="#ref-for-mouseup-4">(3)</a>
+    <li><a href="#ref-for-mouseup-5">5.3.3. Mouse Event Order</a> <a href="#ref-for-mouseup-6">(2)</a> <a href="#ref-for-mouseup-7">(3)</a> <a href="#ref-for-mouseup-8">(4)</a> <a href="#ref-for-mouseup-9">(5)</a> <a href="#ref-for-mouseup-10">(6)</a> <a href="#ref-for-mouseup-11">(7)</a> <a href="#ref-for-mouseup-12">(8)</a> <a href="#ref-for-mouseup-13">(9)</a>
+    <li><a href="#ref-for-mouseup-14">5.3.4.1. click</a> <a href="#ref-for-mouseup-15">(2)</a>
+    <li><a href="#ref-for-mouseup-16">5.3.4.2. dblclick</a> <a href="#ref-for-mouseup-17">(2)</a>
+    <li><a href="#ref-for-mouseup-18">5.3.4.9. mouseup</a>
+    <li><a href="#ref-for-mouseup-19">9.1.1.1. DOMActivate</a>
+    <li><a href="#ref-for-mouseup-20">14. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="wheelevent">
+   <b><a href="#wheelevent">#wheelevent</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-wheelevent-1">4.1. List of Event Types</a>
+    <li><a href="#ref-for-wheelevent-2">5.4. Wheel Events</a>
+    <li><a href="#ref-for-wheelevent-3">5.4.1. Interface WheelEvent</a> <a href="#ref-for-wheelevent-4">(2)</a> <a href="#ref-for-wheelevent-5">(3)</a>
+    <li><a href="#ref-for-wheelevent-6">5.4.2.1. wheel</a> <a href="#ref-for-wheelevent-7">(2)</a> <a href="#ref-for-wheelevent-8">(3)</a> <a href="#ref-for-wheelevent-9">(4)</a> <a href="#ref-for-wheelevent-10">(5)</a>
+    <li><a href="#ref-for-wheelevent-11">7.1.3. Initializers for interface WheelEvent</a>
+    <li><a href="#ref-for-wheelevent-12">12.1.4. New Interfaces</a>
+    <li><a href="#ref-for-wheelevent-13">14. Glossary</a> <a href="#ref-for-wheelevent-14">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-wheelevent-dom_delta_pixel">
+   <b><a href="#dom-wheelevent-dom_delta_pixel">#dom-wheelevent-dom_delta_pixel</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-wheelevent-dom_delta_pixel-1">5.4.1. Interface WheelEvent</a> <a href="#ref-for-dom-wheelevent-dom_delta_pixel-2">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-wheelevent-dom_delta_line">
+   <b><a href="#dom-wheelevent-dom_delta_line">#dom-wheelevent-dom_delta_line</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-wheelevent-dom_delta_line-1">5.4.1. Interface WheelEvent</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-wheelevent-dom_delta_page">
+   <b><a href="#dom-wheelevent-dom_delta_page">#dom-wheelevent-dom_delta_page</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-wheelevent-dom_delta_page-1">5.4.1. Interface WheelEvent</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-wheelevent-deltax">
+   <b><a href="#dom-wheelevent-deltax">#dom-wheelevent-deltax</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-wheelevent-deltax-1">5.4.2.1. wheel</a>
+    <li><a href="#ref-for-dom-wheelevent-deltax-2">7.1.3. Initializers for interface WheelEvent</a>
+    <li><a href="#ref-for-dom-wheelevent-deltax-3">14. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-wheelevent-deltay">
+   <b><a href="#dom-wheelevent-deltay">#dom-wheelevent-deltay</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-wheelevent-deltay-1">5.4.2.1. wheel</a>
+    <li><a href="#ref-for-dom-wheelevent-deltay-2">7.1.3. Initializers for interface WheelEvent</a>
+    <li><a href="#ref-for-dom-wheelevent-deltay-3">14. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-wheelevent-deltaz">
+   <b><a href="#dom-wheelevent-deltaz">#dom-wheelevent-deltaz</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-wheelevent-deltaz-1">5.4.2.1. wheel</a>
+    <li><a href="#ref-for-dom-wheelevent-deltaz-2">7.1.3. Initializers for interface WheelEvent</a>
+    <li><a href="#ref-for-dom-wheelevent-deltaz-3">14. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-wheelevent-deltamode">
+   <b><a href="#dom-wheelevent-deltamode">#dom-wheelevent-deltamode</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-wheelevent-deltamode-1">5.4.2.1. wheel</a>
+    <li><a href="#ref-for-dom-wheelevent-deltamode-2">7.1.3. Initializers for interface WheelEvent</a>
+    <li><a href="#ref-for-dom-wheelevent-deltamode-3">14. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-wheeleventinit">
+   <b><a href="#dictdef-wheeleventinit">#dictdef-wheeleventinit</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-wheeleventinit-1">5.4.1. Interface WheelEvent</a> <a href="#ref-for-dictdef-wheeleventinit-2">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="wheel">
+   <b><a href="#wheel">#wheel</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-wheel-1">4.1. List of Event Types</a>
+    <li><a href="#ref-for-wheel-2">5.4. Wheel Events</a> <a href="#ref-for-wheel-3">(2)</a>
+    <li><a href="#ref-for-wheel-4">5.4.1. Interface WheelEvent</a> <a href="#ref-for-wheel-5">(2)</a> <a href="#ref-for-wheel-6">(3)</a> <a href="#ref-for-wheel-7">(4)</a>
+    <li><a href="#ref-for-wheel-8">5.4.2.1. wheel</a> <a href="#ref-for-wheel-9">(2)</a> <a href="#ref-for-wheel-10">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="inputevent">
+   <b><a href="#inputevent">#inputevent</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-inputevent-1">4.1. List of Event Types</a> <a href="#ref-for-inputevent-2">(2)</a>
+    <li><a href="#ref-for-inputevent-3">5.5.3.1. beforeinput</a> <a href="#ref-for-inputevent-4">(2)</a> <a href="#ref-for-inputevent-5">(3)</a>
+    <li><a href="#ref-for-inputevent-6">5.5.3.2. input</a> <a href="#ref-for-inputevent-7">(2)</a> <a href="#ref-for-inputevent-8">(3)</a>
+    <li><a href="#ref-for-inputevent-9">5.6. Keyboard Events</a>
+    <li><a href="#ref-for-inputevent-10">6.3.5. Default actions and cancelable keyboard events</a> <a href="#ref-for-inputevent-11">(2)</a> <a href="#ref-for-inputevent-12">(3)</a>
+    <li><a href="#ref-for-inputevent-13">9.3.2. keypress event order</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-inputevent-data">
+   <b><a href="#dom-inputevent-data">#dom-inputevent-data</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-inputevent-data-1">5.5.3.1. beforeinput</a>
+    <li><a href="#ref-for-dom-inputevent-data-2">5.5.3.2. input</a>
+    <li><a href="#ref-for-dom-inputevent-data-3">6.3.5. Default actions and cancelable keyboard events</a> <a href="#ref-for-dom-inputevent-data-4">(2)</a> <a href="#ref-for-dom-inputevent-data-5">(3)</a>
+    <li><a href="#ref-for-dom-inputevent-data-6">9.3.2. keypress event order</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-inputevent-iscomposing">
+   <b><a href="#dom-inputevent-iscomposing">#dom-inputevent-iscomposing</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-inputevent-iscomposing-1">5.5.3.1. beforeinput</a>
+    <li><a href="#ref-for-dom-inputevent-iscomposing-2">5.5.3.2. input</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-inputeventinit">
+   <b><a href="#dictdef-inputeventinit">#dictdef-inputeventinit</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-inputeventinit-1">5.5.1. Interface InputEvent</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="beforeinput">
+   <b><a href="#beforeinput">#beforeinput</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-beforeinput-1">4.1. List of Event Types</a> <a href="#ref-for-beforeinput-2">(2)</a>
+    <li><a href="#ref-for-beforeinput-3">5.5.2. Input Event Order</a>
+    <li><a href="#ref-for-beforeinput-4">5.6.1. Interface KeyboardEvent</a>
+    <li><a href="#ref-for-beforeinput-5">5.6.3. Keyboard Event Order</a> <a href="#ref-for-beforeinput-6">(2)</a>
+    <li><a href="#ref-for-beforeinput-7">5.6.4.1. keydown</a> <a href="#ref-for-beforeinput-8">(2)</a> <a href="#ref-for-beforeinput-9">(3)</a> <a href="#ref-for-beforeinput-10">(4)</a>
+    <li><a href="#ref-for-beforeinput-11">5.6.4.2. keyup</a>
+    <li><a href="#ref-for-beforeinput-12">5.7.6. Input Events During Composition</a> <a href="#ref-for-beforeinput-13">(2)</a> <a href="#ref-for-beforeinput-14">(3)</a> <a href="#ref-for-beforeinput-15">(4)</a> <a href="#ref-for-beforeinput-16">(5)</a>
+    <li><a href="#ref-for-beforeinput-17">6.3.2. Modifier keys</a> <a href="#ref-for-beforeinput-18">(2)</a> <a href="#ref-for-beforeinput-19">(3)</a> <a href="#ref-for-beforeinput-20">(4)</a> <a href="#ref-for-beforeinput-21">(5)</a>
+    <li><a href="#ref-for-beforeinput-22">6.3.4. Input Method Editors</a> <a href="#ref-for-beforeinput-23">(2)</a> <a href="#ref-for-beforeinput-24">(3)</a> <a href="#ref-for-beforeinput-25">(4)</a>
+    <li><a href="#ref-for-beforeinput-26">6.3.5. Default actions and cancelable keyboard events</a> <a href="#ref-for-beforeinput-27">(2)</a> <a href="#ref-for-beforeinput-28">(3)</a> <a href="#ref-for-beforeinput-29">(4)</a> <a href="#ref-for-beforeinput-30">(5)</a>
+    <li><a href="#ref-for-beforeinput-31">9.3. Legacy KeyboardEvent events</a>
+    <li><a href="#ref-for-beforeinput-32">9.3.1.1. keypress</a> <a href="#ref-for-beforeinput-33">(2)</a>
+    <li><a href="#ref-for-beforeinput-34">9.3.2. keypress event order</a> <a href="#ref-for-beforeinput-35">(2)</a>
+    <li><a href="#ref-for-beforeinput-36">12.2. Changes between different drafts of UI Events</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="input">
+   <b><a href="#input">#input</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-input-1">4.1. List of Event Types</a> <a href="#ref-for-input-2">(2)</a>
+    <li><a href="#ref-for-input-3">5.5.2. Input Event Order</a>
+    <li><a href="#ref-for-input-4">5.6.1. Interface KeyboardEvent</a>
+    <li><a href="#ref-for-input-5">5.6.3. Keyboard Event Order</a> <a href="#ref-for-input-6">(2)</a>
+    <li><a href="#ref-for-input-7">5.6.4.1. keydown</a> <a href="#ref-for-input-8">(2)</a> <a href="#ref-for-input-9">(3)</a> <a href="#ref-for-input-10">(4)</a>
+    <li><a href="#ref-for-input-11">5.6.4.2. keyup</a>
+    <li><a href="#ref-for-input-12">5.7.6. Input Events During Composition</a> <a href="#ref-for-input-13">(2)</a> <a href="#ref-for-input-14">(3)</a> <a href="#ref-for-input-15">(4)</a> <a href="#ref-for-input-16">(5)</a> <a href="#ref-for-input-17">(6)</a>
+    <li><a href="#ref-for-input-18">6.3.2. Modifier keys</a> <a href="#ref-for-input-19">(2)</a> <a href="#ref-for-input-20">(3)</a> <a href="#ref-for-input-21">(4)</a> <a href="#ref-for-input-22">(5)</a>
+    <li><a href="#ref-for-input-23">6.3.4. Input Method Editors</a> <a href="#ref-for-input-24">(2)</a> <a href="#ref-for-input-25">(3)</a> <a href="#ref-for-input-26">(4)</a>
+    <li><a href="#ref-for-input-27">6.3.5. Default actions and cancelable keyboard events</a> <a href="#ref-for-input-28">(2)</a> <a href="#ref-for-input-29">(3)</a> <a href="#ref-for-input-30">(4)</a> <a href="#ref-for-input-31">(5)</a>
+    <li><a href="#ref-for-input-32">9.3. Legacy KeyboardEvent events</a>
+    <li><a href="#ref-for-input-33">9.3.1.1. keypress</a>
+    <li><a href="#ref-for-input-34">9.3.2. keypress event order</a> <a href="#ref-for-input-35">(2)</a>
+    <li><a href="#ref-for-input-36">12.2. Changes between different drafts of UI Events</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="keyboardevent-keyboardevent">
+   <b><a href="#keyboardevent-keyboardevent">#keyboardevent-keyboardevent</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-keyboardevent-keyboardevent-1">2. Stylistic Conventions</a> <a href="#ref-for-keyboardevent-keyboardevent-2">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-3">(3)</a>
+    <li><a href="#ref-for-keyboardevent-keyboardevent-4">3.6. Constructing Mouse and Keyboard Events</a> <a href="#ref-for-keyboardevent-keyboardevent-5">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-6">(3)</a> <a href="#ref-for-keyboardevent-keyboardevent-7">(4)</a>
+    <li><a href="#ref-for-keyboardevent-keyboardevent-8">4.1. List of Event Types</a> <a href="#ref-for-keyboardevent-keyboardevent-9">(2)</a>
+    <li><a href="#ref-for-keyboardevent-keyboardevent-10">5.3.1. Interface MouseEvent</a>
+    <li><a href="#ref-for-keyboardevent-keyboardevent-11">5.3.2. Event Modifier Initializers</a> <a href="#ref-for-keyboardevent-keyboardevent-12">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-13">(3)</a> <a href="#ref-for-keyboardevent-keyboardevent-14">(4)</a> <a href="#ref-for-keyboardevent-keyboardevent-15">(5)</a> <a href="#ref-for-keyboardevent-keyboardevent-16">(6)</a>
+    <li><a href="#ref-for-keyboardevent-keyboardevent-17">5.6.1. Interface KeyboardEvent</a> <a href="#ref-for-keyboardevent-keyboardevent-18">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-19">(3)</a> <a href="#ref-for-keyboardevent-keyboardevent-20">(4)</a>
+    <li><a href="#ref-for-keyboardevent-keyboardevent-21">5.6.2. Keyboard Event Key Location</a>
+    <li><a href="#ref-for-keyboardevent-keyboardevent-22">5.6.4.1. keydown</a> <a href="#ref-for-keyboardevent-keyboardevent-23">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-24">(3)</a> <a href="#ref-for-keyboardevent-keyboardevent-25">(4)</a> <a href="#ref-for-keyboardevent-keyboardevent-26">(5)</a> <a href="#ref-for-keyboardevent-keyboardevent-27">(6)</a> <a href="#ref-for-keyboardevent-keyboardevent-28">(7)</a> <a href="#ref-for-keyboardevent-keyboardevent-29">(8)</a> <a href="#ref-for-keyboardevent-keyboardevent-30">(9)</a> <a href="#ref-for-keyboardevent-keyboardevent-31">(10)</a>
+    <li><a href="#ref-for-keyboardevent-keyboardevent-32">5.6.4.2. keyup</a> <a href="#ref-for-keyboardevent-keyboardevent-33">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-34">(3)</a> <a href="#ref-for-keyboardevent-keyboardevent-35">(4)</a> <a href="#ref-for-keyboardevent-keyboardevent-36">(5)</a> <a href="#ref-for-keyboardevent-keyboardevent-37">(6)</a> <a href="#ref-for-keyboardevent-keyboardevent-38">(7)</a> <a href="#ref-for-keyboardevent-keyboardevent-39">(8)</a> <a href="#ref-for-keyboardevent-keyboardevent-40">(9)</a> <a href="#ref-for-keyboardevent-keyboardevent-41">(10)</a>
+    <li><a href="#ref-for-keyboardevent-keyboardevent-42">5.7.5. Key Events During Composition</a>
+    <li><a href="#ref-for-keyboardevent-keyboardevent-43">6.2.3. code Examples</a> <a href="#ref-for-keyboardevent-keyboardevent-44">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-45">(3)</a> <a href="#ref-for-keyboardevent-keyboardevent-46">(4)</a> <a href="#ref-for-keyboardevent-keyboardevent-47">(5)</a> <a href="#ref-for-keyboardevent-keyboardevent-48">(6)</a> <a href="#ref-for-keyboardevent-keyboardevent-49">(7)</a> <a href="#ref-for-keyboardevent-keyboardevent-50">(8)</a> <a href="#ref-for-keyboardevent-keyboardevent-51">(9)</a> <a href="#ref-for-keyboardevent-keyboardevent-52">(10)</a>
+    <li><a href="#ref-for-keyboardevent-keyboardevent-53">6.3.2. Modifier keys</a> <a href="#ref-for-keyboardevent-keyboardevent-54">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-55">(3)</a> <a href="#ref-for-keyboardevent-keyboardevent-56">(4)</a> <a href="#ref-for-keyboardevent-keyboardevent-57">(5)</a> <a href="#ref-for-keyboardevent-keyboardevent-58">(6)</a>
+    <li><a href="#ref-for-keyboardevent-keyboardevent-59">6.3.3. Dead keys</a> <a href="#ref-for-keyboardevent-keyboardevent-60">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-61">(3)</a> <a href="#ref-for-keyboardevent-keyboardevent-62">(4)</a>
+    <li><a href="#ref-for-keyboardevent-keyboardevent-63">6.3.4. Input Method Editors</a> <a href="#ref-for-keyboardevent-keyboardevent-64">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-65">(3)</a> <a href="#ref-for-keyboardevent-keyboardevent-66">(4)</a>
+    <li><a href="#ref-for-keyboardevent-keyboardevent-67">6.3.5. Default actions and cancelable keyboard events</a> <a href="#ref-for-keyboardevent-keyboardevent-68">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-69">(3)</a>
+    <li><a href="#ref-for-keyboardevent-keyboardevent-70">7.1.4. Initializers for interface KeyboardEvent</a>
+    <li><a href="#ref-for-keyboardevent-keyboardevent-71">8.1. Legacy KeyboardEvent supplemental interface</a>
+    <li><a href="#ref-for-keyboardevent-keyboardevent-72">8.1.1. Interface KeyboardEvent (supplemental)</a> <a href="#ref-for-keyboardevent-keyboardevent-73">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-74">(3)</a> <a href="#ref-for-keyboardevent-keyboardevent-75">(4)</a>
+    <li><a href="#ref-for-keyboardevent-keyboardevent-76">8.1.2. Interface KeyboardEventInit (supplemental)</a> <a href="#ref-for-keyboardevent-keyboardevent-77">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-78">(3)</a> <a href="#ref-for-keyboardevent-keyboardevent-79">(4)</a> <a href="#ref-for-keyboardevent-keyboardevent-80">(5)</a>
+    <li><a href="#ref-for-keyboardevent-keyboardevent-81">9. Legacy Event Types</a>
+    <li><a href="#ref-for-keyboardevent-keyboardevent-82">9.3. Legacy KeyboardEvent events</a>
+    <li><a href="#ref-for-keyboardevent-keyboardevent-83">9.3.1. Legacy KeyboardEvent event types</a>
+    <li><a href="#ref-for-keyboardevent-keyboardevent-84">9.3.1.1. keypress</a> <a href="#ref-for-keyboardevent-keyboardevent-85">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-86">(3)</a> <a href="#ref-for-keyboardevent-keyboardevent-87">(4)</a> <a href="#ref-for-keyboardevent-keyboardevent-88">(5)</a> <a href="#ref-for-keyboardevent-keyboardevent-89">(6)</a> <a href="#ref-for-keyboardevent-keyboardevent-90">(7)</a> <a href="#ref-for-keyboardevent-keyboardevent-91">(8)</a> <a href="#ref-for-keyboardevent-keyboardevent-92">(9)</a> <a href="#ref-for-keyboardevent-keyboardevent-93">(10)</a> <a href="#ref-for-keyboardevent-keyboardevent-94">(11)</a> <a href="#ref-for-keyboardevent-keyboardevent-95">(12)</a> <a href="#ref-for-keyboardevent-keyboardevent-96">(13)</a>
+    <li><a href="#ref-for-keyboardevent-keyboardevent-97">9.3.2. keypress event order</a>
+    <li><a href="#ref-for-keyboardevent-keyboardevent-98">12.1.4. New Interfaces</a>
+    <li><a href="#ref-for-keyboardevent-keyboardevent-99">12.2. Changes between different drafts of UI Events</a> <a href="#ref-for-keyboardevent-keyboardevent-100">(2)</a> <a href="#ref-for-keyboardevent-keyboardevent-101">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-keyboardevent-dom_key_location_standard">
+   <b><a href="#dom-keyboardevent-dom_key_location_standard">#dom-keyboardevent-dom_key_location_standard</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-keyboardevent-dom_key_location_standard-1">5.6.1. Interface KeyboardEvent</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_standard-2">(2)</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_standard-3">(3)</a>
+    <li><a href="#ref-for-dom-keyboardevent-dom_key_location_standard-4">5.6.2. Keyboard Event Key Location</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_standard-5">(2)</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_standard-6">(3)</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_standard-7">(4)</a>
+    <li><a href="#ref-for-dom-keyboardevent-dom_key_location_standard-8">6.3. Keyboard Event key Values</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-keyboardevent-dom_key_location_left">
+   <b><a href="#dom-keyboardevent-dom_key_location_left">#dom-keyboardevent-dom_key_location_left</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-keyboardevent-dom_key_location_left-1">5.6.1. Interface KeyboardEvent</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_left-2">(2)</a>
+    <li><a href="#ref-for-dom-keyboardevent-dom_key_location_left-3">5.6.2. Keyboard Event Key Location</a>
+    <li><a href="#ref-for-dom-keyboardevent-dom_key_location_left-4">6.2.3. code Examples</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_left-5">(2)</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_left-6">(3)</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_left-7">(4)</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_left-8">(5)</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_left-9">(6)</a>
+    <li><a href="#ref-for-dom-keyboardevent-dom_key_location_left-10">6.3. Keyboard Event key Values</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-keyboardevent-dom_key_location_right">
+   <b><a href="#dom-keyboardevent-dom_key_location_right">#dom-keyboardevent-dom_key_location_right</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-keyboardevent-dom_key_location_right-1">5.6.1. Interface KeyboardEvent</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_right-2">(2)</a>
+    <li><a href="#ref-for-dom-keyboardevent-dom_key_location_right-3">5.6.2. Keyboard Event Key Location</a>
+    <li><a href="#ref-for-dom-keyboardevent-dom_key_location_right-4">6.2.3. code Examples</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_right-5">(2)</a>
+    <li><a href="#ref-for-dom-keyboardevent-dom_key_location_right-6">6.3. Keyboard Event key Values</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-keyboardevent-dom_key_location_numpad">
+   <b><a href="#dom-keyboardevent-dom_key_location_numpad">#dom-keyboardevent-dom_key_location_numpad</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-keyboardevent-dom_key_location_numpad-1">5.6.1. Interface KeyboardEvent</a>
+    <li><a href="#ref-for-dom-keyboardevent-dom_key_location_numpad-2">5.6.2. Keyboard Event Key Location</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_numpad-3">(2)</a> <a href="#ref-for-dom-keyboardevent-dom_key_location_numpad-4">(3)</a>
+    <li><a href="#ref-for-dom-keyboardevent-dom_key_location_numpad-5">6.3. Keyboard Event key Values</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-keyboardevent-key">
+   <b><a href="#dom-keyboardevent-key">#dom-keyboardevent-key</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-keyboardevent-key-1">2. Stylistic Conventions</a> <a href="#ref-for-dom-keyboardevent-key-2">(2)</a>
+    <li><a href="#ref-for-dom-keyboardevent-key-3">3.5. Activation triggers and behavior</a>
+    <li><a href="#ref-for-dom-keyboardevent-key-4">5.6.1. Interface KeyboardEvent</a>
+    <li><a href="#ref-for-dom-keyboardevent-key-5">5.6.2. Keyboard Event Key Location</a> <a href="#ref-for-dom-keyboardevent-key-6">(2)</a>
+    <li><a href="#ref-for-dom-keyboardevent-key-7">5.6.4.1. keydown</a>
+    <li><a href="#ref-for-dom-keyboardevent-key-8">5.6.4.2. keyup</a>
+    <li><a href="#ref-for-dom-keyboardevent-key-9">6.2.1. Motivation for the code Attribute</a> <a href="#ref-for-dom-keyboardevent-key-10">(2)</a> <a href="#ref-for-dom-keyboardevent-key-11">(3)</a> <a href="#ref-for-dom-keyboardevent-key-12">(4)</a>
+    <li><a href="#ref-for-dom-keyboardevent-key-13">6.2.2. The Relationship Between key and code</a> <a href="#ref-for-dom-keyboardevent-key-14">(2)</a> <a href="#ref-for-dom-keyboardevent-key-15">(3)</a> <a href="#ref-for-dom-keyboardevent-key-16">(4)</a>
+    <li><a href="#ref-for-dom-keyboardevent-key-17">6.2.3. code Examples</a> <a href="#ref-for-dom-keyboardevent-key-18">(2)</a> <a href="#ref-for-dom-keyboardevent-key-19">(3)</a> <a href="#ref-for-dom-keyboardevent-key-20">(4)</a> <a href="#ref-for-dom-keyboardevent-key-21">(5)</a> <a href="#ref-for-dom-keyboardevent-key-22">(6)</a> <a href="#ref-for-dom-keyboardevent-key-23">(7)</a> <a href="#ref-for-dom-keyboardevent-key-24">(8)</a>
+    <li><a href="#ref-for-dom-keyboardevent-key-25">6.2.4. code and Virtual Keyboards</a>
+    <li><a href="#ref-for-dom-keyboardevent-key-26">6.3. Keyboard Event key Values</a> <a href="#ref-for-dom-keyboardevent-key-27">(2)</a> <a href="#ref-for-dom-keyboardevent-key-28">(3)</a>
+    <li><a href="#ref-for-dom-keyboardevent-key-29">6.3.2. Modifier keys</a> <a href="#ref-for-dom-keyboardevent-key-30">(2)</a> <a href="#ref-for-dom-keyboardevent-key-31">(3)</a> <a href="#ref-for-dom-keyboardevent-key-32">(4)</a> <a href="#ref-for-dom-keyboardevent-key-33">(5)</a> <a href="#ref-for-dom-keyboardevent-key-34">(6)</a> <a href="#ref-for-dom-keyboardevent-key-35">(7)</a>
+    <li><a href="#ref-for-dom-keyboardevent-key-36">6.3.3. Dead keys</a> <a href="#ref-for-dom-keyboardevent-key-37">(2)</a>
+    <li><a href="#ref-for-dom-keyboardevent-key-38">6.3.4. Input Method Editors</a> <a href="#ref-for-dom-keyboardevent-key-39">(2)</a>
+    <li><a href="#ref-for-dom-keyboardevent-key-40">6.3.5. Default actions and cancelable keyboard events</a> <a href="#ref-for-dom-keyboardevent-key-41">(2)</a> <a href="#ref-for-dom-keyboardevent-key-42">(3)</a>
+    <li><a href="#ref-for-dom-keyboardevent-key-43">6.3.6. Guidelines for selecting key values</a> <a href="#ref-for-dom-keyboardevent-key-44">(2)</a> <a href="#ref-for-dom-keyboardevent-key-45">(3)</a>
+    <li><a href="#ref-for-dom-keyboardevent-key-46">7.1.4. Initializers for interface KeyboardEvent</a>
+    <li><a href="#ref-for-dom-keyboardevent-key-47">8. Legacy Key Attributes</a>
+    <li><a href="#ref-for-dom-keyboardevent-key-48">8.1.1. Interface KeyboardEvent (supplemental)</a>
+    <li><a href="#ref-for-dom-keyboardevent-key-49">9.3.1.1. keypress</a>
+    <li><a href="#ref-for-dom-keyboardevent-key-50">9.3.2. keypress event order</a>
+    <li><a href="#ref-for-dom-keyboardevent-key-51">12.2. Changes between different drafts of UI Events</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-keyboardevent-code">
+   <b><a href="#dom-keyboardevent-code">#dom-keyboardevent-code</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-keyboardevent-code-1">2. Stylistic Conventions</a> <a href="#ref-for-dom-keyboardevent-code-2">(2)</a>
+    <li><a href="#ref-for-dom-keyboardevent-code-3">5.6.1. Interface KeyboardEvent</a>
+    <li><a href="#ref-for-dom-keyboardevent-code-4">5.6.4.1. keydown</a>
+    <li><a href="#ref-for-dom-keyboardevent-code-5">5.6.4.2. keyup</a>
+    <li><a href="#ref-for-dom-keyboardevent-code-6">6.2. Key codes</a> <a href="#ref-for-dom-keyboardevent-code-7">(2)</a> <a href="#ref-for-dom-keyboardevent-code-8">(3)</a>
+    <li><a href="#ref-for-dom-keyboardevent-code-9">6.2.1. Motivation for the code Attribute</a> <a href="#ref-for-dom-keyboardevent-code-10">(2)</a> <a href="#ref-for-dom-keyboardevent-code-11">(3)</a>
+    <li><a href="#ref-for-dom-keyboardevent-code-12">6.2.2. The Relationship Between key and code</a> <a href="#ref-for-dom-keyboardevent-code-13">(2)</a> <a href="#ref-for-dom-keyboardevent-code-14">(3)</a>
+    <li><a href="#ref-for-dom-keyboardevent-code-15">6.2.3. code Examples</a> <a href="#ref-for-dom-keyboardevent-code-16">(2)</a> <a href="#ref-for-dom-keyboardevent-code-17">(3)</a> <a href="#ref-for-dom-keyboardevent-code-18">(4)</a> <a href="#ref-for-dom-keyboardevent-code-19">(5)</a> <a href="#ref-for-dom-keyboardevent-code-20">(6)</a> <a href="#ref-for-dom-keyboardevent-code-21">(7)</a> <a href="#ref-for-dom-keyboardevent-code-22">(8)</a> <a href="#ref-for-dom-keyboardevent-code-23">(9)</a>
+    <li><a href="#ref-for-dom-keyboardevent-code-24">6.2.4. code and Virtual Keyboards</a> <a href="#ref-for-dom-keyboardevent-code-25">(2)</a> <a href="#ref-for-dom-keyboardevent-code-26">(3)</a> <a href="#ref-for-dom-keyboardevent-code-27">(4)</a> <a href="#ref-for-dom-keyboardevent-code-28">(5)</a>
+    <li><a href="#ref-for-dom-keyboardevent-code-29">6.3.2. Modifier keys</a>
+    <li><a href="#ref-for-dom-keyboardevent-code-30">9.3.1.1. keypress</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-keyboardevent-location">
+   <b><a href="#dom-keyboardevent-location">#dom-keyboardevent-location</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-keyboardevent-location-1">5.6.1. Interface KeyboardEvent</a> <a href="#ref-for-dom-keyboardevent-location-2">(2)</a> <a href="#ref-for-dom-keyboardevent-location-3">(3)</a> <a href="#ref-for-dom-keyboardevent-location-4">(4)</a> <a href="#ref-for-dom-keyboardevent-location-5">(5)</a> <a href="#ref-for-dom-keyboardevent-location-6">(6)</a> <a href="#ref-for-dom-keyboardevent-location-7">(7)</a>
+    <li><a href="#ref-for-dom-keyboardevent-location-8">5.6.2. Keyboard Event Key Location</a> <a href="#ref-for-dom-keyboardevent-location-9">(2)</a> <a href="#ref-for-dom-keyboardevent-location-10">(3)</a> <a href="#ref-for-dom-keyboardevent-location-11">(4)</a>
+    <li><a href="#ref-for-dom-keyboardevent-location-12">5.6.4.1. keydown</a>
+    <li><a href="#ref-for-dom-keyboardevent-location-13">5.6.4.2. keyup</a>
+    <li><a href="#ref-for-dom-keyboardevent-location-14">6.3. Keyboard Event key Values</a> <a href="#ref-for-dom-keyboardevent-location-15">(2)</a> <a href="#ref-for-dom-keyboardevent-location-16">(3)</a>
+    <li><a href="#ref-for-dom-keyboardevent-location-17">7.1.4. Initializers for interface KeyboardEvent</a>
+    <li><a href="#ref-for-dom-keyboardevent-location-18">9.3.1.1. keypress</a>
+    <li><a href="#ref-for-dom-keyboardevent-location-19">12.2. Changes between different drafts of UI Events</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-keyboardevent-ctrlkey">
+   <b><a href="#dom-keyboardevent-ctrlkey">#dom-keyboardevent-ctrlkey</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-keyboardevent-ctrlkey-1">5.3.1. Interface MouseEvent</a>
+    <li><a href="#ref-for-dom-keyboardevent-ctrlkey-2">5.6.1. Interface KeyboardEvent</a>
+    <li><a href="#ref-for-dom-keyboardevent-ctrlkey-3">5.6.4.1. keydown</a>
+    <li><a href="#ref-for-dom-keyboardevent-ctrlkey-4">5.6.4.2. keyup</a>
+    <li><a href="#ref-for-dom-keyboardevent-ctrlkey-5">6.3.2. Modifier keys</a> <a href="#ref-for-dom-keyboardevent-ctrlkey-6">(2)</a> <a href="#ref-for-dom-keyboardevent-ctrlkey-7">(3)</a> <a href="#ref-for-dom-keyboardevent-ctrlkey-8">(4)</a> <a href="#ref-for-dom-keyboardevent-ctrlkey-9">(5)</a> <a href="#ref-for-dom-keyboardevent-ctrlkey-10">(6)</a> <a href="#ref-for-dom-keyboardevent-ctrlkey-11">(7)</a> <a href="#ref-for-dom-keyboardevent-ctrlkey-12">(8)</a> <a href="#ref-for-dom-keyboardevent-ctrlkey-13">(9)</a> <a href="#ref-for-dom-keyboardevent-ctrlkey-14">(10)</a> <a href="#ref-for-dom-keyboardevent-ctrlkey-15">(11)</a> <a href="#ref-for-dom-keyboardevent-ctrlkey-16">(12)</a>
+    <li><a href="#ref-for-dom-keyboardevent-ctrlkey-17">9.3.1.1. keypress</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-keyboardevent-shiftkey">
+   <b><a href="#dom-keyboardevent-shiftkey">#dom-keyboardevent-shiftkey</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-keyboardevent-shiftkey-1">5.3.1. Interface MouseEvent</a>
+    <li><a href="#ref-for-dom-keyboardevent-shiftkey-2">5.6.1. Interface KeyboardEvent</a>
+    <li><a href="#ref-for-dom-keyboardevent-shiftkey-3">5.6.4.1. keydown</a>
+    <li><a href="#ref-for-dom-keyboardevent-shiftkey-4">5.6.4.2. keyup</a>
+    <li><a href="#ref-for-dom-keyboardevent-shiftkey-5">6.2.3. code Examples</a> <a href="#ref-for-dom-keyboardevent-shiftkey-6">(2)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-7">(3)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-8">(4)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-9">(5)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-10">(6)</a>
+    <li><a href="#ref-for-dom-keyboardevent-shiftkey-11">6.3.2. Modifier keys</a> <a href="#ref-for-dom-keyboardevent-shiftkey-12">(2)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-13">(3)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-14">(4)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-15">(5)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-16">(6)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-17">(7)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-18">(8)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-19">(9)</a>
+    <li><a href="#ref-for-dom-keyboardevent-shiftkey-20">6.3.5. Default actions and cancelable keyboard events</a> <a href="#ref-for-dom-keyboardevent-shiftkey-21">(2)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-22">(3)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-23">(4)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-24">(5)</a> <a href="#ref-for-dom-keyboardevent-shiftkey-25">(6)</a>
+    <li><a href="#ref-for-dom-keyboardevent-shiftkey-26">9.3.1.1. keypress</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-keyboardevent-altkey">
+   <b><a href="#dom-keyboardevent-altkey">#dom-keyboardevent-altkey</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-keyboardevent-altkey-1">5.3.1. Interface MouseEvent</a>
+    <li><a href="#ref-for-dom-keyboardevent-altkey-2">5.6.1. Interface KeyboardEvent</a>
+    <li><a href="#ref-for-dom-keyboardevent-altkey-3">5.6.4.1. keydown</a>
+    <li><a href="#ref-for-dom-keyboardevent-altkey-4">5.6.4.2. keyup</a>
+    <li><a href="#ref-for-dom-keyboardevent-altkey-5">6.3.2. Modifier keys</a>
+    <li><a href="#ref-for-dom-keyboardevent-altkey-6">9.3.1.1. keypress</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-keyboardevent-metakey">
+   <b><a href="#dom-keyboardevent-metakey">#dom-keyboardevent-metakey</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-keyboardevent-metakey-1">5.3.1. Interface MouseEvent</a>
+    <li><a href="#ref-for-dom-keyboardevent-metakey-2">5.6.1. Interface KeyboardEvent</a>
+    <li><a href="#ref-for-dom-keyboardevent-metakey-3">5.6.4.1. keydown</a>
+    <li><a href="#ref-for-dom-keyboardevent-metakey-4">5.6.4.2. keyup</a>
+    <li><a href="#ref-for-dom-keyboardevent-metakey-5">6.3.2. Modifier keys</a>
+    <li><a href="#ref-for-dom-keyboardevent-metakey-6">9.3.1.1. keypress</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-keyboardevent-repeat">
+   <b><a href="#dom-keyboardevent-repeat">#dom-keyboardevent-repeat</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-keyboardevent-repeat-1">5.6.1. Interface KeyboardEvent</a>
+    <li><a href="#ref-for-dom-keyboardevent-repeat-2">5.6.3. Keyboard Event Order</a>
+    <li><a href="#ref-for-dom-keyboardevent-repeat-3">5.6.4.1. keydown</a>
+    <li><a href="#ref-for-dom-keyboardevent-repeat-4">5.6.4.2. keyup</a>
+    <li><a href="#ref-for-dom-keyboardevent-repeat-5">7.1.4. Initializers for interface KeyboardEvent</a>
+    <li><a href="#ref-for-dom-keyboardevent-repeat-6">9.3.1.1. keypress</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-keyboardevent-iscomposing">
+   <b><a href="#dom-keyboardevent-iscomposing">#dom-keyboardevent-iscomposing</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-keyboardevent-iscomposing-1">5.6.4.1. keydown</a>
+    <li><a href="#ref-for-dom-keyboardevent-iscomposing-2">5.6.4.2. keyup</a>
+    <li><a href="#ref-for-dom-keyboardevent-iscomposing-3">5.7.5. Key Events During Composition</a> <a href="#ref-for-dom-keyboardevent-iscomposing-4">(2)</a>
+    <li><a href="#ref-for-dom-keyboardevent-iscomposing-5">6.3.3. Dead keys</a> <a href="#ref-for-dom-keyboardevent-iscomposing-6">(2)</a>
+    <li><a href="#ref-for-dom-keyboardevent-iscomposing-7">6.3.4. Input Method Editors</a> <a href="#ref-for-dom-keyboardevent-iscomposing-8">(2)</a>
+    <li><a href="#ref-for-dom-keyboardevent-iscomposing-9">9.3.1.1. keypress</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-keyboardevent-getmodifierstate">
+   <b><a href="#dom-keyboardevent-getmodifierstate">#dom-keyboardevent-getmodifierstate</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-keyboardevent-getmodifierstate-1">3.6. Constructing Mouse and Keyboard Events</a>
+    <li><a href="#ref-for-dom-keyboardevent-getmodifierstate-2">5.3.1. Interface MouseEvent</a>
+    <li><a href="#ref-for-dom-keyboardevent-getmodifierstate-3">5.3.2. Event Modifier Initializers</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-4">(2)</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-5">(3)</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-6">(4)</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-7">(5)</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-8">(6)</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-9">(7)</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-10">(8)</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-11">(9)</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-12">(10)</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-13">(11)</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-14">(12)</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-15">(13)</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-16">(14)</a> <a href="#ref-for-dom-keyboardevent-getmodifierstate-17">(15)</a>
+    <li><a href="#ref-for-dom-keyboardevent-getmodifierstate-18">5.6.1. Interface KeyboardEvent</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-keyboardeventinit">
+   <b><a href="#dictdef-keyboardeventinit">#dictdef-keyboardeventinit</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-keyboardeventinit-1">5.6.1. Interface KeyboardEvent</a> <a href="#ref-for-dictdef-keyboardeventinit-2">(2)</a>
+    <li><a href="#ref-for-dictdef-keyboardeventinit-3">8.1.2. Interface KeyboardEventInit (supplemental)</a> <a href="#ref-for-dictdef-keyboardeventinit-4">(2)</a> <a href="#ref-for-dictdef-keyboardeventinit-5">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="keydown">
+   <b><a href="#keydown">#keydown</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-keydown-1">3.5. Activation triggers and behavior</a>
+    <li><a href="#ref-for-keydown-2">4.1. List of Event Types</a>
+    <li><a href="#ref-for-keydown-3">5.6.1. Interface KeyboardEvent</a>
+    <li><a href="#ref-for-keydown-4">5.6.3. Keyboard Event Order</a> <a href="#ref-for-keydown-5">(2)</a> <a href="#ref-for-keydown-6">(3)</a>
+    <li><a href="#ref-for-keydown-7">5.6.4.1. keydown</a> <a href="#ref-for-keydown-8">(2)</a> <a href="#ref-for-keydown-9">(3)</a>
+    <li><a href="#ref-for-keydown-10">5.6.4.2. keyup</a> <a href="#ref-for-keydown-11">(2)</a>
+    <li><a href="#ref-for-keydown-12">5.7.4. Canceling Composition Events</a> <a href="#ref-for-keydown-13">(2)</a> <a href="#ref-for-keydown-14">(3)</a> <a href="#ref-for-keydown-15">(4)</a>
+    <li><a href="#ref-for-keydown-16">5.7.5. Key Events During Composition</a> <a href="#ref-for-keydown-17">(2)</a> <a href="#ref-for-keydown-18">(3)</a>
+    <li><a href="#ref-for-keydown-19">5.7.7.1. compositionstart</a>
+    <li><a href="#ref-for-keydown-20">6.2.3. code Examples</a> <a href="#ref-for-keydown-21">(2)</a> <a href="#ref-for-keydown-22">(3)</a> <a href="#ref-for-keydown-23">(4)</a>
+    <li><a href="#ref-for-keydown-24">6.3.2. Modifier keys</a> <a href="#ref-for-keydown-25">(2)</a> <a href="#ref-for-keydown-26">(3)</a> <a href="#ref-for-keydown-27">(4)</a> <a href="#ref-for-keydown-28">(5)</a> <a href="#ref-for-keydown-29">(6)</a> <a href="#ref-for-keydown-30">(7)</a> <a href="#ref-for-keydown-31">(8)</a> <a href="#ref-for-keydown-32">(9)</a> <a href="#ref-for-keydown-33">(10)</a> <a href="#ref-for-keydown-34">(11)</a> <a href="#ref-for-keydown-35">(12)</a> <a href="#ref-for-keydown-36">(13)</a>
+    <li><a href="#ref-for-keydown-37">6.3.3. Dead keys</a> <a href="#ref-for-keydown-38">(2)</a> <a href="#ref-for-keydown-39">(3)</a> <a href="#ref-for-keydown-40">(4)</a> <a href="#ref-for-keydown-41">(5)</a>
+    <li><a href="#ref-for-keydown-42">6.3.4. Input Method Editors</a> <a href="#ref-for-keydown-43">(2)</a> <a href="#ref-for-keydown-44">(3)</a> <a href="#ref-for-keydown-45">(4)</a> <a href="#ref-for-keydown-46">(5)</a> <a href="#ref-for-keydown-47">(6)</a> <a href="#ref-for-keydown-48">(7)</a> <a href="#ref-for-keydown-49">(8)</a> <a href="#ref-for-keydown-50">(9)</a> <a href="#ref-for-keydown-51">(10)</a> <a href="#ref-for-keydown-52">(11)</a>
+    <li><a href="#ref-for-keydown-53">6.3.5. Default actions and cancelable keyboard events</a> <a href="#ref-for-keydown-54">(2)</a> <a href="#ref-for-keydown-55">(3)</a> <a href="#ref-for-keydown-56">(4)</a> <a href="#ref-for-keydown-57">(5)</a> <a href="#ref-for-keydown-58">(6)</a> <a href="#ref-for-keydown-59">(7)</a> <a href="#ref-for-keydown-60">(8)</a>
+    <li><a href="#ref-for-keydown-61">8.1.1. Interface KeyboardEvent (supplemental)</a>
+    <li><a href="#ref-for-keydown-62">8.2.1. How to determine keyCode for keydown and keyup events</a> <a href="#ref-for-keydown-63">(2)</a> <a href="#ref-for-keydown-64">(3)</a>
+    <li><a href="#ref-for-keydown-65">9.1.2. Activation event order</a>
+    <li><a href="#ref-for-keydown-66">9.3.2. keypress event order</a> <a href="#ref-for-keydown-67">(2)</a>
+    <li><a href="#ref-for-keydown-68">14. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="keyup">
+   <b><a href="#keyup">#keyup</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-keyup-1">4.1. List of Event Types</a>
+    <li><a href="#ref-for-keyup-2">5.6.3. Keyboard Event Order</a> <a href="#ref-for-keyup-3">(2)</a> <a href="#ref-for-keyup-4">(3)</a> <a href="#ref-for-keyup-5">(4)</a>
+    <li><a href="#ref-for-keyup-6">5.6.4.1. keydown</a> <a href="#ref-for-keyup-7">(2)</a>
+    <li><a href="#ref-for-keyup-8">5.6.4.2. keyup</a> <a href="#ref-for-keyup-9">(2)</a>
+    <li><a href="#ref-for-keyup-10">5.7.4. Canceling Composition Events</a> <a href="#ref-for-keyup-11">(2)</a>
+    <li><a href="#ref-for-keyup-12">5.7.5. Key Events During Composition</a> <a href="#ref-for-keyup-13">(2)</a> <a href="#ref-for-keyup-14">(3)</a>
+    <li><a href="#ref-for-keyup-15">6.2.3. code Examples</a> <a href="#ref-for-keyup-16">(2)</a> <a href="#ref-for-keyup-17">(3)</a> <a href="#ref-for-keyup-18">(4)</a>
+    <li><a href="#ref-for-keyup-19">6.3.2. Modifier keys</a> <a href="#ref-for-keyup-20">(2)</a> <a href="#ref-for-keyup-21">(3)</a> <a href="#ref-for-keyup-22">(4)</a> <a href="#ref-for-keyup-23">(5)</a> <a href="#ref-for-keyup-24">(6)</a> <a href="#ref-for-keyup-25">(7)</a> <a href="#ref-for-keyup-26">(8)</a> <a href="#ref-for-keyup-27">(9)</a> <a href="#ref-for-keyup-28">(10)</a> <a href="#ref-for-keyup-29">(11)</a> <a href="#ref-for-keyup-30">(12)</a> <a href="#ref-for-keyup-31">(13)</a> <a href="#ref-for-keyup-32">(14)</a>
+    <li><a href="#ref-for-keyup-33">6.3.3. Dead keys</a> <a href="#ref-for-keyup-34">(2)</a> <a href="#ref-for-keyup-35">(3)</a> <a href="#ref-for-keyup-36">(4)</a>
+    <li><a href="#ref-for-keyup-37">6.3.4. Input Method Editors</a> <a href="#ref-for-keyup-38">(2)</a> <a href="#ref-for-keyup-39">(3)</a> <a href="#ref-for-keyup-40">(4)</a> <a href="#ref-for-keyup-41">(5)</a> <a href="#ref-for-keyup-42">(6)</a> <a href="#ref-for-keyup-43">(7)</a> <a href="#ref-for-keyup-44">(8)</a> <a href="#ref-for-keyup-45">(9)</a> <a href="#ref-for-keyup-46">(10)</a>
+    <li><a href="#ref-for-keyup-47">6.3.5. Default actions and cancelable keyboard events</a> <a href="#ref-for-keyup-48">(2)</a> <a href="#ref-for-keyup-49">(3)</a> <a href="#ref-for-keyup-50">(4)</a> <a href="#ref-for-keyup-51">(5)</a> <a href="#ref-for-keyup-52">(6)</a> <a href="#ref-for-keyup-53">(7)</a> <a href="#ref-for-keyup-54">(8)</a>
+    <li><a href="#ref-for-keyup-55">8.1.1. Interface KeyboardEvent (supplemental)</a>
+    <li><a href="#ref-for-keyup-56">8.2.1. How to determine keyCode for keydown and keyup events</a> <a href="#ref-for-keyup-57">(2)</a>
+    <li><a href="#ref-for-keyup-58">9.3.2. keypress event order</a> <a href="#ref-for-keyup-59">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="compositionevent">
+   <b><a href="#compositionevent">#compositionevent</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-compositionevent-1">4.1. List of Event Types</a> <a href="#ref-for-compositionevent-2">(2)</a> <a href="#ref-for-compositionevent-3">(3)</a>
+    <li><a href="#ref-for-compositionevent-4">5.7.1. Interface CompositionEvent</a> <a href="#ref-for-compositionevent-5">(2)</a> <a href="#ref-for-compositionevent-6">(3)</a>
+    <li><a href="#ref-for-compositionevent-7">5.7.3. Handwriting Recognition Systems</a>
+    <li><a href="#ref-for-compositionevent-8">5.7.7.1. compositionstart</a> <a href="#ref-for-compositionevent-9">(2)</a>
+    <li><a href="#ref-for-compositionevent-10">5.7.7.2. compositionupdate</a> <a href="#ref-for-compositionevent-11">(2)</a>
+    <li><a href="#ref-for-compositionevent-12">5.7.7.3. compositionend</a> <a href="#ref-for-compositionevent-13">(2)</a>
+    <li><a href="#ref-for-compositionevent-14">6.3.3. Dead keys</a> <a href="#ref-for-compositionevent-15">(2)</a>
+    <li><a href="#ref-for-compositionevent-16">6.3.4. Input Method Editors</a> <a href="#ref-for-compositionevent-17">(2)</a> <a href="#ref-for-compositionevent-18">(3)</a> <a href="#ref-for-compositionevent-19">(4)</a>
+    <li><a href="#ref-for-compositionevent-20">12.1.4. New Interfaces</a>
+    <li><a href="#ref-for-compositionevent-21">12.2. Changes between different drafts of UI Events</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-compositionevent-data">
+   <b><a href="#dom-compositionevent-data">#dom-compositionevent-data</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-compositionevent-data-1">5.7. Composition Events</a>
+    <li><a href="#ref-for-dom-compositionevent-data-2">5.7.3. Handwriting Recognition Systems</a>
+    <li><a href="#ref-for-dom-compositionevent-data-3">5.7.7.1. compositionstart</a> <a href="#ref-for-dom-compositionevent-data-4">(2)</a> <a href="#ref-for-dom-compositionevent-data-5">(3)</a>
+    <li><a href="#ref-for-dom-compositionevent-data-6">5.7.7.2. compositionupdate</a> <a href="#ref-for-dom-compositionevent-data-7">(2)</a> <a href="#ref-for-dom-compositionevent-data-8">(3)</a>
+    <li><a href="#ref-for-dom-compositionevent-data-9">5.7.7.3. compositionend</a>
+    <li><a href="#ref-for-dom-compositionevent-data-10">6.3. Keyboard Event key Values</a> <a href="#ref-for-dom-compositionevent-data-11">(2)</a>
+    <li><a href="#ref-for-dom-compositionevent-data-12">6.3.3. Dead keys</a> <a href="#ref-for-dom-compositionevent-data-13">(2)</a> <a href="#ref-for-dom-compositionevent-data-14">(3)</a>
+    <li><a href="#ref-for-dom-compositionevent-data-15">6.3.4. Input Method Editors</a> <a href="#ref-for-dom-compositionevent-data-16">(2)</a> <a href="#ref-for-dom-compositionevent-data-17">(3)</a>
+    <li><a href="#ref-for-dom-compositionevent-data-18">7.1.5. Initializers for interface CompositionEvent</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dictdef-compositioneventinit">
+   <b><a href="#dictdef-compositioneventinit">#dictdef-compositioneventinit</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-compositioneventinit-1">5.7.1. Interface CompositionEvent</a> <a href="#ref-for-dictdef-compositioneventinit-2">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="compositionstart">
+   <b><a href="#compositionstart">#compositionstart</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-compositionstart-1">4.1. List of Event Types</a>
+    <li><a href="#ref-for-compositionstart-2">5.5.1. Interface InputEvent</a>
+    <li><a href="#ref-for-compositionstart-3">5.6.1. Interface KeyboardEvent</a>
+    <li><a href="#ref-for-compositionstart-4">5.7. Composition Events</a> <a href="#ref-for-compositionstart-5">(2)</a>
+    <li><a href="#ref-for-compositionstart-6">5.7.2. Composition Event Order</a>
+    <li><a href="#ref-for-compositionstart-7">5.7.3. Handwriting Recognition Systems</a>
+    <li><a href="#ref-for-compositionstart-8">5.7.4. Canceling Composition Events</a> <a href="#ref-for-compositionstart-9">(2)</a>
+    <li><a href="#ref-for-compositionstart-10">5.7.5. Key Events During Composition</a>
+    <li><a href="#ref-for-compositionstart-11">5.7.7.1. compositionstart</a> <a href="#ref-for-compositionstart-12">(2)</a>
+    <li><a href="#ref-for-compositionstart-13">6.3.3. Dead keys</a> <a href="#ref-for-compositionstart-14">(2)</a>
+    <li><a href="#ref-for-compositionstart-15">6.3.4. Input Method Editors</a> <a href="#ref-for-compositionstart-16">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="compositionupdate">
+   <b><a href="#compositionupdate">#compositionupdate</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-compositionupdate-1">4.1. List of Event Types</a>
+    <li><a href="#ref-for-compositionupdate-2">5.7. Composition Events</a>
+    <li><a href="#ref-for-compositionupdate-3">5.7.2. Composition Event Order</a>
+    <li><a href="#ref-for-compositionupdate-4">5.7.3. Handwriting Recognition Systems</a> <a href="#ref-for-compositionupdate-5">(2)</a>
+    <li><a href="#ref-for-compositionupdate-6">5.7.5. Key Events During Composition</a>
+    <li><a href="#ref-for-compositionupdate-7">5.7.6. Input Events During Composition</a> <a href="#ref-for-compositionupdate-8">(2)</a> <a href="#ref-for-compositionupdate-9">(3)</a> <a href="#ref-for-compositionupdate-10">(4)</a>
+    <li><a href="#ref-for-compositionupdate-11">5.7.7.2. compositionupdate</a>
+    <li><a href="#ref-for-compositionupdate-12">6.3.3. Dead keys</a> <a href="#ref-for-compositionupdate-13">(2)</a> <a href="#ref-for-compositionupdate-14">(3)</a> <a href="#ref-for-compositionupdate-15">(4)</a> <a href="#ref-for-compositionupdate-16">(5)</a>
+    <li><a href="#ref-for-compositionupdate-17">6.3.4. Input Method Editors</a> <a href="#ref-for-compositionupdate-18">(2)</a> <a href="#ref-for-compositionupdate-19">(3)</a> <a href="#ref-for-compositionupdate-20">(4)</a> <a href="#ref-for-compositionupdate-21">(5)</a> <a href="#ref-for-compositionupdate-22">(6)</a> <a href="#ref-for-compositionupdate-23">(7)</a> <a href="#ref-for-compositionupdate-24">(8)</a> <a href="#ref-for-compositionupdate-25">(9)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="compositionend">
+   <b><a href="#compositionend">#compositionend</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-compositionend-1">4.1. List of Event Types</a>
+    <li><a href="#ref-for-compositionend-2">5.5.1. Interface InputEvent</a>
+    <li><a href="#ref-for-compositionend-3">5.6.1. Interface KeyboardEvent</a>
+    <li><a href="#ref-for-compositionend-4">5.7. Composition Events</a>
+    <li><a href="#ref-for-compositionend-5">5.7.2. Composition Event Order</a>
+    <li><a href="#ref-for-compositionend-6">5.7.3. Handwriting Recognition Systems</a>
+    <li><a href="#ref-for-compositionend-7">5.7.4. Canceling Composition Events</a> <a href="#ref-for-compositionend-8">(2)</a>
+    <li><a href="#ref-for-compositionend-9">5.7.5. Key Events During Composition</a>
+    <li><a href="#ref-for-compositionend-10">5.7.6. Input Events During Composition</a> <a href="#ref-for-compositionend-11">(2)</a>
+    <li><a href="#ref-for-compositionend-12">5.7.7.2. compositionupdate</a>
+    <li><a href="#ref-for-compositionend-13">5.7.7.3. compositionend</a>
+    <li><a href="#ref-for-compositionend-14">6.3.3. Dead keys</a> <a href="#ref-for-compositionend-15">(2)</a>
+    <li><a href="#ref-for-compositionend-16">6.3.4. Input Method Editors</a> <a href="#ref-for-compositionend-17">(2)</a> <a href="#ref-for-compositionend-18">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-keyboardevent-charcode">
+   <b><a href="#dom-keyboardevent-charcode">#dom-keyboardevent-charcode</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-keyboardevent-charcode-1">6.3.1. Key Values and Unicode</a>
+    <li><a href="#ref-for-dom-keyboardevent-charcode-2">8. Legacy Key Attributes</a>
+    <li><a href="#ref-for-dom-keyboardevent-charcode-3">8.1. Legacy KeyboardEvent supplemental interface</a> <a href="#ref-for-dom-keyboardevent-charcode-4">(2)</a>
+    <li><a href="#ref-for-dom-keyboardevent-charcode-5">8.1.1. Interface KeyboardEvent (supplemental)</a> <a href="#ref-for-dom-keyboardevent-charcode-6">(2)</a> <a href="#ref-for-dom-keyboardevent-charcode-7">(3)</a>
+    <li><a href="#ref-for-dom-keyboardevent-charcode-8">8.1.2. Interface KeyboardEventInit (supplemental)</a> <a href="#ref-for-dom-keyboardevent-charcode-9">(2)</a> <a href="#ref-for-dom-keyboardevent-charcode-10">(3)</a>
+    <li><a href="#ref-for-dom-keyboardevent-charcode-11">8.2. Legacy key models</a>
+    <li><a href="#ref-for-dom-keyboardevent-charcode-12">9.3. Legacy KeyboardEvent events</a>
+    <li><a href="#ref-for-dom-keyboardevent-charcode-13">9.3.1.1. keypress</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-keyboardevent-keycode">
+   <b><a href="#dom-keyboardevent-keycode">#dom-keyboardevent-keycode</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-keyboardevent-keycode-1">6.3.1. Key Values and Unicode</a>
+    <li><a href="#ref-for-dom-keyboardevent-keycode-2">8. Legacy Key Attributes</a>
+    <li><a href="#ref-for-dom-keyboardevent-keycode-3">8.1. Legacy KeyboardEvent supplemental interface</a> <a href="#ref-for-dom-keyboardevent-keycode-4">(2)</a>
+    <li><a href="#ref-for-dom-keyboardevent-keycode-5">8.1.1. Interface KeyboardEvent (supplemental)</a> <a href="#ref-for-dom-keyboardevent-keycode-6">(2)</a> <a href="#ref-for-dom-keyboardevent-keycode-7">(3)</a> <a href="#ref-for-dom-keyboardevent-keycode-8">(4)</a> <a href="#ref-for-dom-keyboardevent-keycode-9">(5)</a>
+    <li><a href="#ref-for-dom-keyboardevent-keycode-10">8.1.2. Interface KeyboardEventInit (supplemental)</a> <a href="#ref-for-dom-keyboardevent-keycode-11">(2)</a> <a href="#ref-for-dom-keyboardevent-keycode-12">(3)</a> <a href="#ref-for-dom-keyboardevent-keycode-13">(4)</a>
+    <li><a href="#ref-for-dom-keyboardevent-keycode-14">8.2. Legacy key models</a> <a href="#ref-for-dom-keyboardevent-keycode-15">(2)</a>
+    <li><a href="#ref-for-dom-keyboardevent-keycode-16">8.2.1. How to determine keyCode for keydown and keyup events</a> <a href="#ref-for-dom-keyboardevent-keycode-17">(2)</a>
+    <li><a href="#ref-for-dom-keyboardevent-keycode-18">8.2.2. How to determine keyCode for keypress events</a> <a href="#ref-for-dom-keyboardevent-keycode-19">(2)</a> <a href="#ref-for-dom-keyboardevent-keycode-20">(3)</a> <a href="#ref-for-dom-keyboardevent-keycode-21">(4)</a>
+    <li><a href="#ref-for-dom-keyboardevent-keycode-22">9.3. Legacy KeyboardEvent events</a>
+    <li><a href="#ref-for-dom-keyboardevent-keycode-23">9.3.1.1. keypress</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-keyboardevent-which">
+   <b><a href="#dom-keyboardevent-which">#dom-keyboardevent-which</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-keyboardevent-which-1">8.1. Legacy KeyboardEvent supplemental interface</a> <a href="#ref-for-dom-keyboardevent-which-2">(2)</a>
+    <li><a href="#ref-for-dom-keyboardevent-which-3">8.1.1. Interface KeyboardEvent (supplemental)</a> <a href="#ref-for-dom-keyboardevent-which-4">(2)</a>
+    <li><a href="#ref-for-dom-keyboardevent-which-5">8.1.2. Interface KeyboardEventInit (supplemental)</a> <a href="#ref-for-dom-keyboardevent-which-6">(2)</a> <a href="#ref-for-dom-keyboardevent-which-7">(3)</a>
+    <li><a href="#ref-for-dom-keyboardevent-which-8">9.3. Legacy KeyboardEvent events</a>
+    <li><a href="#ref-for-dom-keyboardevent-which-9">9.3.1.1. keypress</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="domactivate">
+   <b><a href="#domactivate">#domactivate</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-domactivate-1">5.6.4.1. keydown</a>
+    <li><a href="#ref-for-domactivate-2">9. Legacy Event Types</a> <a href="#ref-for-domactivate-3">(2)</a>
+    <li><a href="#ref-for-domactivate-4">9.1.1.1. DOMActivate</a> <a href="#ref-for-domactivate-5">(2)</a> <a href="#ref-for-domactivate-6">(3)</a> <a href="#ref-for-domactivate-7">(4)</a> <a href="#ref-for-domactivate-8">(5)</a> <a href="#ref-for-domactivate-9">(6)</a> <a href="#ref-for-domactivate-10">(7)</a> <a href="#ref-for-domactivate-11">(8)</a> <a href="#ref-for-domactivate-12">(9)</a> <a href="#ref-for-domactivate-13">(10)</a> <a href="#ref-for-domactivate-14">(11)</a> <a href="#ref-for-domactivate-15">(12)</a> <a href="#ref-for-domactivate-16">(13)</a>
+    <li><a href="#ref-for-domactivate-17">9.1.2. Activation event order</a> <a href="#ref-for-domactivate-18">(2)</a>
+    <li><a href="#ref-for-domactivate-19">9.3.1.1. keypress</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="domfocusin">
+   <b><a href="#domfocusin">#domfocusin</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-domfocusin-1">9. Legacy Event Types</a>
+    <li><a href="#ref-for-domfocusin-2">9.2.1.1. DOMFocusIn</a>
+    <li><a href="#ref-for-domfocusin-3">9.2.2. Legacy FocusEvent event order</a> <a href="#ref-for-domfocusin-4">(2)</a> <a href="#ref-for-domfocusin-5">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="domfocusout">
+   <b><a href="#domfocusout">#domfocusout</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-domfocusout-1">9. Legacy Event Types</a>
+    <li><a href="#ref-for-domfocusout-2">9.2.1.2. DOMFocusOut</a>
+    <li><a href="#ref-for-domfocusout-3">9.2.2. Legacy FocusEvent event order</a> <a href="#ref-for-domfocusout-4">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="keypress">
+   <b><a href="#keypress">#keypress</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-keypress-1">4.1. List of Event Types</a>
+    <li><a href="#ref-for-keypress-2">5.6.4.1. keydown</a>
+    <li><a href="#ref-for-keypress-3">6.2.3. code Examples</a> <a href="#ref-for-keypress-4">(2)</a>
+    <li><a href="#ref-for-keypress-5">6.3.5. Default actions and cancelable keyboard events</a> <a href="#ref-for-keypress-6">(2)</a>
+    <li><a href="#ref-for-keypress-7">8.1.1. Interface KeyboardEvent (supplemental)</a>
+    <li><a href="#ref-for-keypress-8">8.2.2. How to determine keyCode for keypress events</a> <a href="#ref-for-keypress-9">(2)</a>
+    <li><a href="#ref-for-keypress-10">9. Legacy Event Types</a>
+    <li><a href="#ref-for-keypress-11">9.3. Legacy KeyboardEvent events</a> <a href="#ref-for-keypress-12">(2)</a> <a href="#ref-for-keypress-13">(3)</a>
+    <li><a href="#ref-for-keypress-14">9.3.1.1. keypress</a> <a href="#ref-for-keypress-15">(2)</a> <a href="#ref-for-keypress-16">(3)</a> <a href="#ref-for-keypress-17">(4)</a>
+    <li><a href="#ref-for-keypress-18">9.3.2. keypress event order</a> <a href="#ref-for-keypress-19">(2)</a> <a href="#ref-for-keypress-20">(3)</a> <a href="#ref-for-keypress-21">(4)</a> <a href="#ref-for-keypress-22">(5)</a>
+    <li><a href="#ref-for-keypress-23">12.2. Changes between different drafts of UI Events</a> <a href="#ref-for-keypress-24">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="domattrmodified">
+   <b><a href="#domattrmodified">#domattrmodified</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-domattrmodified-1">9. Legacy Event Types</a>
+    <li><a href="#ref-for-domattrmodified-2">9.4.1. Interface MutationEvent</a> <a href="#ref-for-domattrmodified-3">(2)</a> <a href="#ref-for-domattrmodified-4">(3)</a> <a href="#ref-for-domattrmodified-5">(4)</a> <a href="#ref-for-domattrmodified-6">(5)</a>
+    <li><a href="#ref-for-domattrmodified-7">9.4.2.1. DOMAttrModified</a>
+    <li><a href="#ref-for-domattrmodified-8">9.4.2.3. DOMNodeInserted</a>
+    <li><a href="#ref-for-domattrmodified-9">9.4.2.5. DOMNodeRemoved</a>
+    <li><a href="#ref-for-domattrmodified-10">9.4.2.6. DOMNodeRemovedFromDocument</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="domcharacterdatamodified">
+   <b><a href="#domcharacterdatamodified">#domcharacterdatamodified</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-domcharacterdatamodified-1">9. Legacy Event Types</a>
+    <li><a href="#ref-for-domcharacterdatamodified-2">9.4.1. Interface MutationEvent</a> <a href="#ref-for-domcharacterdatamodified-3">(2)</a>
+    <li><a href="#ref-for-domcharacterdatamodified-4">9.4.2.2. DOMCharacterDataModified</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="domnodeinserted">
+   <b><a href="#domnodeinserted">#domnodeinserted</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-domnodeinserted-1">9. Legacy Event Types</a>
+    <li><a href="#ref-for-domnodeinserted-2">9.4.2.3. DOMNodeInserted</a>
+    <li><a href="#ref-for-domnodeinserted-3">9.4.2.4. DOMNodeInsertedIntoDocument</a>
+    <li><a href="#ref-for-domnodeinserted-4">12.1.2. Changes to DOM Level 2 event types</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="domnodeinsertedintodocument">
+   <b><a href="#domnodeinsertedintodocument">#domnodeinsertedintodocument</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-domnodeinsertedintodocument-1">9. Legacy Event Types</a>
+    <li><a href="#ref-for-domnodeinsertedintodocument-2">9.4.2.4. DOMNodeInsertedIntoDocument</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="domnoderemoved">
+   <b><a href="#domnoderemoved">#domnoderemoved</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-domnoderemoved-1">9. Legacy Event Types</a>
+    <li><a href="#ref-for-domnoderemoved-2">9.4.2.5. DOMNodeRemoved</a>
+    <li><a href="#ref-for-domnoderemoved-3">9.4.2.6. DOMNodeRemovedFromDocument</a>
+    <li><a href="#ref-for-domnoderemoved-4">12.1.2. Changes to DOM Level 2 event types</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="domnoderemovedfromdocument">
+   <b><a href="#domnoderemovedfromdocument">#domnoderemovedfromdocument</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-domnoderemovedfromdocument-1">9. Legacy Event Types</a>
+    <li><a href="#ref-for-domnoderemovedfromdocument-2">9.4.2.6. DOMNodeRemovedFromDocument</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="domsubtreemodified">
+   <b><a href="#domsubtreemodified">#domsubtreemodified</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-domsubtreemodified-1">9. Legacy Event Types</a>
+    <li><a href="#ref-for-domsubtreemodified-2">9.4.2.7. DOMSubtreeModified</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="activation-behavior">
+   <b><a href="#activation-behavior">#activation-behavior</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-activation-behavior-1">3.5. Activation triggers and behavior</a>
+    <li><a href="#ref-for-activation-behavior-2">4.1. List of Event Types</a> <a href="#ref-for-activation-behavior-3">(2)</a> <a href="#ref-for-activation-behavior-4">(3)</a>
+    <li><a href="#ref-for-activation-behavior-5">5.6.4.1. keydown</a>
+    <li><a href="#ref-for-activation-behavior-6">9.1.1.1. DOMActivate</a>
+    <li><a href="#ref-for-activation-behavior-7">9.1.2. Activation event order</a> <a href="#ref-for-activation-behavior-8">(2)</a>
+    <li><a href="#ref-for-activation-behavior-9">14. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="activation-trigger">
+   <b><a href="#activation-trigger">#activation-trigger</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-activation-trigger-1">3.5. Activation triggers and behavior</a> <a href="#ref-for-activation-trigger-2">(2)</a> <a href="#ref-for-activation-trigger-3">(3)</a> <a href="#ref-for-activation-trigger-4">(4)</a> <a href="#ref-for-activation-trigger-5">(5)</a>
+    <li><a href="#ref-for-activation-trigger-6">9.1.1.1. DOMActivate</a> <a href="#ref-for-activation-trigger-7">(2)</a> <a href="#ref-for-activation-trigger-8">(3)</a>
+    <li><a href="#ref-for-activation-trigger-9">14. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="body-element">
+   <b><a href="#body-element">#body-element</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-body-element-1">5.3.3. Mouse Event Order</a>
+    <li><a href="#ref-for-body-element-2">5.6.3. Keyboard Event Order</a>
+    <li><a href="#ref-for-body-element-3">5.6.4.1. keydown</a>
+    <li><a href="#ref-for-body-element-4">5.6.4.2. keyup</a>
+    <li><a href="#ref-for-body-element-5">9.3.1.1. keypress</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="bubble-phase">
+   <b><a href="#bubble-phase">#bubble-phase</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-bubble-phase-1">3.1. Event dispatch and DOM event flow</a>
+    <li><a href="#ref-for-bubble-phase-2">14. Glossary</a> <a href="#ref-for-bubble-phase-3">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="capture-phase">
+   <b><a href="#capture-phase">#capture-phase</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-capture-phase-1">3.1. Event dispatch and DOM event flow</a>
+    <li><a href="#ref-for-capture-phase-2">14. Glossary</a> <a href="#ref-for-capture-phase-3">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="character-value">
+   <b><a href="#character-value">#character-value</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-character-value-1">5.6.1. Interface KeyboardEvent</a>
+    <li><a href="#ref-for-character-value-2">5.6.3. Keyboard Event Order</a> <a href="#ref-for-character-value-3">(2)</a>
+    <li><a href="#ref-for-character-value-4">5.6.4.1. keydown</a>
+    <li><a href="#ref-for-character-value-5">5.6.4.2. keyup</a>
+    <li><a href="#ref-for-character-value-6">6.3. Keyboard Event key Values</a> <a href="#ref-for-character-value-7">(2)</a>
+    <li><a href="#ref-for-character-value-8">6.3.1. Key Values and Unicode</a>
+    <li><a href="#ref-for-character-value-9">9.3.1.1. keypress</a> <a href="#ref-for-character-value-10">(2)</a>
+    <li><a href="#ref-for-character-value-11">14. Glossary</a> <a href="#ref-for-character-value-12">(2)</a> <a href="#ref-for-character-value-13">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="current-event-target">
+   <b><a href="#current-event-target">#current-event-target</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-current-event-target-1">3.1. Event dispatch and DOM event flow</a>
+    <li><a href="#ref-for-current-event-target-2">14. Glossary</a> <a href="#ref-for-current-event-target-3">(2)</a> <a href="#ref-for-current-event-target-4">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dead-key">
+   <b><a href="#dead-key">#dead-key</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dead-key-1">6. Keyboard events and key values</a>
+    <li><a href="#ref-for-dead-key-2">6.3. Keyboard Event key Values</a> <a href="#ref-for-dead-key-3">(2)</a>
+    <li><a href="#ref-for-dead-key-4">6.3.3. Dead keys</a> <a href="#ref-for-dead-key-5">(2)</a> <a href="#ref-for-dead-key-6">(3)</a> <a href="#ref-for-dead-key-7">(4)</a> <a href="#ref-for-dead-key-8">(5)</a>
+    <li><a href="#ref-for-dead-key-9">6.3.5. Default actions and cancelable keyboard events</a> <a href="#ref-for-dead-key-10">(2)</a>
+    <li><a href="#ref-for-dead-key-11">6.3.6. Guidelines for selecting key values</a>
+    <li><a href="#ref-for-dead-key-12">14. Glossary</a> <a href="#ref-for-dead-key-13">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="default-action">
+   <b><a href="#default-action">#default-action</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-default-action-1">3.2. Default actions and cancelable events</a> <a href="#ref-for-default-action-2">(2)</a> <a href="#ref-for-default-action-3">(3)</a> <a href="#ref-for-default-action-4">(4)</a> <a href="#ref-for-default-action-5">(5)</a> <a href="#ref-for-default-action-6">(6)</a> <a href="#ref-for-default-action-7">(7)</a> <a href="#ref-for-default-action-8">(8)</a> <a href="#ref-for-default-action-9">(9)</a>
+    <li><a href="#ref-for-default-action-10">3.4. Trusted events</a> <a href="#ref-for-default-action-11">(2)</a>
+    <li><a href="#ref-for-default-action-12">5.3.1. Interface MouseEvent</a> <a href="#ref-for-default-action-13">(2)</a>
+    <li><a href="#ref-for-default-action-14">5.3.4.1. click</a> <a href="#ref-for-default-action-15">(2)</a> <a href="#ref-for-default-action-16">(3)</a> <a href="#ref-for-default-action-17">(4)</a>
+    <li><a href="#ref-for-default-action-18">5.3.4.2. dblclick</a> <a href="#ref-for-default-action-19">(2)</a> <a href="#ref-for-default-action-20">(3)</a>
+    <li><a href="#ref-for-default-action-21">5.3.4.3. mousedown</a>
+    <li><a href="#ref-for-default-action-22">5.4.2.1. wheel</a>
+    <li><a href="#ref-for-default-action-23">5.6.3. Keyboard Event Order</a> <a href="#ref-for-default-action-24">(2)</a> <a href="#ref-for-default-action-25">(3)</a>
+    <li><a href="#ref-for-default-action-26">5.7.4. Canceling Composition Events</a> <a href="#ref-for-default-action-27">(2)</a>
+    <li><a href="#ref-for-default-action-28">6.3.5. Default actions and cancelable keyboard events</a> <a href="#ref-for-default-action-29">(2)</a> <a href="#ref-for-default-action-30">(3)</a> <a href="#ref-for-default-action-31">(4)</a> <a href="#ref-for-default-action-32">(5)</a>
+    <li><a href="#ref-for-default-action-33">9.1.1.1. DOMActivate</a> <a href="#ref-for-default-action-34">(2)</a>
+    <li><a href="#ref-for-default-action-35">9.1.2. Activation event order</a> <a href="#ref-for-default-action-36">(2)</a> <a href="#ref-for-default-action-37">(3)</a> <a href="#ref-for-default-action-38">(4)</a> <a href="#ref-for-default-action-39">(5)</a>
+    <li><a href="#ref-for-default-action-40">9.3.1.1. keypress</a>
+    <li><a href="#ref-for-default-action-41">9.3.2. keypress event order</a>
+    <li><a href="#ref-for-default-action-42">14. Glossary</a> <a href="#ref-for-default-action-43">(2)</a> <a href="#ref-for-default-action-44">(3)</a> <a href="#ref-for-default-action-45">(4)</a> <a href="#ref-for-default-action-46">(5)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="delta">
+   <b><a href="#delta">#delta</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-delta-1">5.4. Wheel Events</a> <a href="#ref-for-delta-2">(2)</a> <a href="#ref-for-delta-3">(3)</a>
+    <li><a href="#ref-for-delta-4">5.4.1. Interface WheelEvent</a> <a href="#ref-for-delta-5">(2)</a> <a href="#ref-for-delta-6">(3)</a> <a href="#ref-for-delta-7">(4)</a> <a href="#ref-for-delta-8">(5)</a>
+    <li><a href="#ref-for-delta-9">5.4.2.1. wheel</a> <a href="#ref-for-delta-10">(2)</a> <a href="#ref-for-delta-11">(3)</a>
+    <li><a href="#ref-for-delta-12">14. Glossary</a> <a href="#ref-for-delta-13">(2)</a> <a href="#ref-for-delta-14">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="deprecates">
+   <b><a href="#deprecates">#deprecates</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-deprecates-1">1.2.1. Web browsers and other dynamic or interactive user agents</a> <a href="#ref-for-deprecates-2">(2)</a>
+    <li><a href="#ref-for-deprecates-3">1.2.2. Authoring tools</a>
+    <li><a href="#ref-for-deprecates-4">1.2.3. Content authors and content</a>
+    <li><a href="#ref-for-deprecates-5">1.2.4. Specifications and host languages</a>
+    <li><a href="#ref-for-deprecates-6">9.1.1.1. DOMActivate</a>
+    <li><a href="#ref-for-deprecates-7">9.2.1.1. DOMFocusIn</a>
+    <li><a href="#ref-for-deprecates-8">9.2.1.2. DOMFocusOut</a>
+    <li><a href="#ref-for-deprecates-9">9.3.1.1. keypress</a>
+    <li><a href="#ref-for-deprecates-10">9.4. Legacy MutationEvent events</a>
+    <li><a href="#ref-for-deprecates-11">9.4.2.1. DOMAttrModified</a>
+    <li><a href="#ref-for-deprecates-12">9.4.2.2. DOMCharacterDataModified</a>
+    <li><a href="#ref-for-deprecates-13">9.4.2.3. DOMNodeInserted</a>
+    <li><a href="#ref-for-deprecates-14">9.4.2.4. DOMNodeInsertedIntoDocument</a>
+    <li><a href="#ref-for-deprecates-15">9.4.2.5. DOMNodeRemoved</a>
+    <li><a href="#ref-for-deprecates-16">9.4.2.6. DOMNodeRemovedFromDocument</a>
+    <li><a href="#ref-for-deprecates-17">9.4.2.7. DOMSubtreeModified</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dispatch">
+   <b><a href="#dispatch">#dispatch</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dispatch-1">1.2.1. Web browsers and other dynamic or interactive user agents</a>
+    <li><a href="#ref-for-dispatch-2">3.1. Event dispatch and DOM event flow</a>
+    <li><a href="#ref-for-dispatch-3">14. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-application">
+   <b><a href="#dom-application">#dom-application</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-application-1">3.2. Default actions and cancelable events</a>
+    <li><a href="#ref-for-dom-application-2">11. Security Considerations</a> <a href="#ref-for-dom-application-3">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-level-0">
+   <b><a href="#dom-level-0">#dom-level-0</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-level-0-1">5.3.1. Interface MouseEvent</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="empty-string">
+   <b><a href="#empty-string">#empty-string</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-empty-string-1">5.5.1. Interface InputEvent</a>
+    <li><a href="#ref-for-empty-string-2">5.5.3.1. beforeinput</a>
+    <li><a href="#ref-for-empty-string-3">5.5.3.2. input</a>
+    <li><a href="#ref-for-empty-string-4">5.7. Composition Events</a>
+    <li><a href="#ref-for-empty-string-5">5.7.1. Interface CompositionEvent</a>
+    <li><a href="#ref-for-empty-string-6">5.7.7.1. compositionstart</a> <a href="#ref-for-empty-string-7">(2)</a>
+    <li><a href="#ref-for-empty-string-8">5.7.7.2. compositionupdate</a> <a href="#ref-for-empty-string-9">(2)</a>
+    <li><a href="#ref-for-empty-string-10">5.7.7.3. compositionend</a>
+    <li><a href="#ref-for-empty-string-11">6.3.4. Input Method Editors</a>
+    <li><a href="#ref-for-empty-string-12">9.4.1. Interface MutationEvent</a> <a href="#ref-for-empty-string-13">(2)</a> <a href="#ref-for-empty-string-14">(3)</a>
+    <li><a href="#ref-for-empty-string-15">9.4.2.2. DOMCharacterDataModified</a>
+    <li><a href="#ref-for-empty-string-16">9.4.2.3. DOMNodeInserted</a> <a href="#ref-for-empty-string-17">(2)</a> <a href="#ref-for-empty-string-18">(3)</a>
+    <li><a href="#ref-for-empty-string-19">9.4.2.4. DOMNodeInsertedIntoDocument</a> <a href="#ref-for-empty-string-20">(2)</a> <a href="#ref-for-empty-string-21">(3)</a>
+    <li><a href="#ref-for-empty-string-22">9.4.2.5. DOMNodeRemoved</a> <a href="#ref-for-empty-string-23">(2)</a> <a href="#ref-for-empty-string-24">(3)</a>
+    <li><a href="#ref-for-empty-string-25">9.4.2.6. DOMNodeRemovedFromDocument</a> <a href="#ref-for-empty-string-26">(2)</a> <a href="#ref-for-empty-string-27">(3)</a>
+    <li><a href="#ref-for-empty-string-28">9.4.2.7. DOMSubtreeModified</a> <a href="#ref-for-empty-string-29">(2)</a> <a href="#ref-for-empty-string-30">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="event">
+   <b><a href="#event">#event</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-event-1">1.1. Overview</a>
+    <li><a href="#ref-for-event-2">14. Glossary</a> <a href="#ref-for-event-3">(2)</a> <a href="#ref-for-event-4">(3)</a> <a href="#ref-for-event-5">(4)</a> <a href="#ref-for-event-6">(5)</a> <a href="#ref-for-event-7">(6)</a> <a href="#ref-for-event-8">(7)</a> <a href="#ref-for-event-9">(8)</a> <a href="#ref-for-event-10">(9)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="event-focus">
+   <b><a href="#event-focus">#event-focus</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-event-focus-1">14. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="focus-ring">
+   <b><a href="#focus-ring">#focus-ring</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-focus-ring-1">5.2.3. Document Focus and Focus Context</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="event-handler">
+   <b><a href="#event-handler">#event-handler</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-event-handler-1">14. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="event-listener">
+   <b><a href="#event-listener">#event-listener</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-event-listener-1">14. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="event-order">
+   <b><a href="#event-order">#event-order</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-event-order-1">3.3. Synchronous and asynchronous events</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="event-phase">
+   <b><a href="#event-phase">#event-phase</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-event-phase-1">3.1. Event dispatch and DOM event flow</a>
+    <li><a href="#ref-for-event-phase-2">14. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="event-target">
+   <b><a href="#event-target">#event-target</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-event-target-1">3.1. Event dispatch and DOM event flow</a> <a href="#ref-for-event-target-2">(2)</a> <a href="#ref-for-event-target-3">(3)</a>
+    <li><a href="#ref-for-event-target-4">3.5. Activation triggers and behavior</a>
+    <li><a href="#ref-for-event-target-5">4.1. List of Event Types</a>
+    <li><a href="#ref-for-event-target-6">5.2.3. Document Focus and Focus Context</a>
+    <li><a href="#ref-for-event-target-7">5.2.4.1. blur</a> <a href="#ref-for-event-target-8">(2)</a> <a href="#ref-for-event-target-9">(3)</a>
+    <li><a href="#ref-for-event-target-10">5.2.4.2. focus</a> <a href="#ref-for-event-target-11">(2)</a> <a href="#ref-for-event-target-12">(3)</a>
+    <li><a href="#ref-for-event-target-13">5.2.4.3. focusin</a> <a href="#ref-for-event-target-14">(2)</a> <a href="#ref-for-event-target-15">(3)</a> <a href="#ref-for-event-target-16">(4)</a> <a href="#ref-for-event-target-17">(5)</a>
+    <li><a href="#ref-for-event-target-18">5.2.4.4. focusout</a> <a href="#ref-for-event-target-19">(2)</a> <a href="#ref-for-event-target-20">(3)</a> <a href="#ref-for-event-target-21">(4)</a>
+    <li><a href="#ref-for-event-target-22">5.3.3. Mouse Event Order</a>
+    <li><a href="#ref-for-event-target-23">5.3.4.1. click</a> <a href="#ref-for-event-target-24">(2)</a> <a href="#ref-for-event-target-25">(3)</a>
+    <li><a href="#ref-for-event-target-26">5.3.4.2. dblclick</a> <a href="#ref-for-event-target-27">(2)</a>
+    <li><a href="#ref-for-event-target-28">5.3.4.4. mouseenter</a>
+    <li><a href="#ref-for-event-target-29">5.3.4.5. mouseleave</a>
+    <li><a href="#ref-for-event-target-30">5.3.4.7. mouseout</a>
+    <li><a href="#ref-for-event-target-31">5.3.4.8. mouseover</a> <a href="#ref-for-event-target-32">(2)</a>
+    <li><a href="#ref-for-event-target-33">5.4.2.1. wheel</a>
+    <li><a href="#ref-for-event-target-34">5.5.3.1. beforeinput</a>
+    <li><a href="#ref-for-event-target-35">5.5.3.2. input</a>
+    <li><a href="#ref-for-event-target-36">5.6.3. Keyboard Event Order</a> <a href="#ref-for-event-target-37">(2)</a> <a href="#ref-for-event-target-38">(3)</a>
+    <li><a href="#ref-for-event-target-39">9.1.1.1. DOMActivate</a>
+    <li><a href="#ref-for-event-target-40">9.2.1.1. DOMFocusIn</a> <a href="#ref-for-event-target-41">(2)</a>
+    <li><a href="#ref-for-event-target-42">9.2.1.2. DOMFocusOut</a> <a href="#ref-for-event-target-43">(2)</a>
+    <li><a href="#ref-for-event-target-44">9.4.2.1. DOMAttrModified</a>
+    <li><a href="#ref-for-event-target-45">9.4.2.2. DOMCharacterDataModified</a>
+    <li><a href="#ref-for-event-target-46">9.4.2.3. DOMNodeInserted</a>
+    <li><a href="#ref-for-event-target-47">9.4.2.4. DOMNodeInsertedIntoDocument</a>
+    <li><a href="#ref-for-event-target-48">9.4.2.5. DOMNodeRemoved</a>
+    <li><a href="#ref-for-event-target-49">9.4.2.6. DOMNodeRemovedFromDocument</a>
+    <li><a href="#ref-for-event-target-50">14. Glossary</a> <a href="#ref-for-event-target-51">(2)</a> <a href="#ref-for-event-target-52">(3)</a> <a href="#ref-for-event-target-53">(4)</a> <a href="#ref-for-event-target-54">(5)</a> <a href="#ref-for-event-target-55">(6)</a> <a href="#ref-for-event-target-56">(7)</a> <a href="#ref-for-event-target-57">(8)</a> <a href="#ref-for-event-target-58">(9)</a> <a href="#ref-for-event-target-59">(10)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="event-type">
+   <b><a href="#event-type">#event-type</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-event-type-1">1.2.1. Web browsers and other dynamic or interactive user agents</a> <a href="#ref-for-event-type-2">(2)</a> <a href="#ref-for-event-type-3">(3)</a> <a href="#ref-for-event-type-4">(4)</a>
+    <li><a href="#ref-for-event-type-5">1.2.2. Authoring tools</a> <a href="#ref-for-event-type-6">(2)</a>
+    <li><a href="#ref-for-event-type-7">1.2.3. Content authors and content</a> <a href="#ref-for-event-type-8">(2)</a>
+    <li><a href="#ref-for-event-type-9">1.2.4. Specifications and host languages</a> <a href="#ref-for-event-type-10">(2)</a> <a href="#ref-for-event-type-11">(3)</a> <a href="#ref-for-event-type-12">(4)</a>
+    <li><a href="#ref-for-event-type-13">3.1. Event dispatch and DOM event flow</a>
+    <li><a href="#ref-for-event-type-14">9.1.1.1. DOMActivate</a> <a href="#ref-for-event-type-15">(2)</a> <a href="#ref-for-event-type-16">(3)</a> <a href="#ref-for-event-type-17">(4)</a> <a href="#ref-for-event-type-18">(5)</a> <a href="#ref-for-event-type-19">(6)</a> <a href="#ref-for-event-type-20">(7)</a> <a href="#ref-for-event-type-21">(8)</a> <a href="#ref-for-event-type-22">(9)</a> <a href="#ref-for-event-type-23">(10)</a> <a href="#ref-for-event-type-24">(11)</a> <a href="#ref-for-event-type-25">(12)</a>
+    <li><a href="#ref-for-event-type-26">14. Glossary</a> <a href="#ref-for-event-type-27">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="fire">
+   <b><a href="#fire">#fire</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-fire-1">14. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="host-language">
+   <b><a href="#host-language">#host-language</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-host-language-1">1.2.2. Authoring tools</a>
+    <li><a href="#ref-for-host-language-2">1.2.4. Specifications and host languages</a> <a href="#ref-for-host-language-3">(2)</a> <a href="#ref-for-host-language-4">(3)</a>
+    <li><a href="#ref-for-host-language-5">5.1.2.5. select</a> <a href="#ref-for-host-language-6">(2)</a>
+    <li><a href="#ref-for-host-language-7">5.2.3. Document Focus and Focus Context</a>
+    <li><a href="#ref-for-host-language-8">5.6.3. Keyboard Event Order</a>
+    <li><a href="#ref-for-host-language-9">6.3. Keyboard Event key Values</a> <a href="#ref-for-host-language-10">(2)</a>
+    <li><a href="#ref-for-host-language-11">9.1.1.1. DOMActivate</a>
+    <li><a href="#ref-for-host-language-12">14. Glossary</a> <a href="#ref-for-host-language-13">(2)</a> <a href="#ref-for-host-language-14">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="hysteresis">
+   <b><a href="#hysteresis">#hysteresis</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-hysteresis-1">5.3.3. Mouse Event Order</a>
+    <li><a href="#ref-for-hysteresis-2">5.3.4.1. click</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="ime">
+   <b><a href="#ime">#ime</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-ime-1">5.6.1. Interface KeyboardEvent</a>
+    <li><a href="#ref-for-ime-2">5.7. Composition Events</a>
+    <li><a href="#ref-for-ime-3">5.7.7.1. compositionstart</a>
+    <li><a href="#ref-for-ime-4">5.7.7.3. compositionend</a>
+    <li><a href="#ref-for-ime-5">6.3.4. Input Method Editors</a> <a href="#ref-for-ime-6">(2)</a> <a href="#ref-for-ime-7">(3)</a> <a href="#ref-for-ime-8">(4)</a> <a href="#ref-for-ime-9">(5)</a>
+    <li><a href="#ref-for-ime-10">6.3.4.1. Input Method Editor mode keys</a> <a href="#ref-for-ime-11">(2)</a> <a href="#ref-for-ime-12">(3)</a> <a href="#ref-for-ime-13">(4)</a> <a href="#ref-for-ime-14">(5)</a>
+    <li><a href="#ref-for-ime-15">14. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="input-method-editor">
+   <b><a href="#input-method-editor">#input-method-editor</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-input-method-editor-1">5.5.3.1. beforeinput</a>
+    <li><a href="#ref-for-input-method-editor-2">5.5.3.2. input</a>
+    <li><a href="#ref-for-input-method-editor-3">6.3.1. Key Values and Unicode</a>
+    <li><a href="#ref-for-input-method-editor-4">6.3.4. Input Method Editors</a> <a href="#ref-for-input-method-editor-5">(2)</a>
+    <li><a href="#ref-for-input-method-editor-6">6.3.4.1. Input Method Editor mode keys</a> <a href="#ref-for-input-method-editor-7">(2)</a> <a href="#ref-for-input-method-editor-8">(3)</a> <a href="#ref-for-input-method-editor-9">(4)</a> <a href="#ref-for-input-method-editor-10">(5)</a>
+    <li><a href="#ref-for-input-method-editor-11">9.3.1.1. keypress</a>
+    <li><a href="#ref-for-input-method-editor-12">14. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="key-mapping">
+   <b><a href="#key-mapping">#key-mapping</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-key-mapping-1">5.6.4.1. keydown</a>
+    <li><a href="#ref-for-key-mapping-2">5.6.4.2. keyup</a>
+    <li><a href="#ref-for-key-mapping-3">6.3. Keyboard Event key Values</a>
+    <li><a href="#ref-for-key-mapping-4">6.3.6. Guidelines for selecting key values</a>
+    <li><a href="#ref-for-key-mapping-5">9.3.1.1. keypress</a>
+    <li><a href="#ref-for-key-mapping-6">14. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="key-value">
+   <b><a href="#key-value">#key-value</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-key-value-1">6.3. Keyboard Event key Values</a> <a href="#ref-for-key-value-2">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="modifier-key">
+   <b><a href="#modifier-key">#modifier-key</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-modifier-key-1">6.3.2. Modifier keys</a>
+    <li><a href="#ref-for-modifier-key-2">14. Glossary</a> <a href="#ref-for-modifier-key-3">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="namespace-uris">
+   <b><a href="#namespace-uris">#namespace-uris</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-namespace-uris-1">1.2. Conformance</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="phase">
+   <b><a href="#phase">#phase</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-phase-1">14. Glossary</a> <a href="#ref-for-phase-2">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="propagation-path">
+   <b><a href="#propagation-path">#propagation-path</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-propagation-path-1">3.1. Event dispatch and DOM event flow</a> <a href="#ref-for-propagation-path-2">(2)</a> <a href="#ref-for-propagation-path-3">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="qwerty">
+   <b><a href="#qwerty">#qwerty</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-qwerty-1">6.3. Keyboard Event key Values</a> <a href="#ref-for-qwerty-2">(2)</a>
+    <li><a href="#ref-for-qwerty-3">14. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="root-element">
+   <b><a href="#root-element">#root-element</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-root-element-1">5.3.3. Mouse Event Order</a> <a href="#ref-for-root-element-2">(2)</a>
+    <li><a href="#ref-for-root-element-3">5.6.3. Keyboard Event Order</a>
+    <li><a href="#ref-for-root-element-4">5.6.4.1. keydown</a>
+    <li><a href="#ref-for-root-element-5">5.6.4.2. keyup</a>
+    <li><a href="#ref-for-root-element-6">9.3.1.1. keypress</a>
+    <li><a href="#ref-for-root-element-7">14. Glossary</a> <a href="#ref-for-root-element-8">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="rotation">
+   <b><a href="#rotation">#rotation</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-rotation-1">5.4. Wheel Events</a> <a href="#ref-for-rotation-2">(2)</a>
+    <li><a href="#ref-for-rotation-3">5.4.1. Interface WheelEvent</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="target-phase">
+   <b><a href="#target-phase">#target-phase</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-target-phase-1">3.1. Event dispatch and DOM event flow</a>
+    <li><a href="#ref-for-target-phase-2">14. Glossary</a> <a href="#ref-for-target-phase-3">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="text-composition-system">
+   <b><a href="#text-composition-system">#text-composition-system</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-text-composition-system-1">4.1. List of Event Types</a> <a href="#ref-for-text-composition-system-2">(2)</a>
+    <li><a href="#ref-for-text-composition-system-3">5.6.4.1. keydown</a> <a href="#ref-for-text-composition-system-4">(2)</a>
+    <li><a href="#ref-for-text-composition-system-5">5.7.7.1. compositionstart</a> <a href="#ref-for-text-composition-system-6">(2)</a> <a href="#ref-for-text-composition-system-7">(3)</a> <a href="#ref-for-text-composition-system-8">(4)</a> <a href="#ref-for-text-composition-system-9">(5)</a> <a href="#ref-for-text-composition-system-10">(6)</a> <a href="#ref-for-text-composition-system-11">(7)</a>
+    <li><a href="#ref-for-text-composition-system-12">5.7.7.2. compositionupdate</a> <a href="#ref-for-text-composition-system-13">(2)</a> <a href="#ref-for-text-composition-system-14">(3)</a>
+    <li><a href="#ref-for-text-composition-system-15">5.7.7.3. compositionend</a> <a href="#ref-for-text-composition-system-16">(2)</a>
+    <li><a href="#ref-for-text-composition-system-17">9. Legacy Event Types</a>
+    <li><a href="#ref-for-text-composition-system-18">9.3.1.1. keypress</a>
+    <li><a href="#ref-for-text-composition-system-19">14. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="topmost-event-target">
+   <b><a href="#topmost-event-target">#topmost-event-target</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-topmost-event-target-1">5.3.4.1. click</a> <a href="#ref-for-topmost-event-target-2">(2)</a>
+    <li><a href="#ref-for-topmost-event-target-3">5.3.4.2. dblclick</a>
+    <li><a href="#ref-for-topmost-event-target-4">5.3.4.3. mousedown</a>
+    <li><a href="#ref-for-topmost-event-target-5">5.3.4.4. mouseenter</a>
+    <li><a href="#ref-for-topmost-event-target-6">5.3.4.5. mouseleave</a>
+    <li><a href="#ref-for-topmost-event-target-7">5.3.4.6. mousemove</a>
+    <li><a href="#ref-for-topmost-event-target-8">5.3.4.7. mouseout</a>
+    <li><a href="#ref-for-topmost-event-target-9">5.3.4.8. mouseover</a>
+    <li><a href="#ref-for-topmost-event-target-10">5.3.4.9. mouseup</a>
+    <li><a href="#ref-for-topmost-event-target-11">5.4.2.1. wheel</a>
+    <li><a href="#ref-for-topmost-event-target-12">14. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="unicode-code-point">
+   <b><a href="#unicode-code-point">#unicode-code-point</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-unicode-code-point-1">6.1.1. Key Legends</a> <a href="#ref-for-unicode-code-point-2">(2)</a>
+    <li><a href="#ref-for-unicode-code-point-3">6.3.2. Modifier keys</a>
+    <li><a href="#ref-for-unicode-code-point-4">6.3.6. Guidelines for selecting key values</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="un-initialized-value">
+   <b><a href="#un-initialized-value">#un-initialized-value</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-un-initialized-value-1">5.1.1. Interface UIEvent</a> <a href="#ref-for-un-initialized-value-2">(2)</a>
+    <li><a href="#ref-for-un-initialized-value-3">5.2.1. Interface FocusEvent</a>
+    <li><a href="#ref-for-un-initialized-value-4">5.3.1. Interface MouseEvent</a> <a href="#ref-for-un-initialized-value-5">(2)</a> <a href="#ref-for-un-initialized-value-6">(3)</a> <a href="#ref-for-un-initialized-value-7">(4)</a> <a href="#ref-for-un-initialized-value-8">(5)</a> <a href="#ref-for-un-initialized-value-9">(6)</a> <a href="#ref-for-un-initialized-value-10">(7)</a> <a href="#ref-for-un-initialized-value-11">(8)</a> <a href="#ref-for-un-initialized-value-12">(9)</a> <a href="#ref-for-un-initialized-value-13">(10)</a> <a href="#ref-for-un-initialized-value-14">(11)</a> <a href="#ref-for-un-initialized-value-15">(12)</a>
+    <li><a href="#ref-for-un-initialized-value-16">5.4.1. Interface WheelEvent</a> <a href="#ref-for-un-initialized-value-17">(2)</a> <a href="#ref-for-un-initialized-value-18">(3)</a> <a href="#ref-for-un-initialized-value-19">(4)</a>
+    <li><a href="#ref-for-un-initialized-value-20">5.5.1. Interface InputEvent</a> <a href="#ref-for-un-initialized-value-21">(2)</a>
+    <li><a href="#ref-for-un-initialized-value-22">5.6.1. Interface KeyboardEvent</a> <a href="#ref-for-un-initialized-value-23">(2)</a> <a href="#ref-for-un-initialized-value-24">(3)</a> <a href="#ref-for-un-initialized-value-25">(4)</a> <a href="#ref-for-un-initialized-value-26">(5)</a> <a href="#ref-for-un-initialized-value-27">(6)</a> <a href="#ref-for-un-initialized-value-28">(7)</a> <a href="#ref-for-un-initialized-value-29">(8)</a> <a href="#ref-for-un-initialized-value-30">(9)</a>
+    <li><a href="#ref-for-un-initialized-value-31">5.7.1. Interface CompositionEvent</a>
+    <li><a href="#ref-for-un-initialized-value-32">9.4.1. Interface MutationEvent</a> <a href="#ref-for-un-initialized-value-33">(2)</a> <a href="#ref-for-un-initialized-value-34">(3)</a> <a href="#ref-for-un-initialized-value-35">(4)</a> <a href="#ref-for-un-initialized-value-36">(5)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="user-agent">
+   <b><a href="#user-agent">#user-agent</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-user-agent-1">1.2. Conformance</a> <a href="#ref-for-user-agent-2">(2)</a> <a href="#ref-for-user-agent-3">(3)</a>
+    <li><a href="#ref-for-user-agent-4">1.2.1. Web browsers and other dynamic or interactive user agents</a> <a href="#ref-for-user-agent-5">(2)</a>
+    <li><a href="#ref-for-user-agent-6">2. Stylistic Conventions</a>
+    <li><a href="#ref-for-user-agent-7">3.4. Trusted events</a> <a href="#ref-for-user-agent-8">(2)</a>
+    <li><a href="#ref-for-user-agent-9">5.1.2.1. load</a>
+    <li><a href="#ref-for-user-agent-10">5.1.2.2. unload</a>
+    <li><a href="#ref-for-user-agent-11">5.1.2.3. abort</a>
+    <li><a href="#ref-for-user-agent-12">5.1.2.4. error</a>
+    <li><a href="#ref-for-user-agent-13">5.1.2.5. select</a>
+    <li><a href="#ref-for-user-agent-14">5.2.4.1. blur</a>
+    <li><a href="#ref-for-user-agent-15">5.2.4.2. focus</a>
+    <li><a href="#ref-for-user-agent-16">5.2.4.3. focusin</a>
+    <li><a href="#ref-for-user-agent-17">5.2.4.4. focusout</a>
+    <li><a href="#ref-for-user-agent-18">5.3.4.2. dblclick</a>
+    <li><a href="#ref-for-user-agent-19">5.3.4.3. mousedown</a>
+    <li><a href="#ref-for-user-agent-20">5.3.4.4. mouseenter</a>
+    <li><a href="#ref-for-user-agent-21">5.3.4.5. mouseleave</a>
+    <li><a href="#ref-for-user-agent-22">5.3.4.6. mousemove</a>
+    <li><a href="#ref-for-user-agent-23">5.3.4.7. mouseout</a>
+    <li><a href="#ref-for-user-agent-24">5.3.4.8. mouseover</a>
+    <li><a href="#ref-for-user-agent-25">5.3.4.9. mouseup</a>
+    <li><a href="#ref-for-user-agent-26">5.4.2.1. wheel</a> <a href="#ref-for-user-agent-27">(2)</a>
+    <li><a href="#ref-for-user-agent-28">5.5.3.1. beforeinput</a>
+    <li><a href="#ref-for-user-agent-29">5.5.3.2. input</a>
+    <li><a href="#ref-for-user-agent-30">5.6.1. Interface KeyboardEvent</a>
+    <li><a href="#ref-for-user-agent-31">5.6.4.1. keydown</a> <a href="#ref-for-user-agent-32">(2)</a>
+    <li><a href="#ref-for-user-agent-33">5.6.4.2. keyup</a>
+    <li><a href="#ref-for-user-agent-34">5.7.7.1. compositionstart</a>
+    <li><a href="#ref-for-user-agent-35">5.7.7.2. compositionupdate</a>
+    <li><a href="#ref-for-user-agent-36">5.7.7.3. compositionend</a> <a href="#ref-for-user-agent-37">(2)</a>
+    <li><a href="#ref-for-user-agent-38">7. Legacy Event Initializers</a>
+    <li><a href="#ref-for-user-agent-39">8. Legacy Key Attributes</a> <a href="#ref-for-user-agent-40">(2)</a> <a href="#ref-for-user-agent-41">(3)</a>
+    <li><a href="#ref-for-user-agent-42">8.1. Legacy KeyboardEvent supplemental interface</a>
+    <li><a href="#ref-for-user-agent-43">9. Legacy Event Types</a>
+    <li><a href="#ref-for-user-agent-44">9.1.1.1. DOMActivate</a> <a href="#ref-for-user-agent-45">(2)</a> <a href="#ref-for-user-agent-46">(3)</a> <a href="#ref-for-user-agent-47">(4)</a> <a href="#ref-for-user-agent-48">(5)</a>
+    <li><a href="#ref-for-user-agent-49">9.1.2. Activation event order</a> <a href="#ref-for-user-agent-50">(2)</a> <a href="#ref-for-user-agent-51">(3)</a>
+    <li><a href="#ref-for-user-agent-52">9.2.1.1. DOMFocusIn</a>
+    <li><a href="#ref-for-user-agent-53">9.2.1.2. DOMFocusOut</a>
+    <li><a href="#ref-for-user-agent-54">9.3.1.1. keypress</a>
+    <li><a href="#ref-for-user-agent-55">9.4. Legacy MutationEvent events</a>
+    <li><a href="#ref-for-user-agent-56">9.4.2.1. DOMAttrModified</a>
+    <li><a href="#ref-for-user-agent-57">9.4.2.2. DOMCharacterDataModified</a>
+    <li><a href="#ref-for-user-agent-58">9.4.2.3. DOMNodeInserted</a> <a href="#ref-for-user-agent-59">(2)</a>
+    <li><a href="#ref-for-user-agent-60">9.4.2.4. DOMNodeInsertedIntoDocument</a> <a href="#ref-for-user-agent-61">(2)</a>
+    <li><a href="#ref-for-user-agent-62">9.4.2.5. DOMNodeRemoved</a> <a href="#ref-for-user-agent-63">(2)</a>
+    <li><a href="#ref-for-user-agent-64">9.4.2.6. DOMNodeRemovedFromDocument</a> <a href="#ref-for-user-agent-65">(2)</a>
+    <li><a href="#ref-for-user-agent-66">14. Glossary</a> <a href="#ref-for-user-agent-67">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="window">
+   <b><a href="#window">#window</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-window-1">3.1. Event dispatch and DOM event flow</a> <a href="#ref-for-window-2">(2)</a>
+    <li><a href="#ref-for-window-3">4.1. List of Event Types</a> <a href="#ref-for-window-4">(2)</a> <a href="#ref-for-window-5">(3)</a> <a href="#ref-for-window-6">(4)</a> <a href="#ref-for-window-7">(5)</a> <a href="#ref-for-window-8">(6)</a> <a href="#ref-for-window-9">(7)</a> <a href="#ref-for-window-10">(8)</a> <a href="#ref-for-window-11">(9)</a>
+    <li><a href="#ref-for-window-12">5.1.2.1. load</a> <a href="#ref-for-window-13">(2)</a> <a href="#ref-for-window-14">(3)</a>
+    <li><a href="#ref-for-window-15">5.1.2.2. unload</a> <a href="#ref-for-window-16">(2)</a>
+    <li><a href="#ref-for-window-17">5.1.2.3. abort</a> <a href="#ref-for-window-18">(2)</a>
+    <li><a href="#ref-for-window-19">5.1.2.4. error</a> <a href="#ref-for-window-20">(2)</a>
+    <li><a href="#ref-for-window-21">5.1.2.5. select</a>
+    <li><a href="#ref-for-window-22">5.2.4.1. blur</a> <a href="#ref-for-window-23">(2)</a>
+    <li><a href="#ref-for-window-24">5.2.4.2. focus</a> <a href="#ref-for-window-25">(2)</a>
+    <li><a href="#ref-for-window-26">5.2.4.3. focusin</a> <a href="#ref-for-window-27">(2)</a>
+    <li><a href="#ref-for-window-28">5.2.4.4. focusout</a> <a href="#ref-for-window-29">(2)</a>
+    <li><a href="#ref-for-window-30">5.3.4.1. click</a>
+    <li><a href="#ref-for-window-31">5.3.4.2. dblclick</a>
+    <li><a href="#ref-for-window-32">5.3.4.3. mousedown</a>
+    <li><a href="#ref-for-window-33">5.3.4.4. mouseenter</a>
+    <li><a href="#ref-for-window-34">5.3.4.5. mouseleave</a>
+    <li><a href="#ref-for-window-35">5.3.4.6. mousemove</a>
+    <li><a href="#ref-for-window-36">5.3.4.7. mouseout</a>
+    <li><a href="#ref-for-window-37">5.3.4.8. mouseover</a>
+    <li><a href="#ref-for-window-38">5.3.4.9. mouseup</a>
+    <li><a href="#ref-for-window-39">5.4.2.1. wheel</a>
+    <li><a href="#ref-for-window-40">5.5.3.1. beforeinput</a>
+    <li><a href="#ref-for-window-41">5.5.3.2. input</a>
+    <li><a href="#ref-for-window-42">5.6.4.1. keydown</a>
+    <li><a href="#ref-for-window-43">5.6.4.2. keyup</a>
+    <li><a href="#ref-for-window-44">5.7.7.1. compositionstart</a>
+    <li><a href="#ref-for-window-45">5.7.7.2. compositionupdate</a>
+    <li><a href="#ref-for-window-46">5.7.7.3. compositionend</a>
+    <li><a href="#ref-for-window-47">9. Legacy Event Types</a> <a href="#ref-for-window-48">(2)</a> <a href="#ref-for-window-49">(3)</a>
+    <li><a href="#ref-for-window-50">9.1.1.1. DOMActivate</a>
+    <li><a href="#ref-for-window-51">9.2.1.1. DOMFocusIn</a> <a href="#ref-for-window-52">(2)</a>
+    <li><a href="#ref-for-window-53">9.2.1.2. DOMFocusOut</a> <a href="#ref-for-window-54">(2)</a>
+    <li><a href="#ref-for-window-55">9.3.1.1. keypress</a>
+    <li><a href="#ref-for-window-56">9.4.2.7. DOMSubtreeModified</a>
+    <li><a href="#ref-for-window-57">12.1.1. Changes to DOM Level 2 event flow</a>
+    <li><a href="#ref-for-window-58">14. Glossary</a>
+   </ul>
+  </aside>
+<script>/* script-dfn-panel */
+
         document.body.addEventListener("click", function(e) {
             var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
             // Find the dfn element or panel, if any, that was clicked on.
             var el = e.target;
             var target;
+            var hitALink = false;
             while(el.parentElement) {
-                if(el.tagName == "DFN") {
-                    target = "dfn";
-                    break;
+                if(el.tagName == "A") {
+                    // Clicking on a link in a <dfn> shouldn't summon the panel
+                    hitALink = true;
                 }
-                if(/H\d/.test(el.tagName) && el.getAttribute('data-dfn-type') != null) {
+                if(el.classList.contains("dfn-paneled")) {
                     target = "dfn";
                     break;
                 }
@@ -8132,15 +10092,29 @@ partial interface <a class="idl-code" data-link-type="interface" href="#keyboard
                     el.classList.remove("activated");
                 });
             }
-            if(target == "dfn") {
+            if(target == "dfn" && !hitALink) {
                 // open the panel
-                var dfnPanel = el.querySelector(".dfn-panel");
+                var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
                 if(dfnPanel) {
+                    console.log(dfnPanel);
                     dfnPanel.classList.add("on");
+                    var rect = el.getBoundingClientRect();
+                    dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
+                    dfnPanel.style.top = window.scrollY + rect.top + "px";
+                    var panelRect = dfnPanel.getBoundingClientRect();
+                    var panelWidth = panelRect.right - panelRect.left;
+                    if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
+                        // Reposition, because the panel is overflowing
+                        dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
+                    }
+                } else {
+                    console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
                 }
             } else if(target == "dfn-panel") {
                 // Switch it to "activated" state, which pins it.
                 el.classList.add("activated");
+                el.style.left = null;
+                el.style.top = null;
             }
 
         });

--- a/sections/architecture.txt
+++ b/sections/architecture.txt
@@ -2,7 +2,7 @@
 <h2 id="dom-event-architecture">DOM Event Architecture</h2>
 
 
-<em>This section is non-normative. Refer to [[DOM4]] for a normative description
+<em>This section is non-normative. Refer to [[DOM]] for a normative description
 of the DOM event architecture</em>
 
 <h3 id="event-flow">Event dispatch and DOM event flow</h3>

--- a/sections/event-interfaces.txt
+++ b/sections/event-interfaces.txt
@@ -17,6 +17,7 @@ implementation:
     *   {{Event/eventPhase}} attribute
     *   {{Event/bubbles}} attribute
     *   {{Event/cancelable}} attribute
+    *   {{Event/composed}} attribute
     *   {{Event/timeStamp}} attribute
     *   {{Event/defaultPrevented}} attribute
     *   {{Event/isTrusted}} attribute

--- a/sections/event-types.txt
+++ b/sections/event-types.txt
@@ -541,6 +541,10 @@ events.
 					<td>No</td>
 				</tr>
 				<tr>
+					<th>Composed</th>
+					<td>Yes</td>
+				</tr>
+				<tr>
 					<th>Default action</th>
 					<td>None</td>
 				</tr>
@@ -595,6 +599,10 @@ events.
 					<td>No</td>
 				</tr>
 				<tr>
+					<th>Composed</th>
+					<td>Yes</td>
+				</tr>
+				<tr>
 					<th>Default action</th>
 					<td>None</td>
 				</tr>
@@ -647,6 +655,10 @@ events.
 				<tr>
 					<th>Cancelable</th>
 					<td>No</td>
+				</tr>
+				<tr>
+					<th>Composed</th>
+					<td>Yes</td>
 				</tr>
 				<tr>
 					<th>Default action</th>
@@ -712,6 +724,10 @@ events.
 				<tr>
 					<th>Cancelable</th>
 					<td>No</td>
+				</tr>
+				<tr>
+					<th>Composed</th>
+					<td>Yes</td>
 				</tr>
 				<tr>
 					<th>Default action</th>
@@ -1468,6 +1484,10 @@ events.
 					<td>Yes</td>
 				</tr>
 				<tr>
+					<th>Composed</th>
+					<td>Yes</td>
+				</tr>
+				<tr>
 					<th>Default action</th>
 					<td>Varies</td>
 				</tr>
@@ -1602,6 +1622,10 @@ events.
 					<td>Yes</td>
 				</tr>
 				<tr>
+					<th>Composed</th>
+					<td>Yes</td>
+				</tr>
+				<tr>
 					<th>Default action</th>
 					<td>None</td>
 				</tr>
@@ -1701,6 +1725,10 @@ events.
 					<td>Yes</td>
 				</tr>
 				<tr>
+					<th>Composed</th>
+					<td>Yes</td>
+				</tr>
+				<tr>
 					<th>Default action</th>
 					<td>Varies: Start a drag/drop operation; start a text selection; start a scroll/pan interaction (in combination with the middle mouse button, if supported)</td>
 				</tr>
@@ -1785,6 +1813,10 @@ events.
 					<td>No</td>
 				</tr>
 				<tr>
+					<th>Composed</th>
+					<td>Yes</td>
+				</tr>
+				<tr>
 					<th>Default action</th>
 					<td>None</td>
 				</tr>
@@ -1867,6 +1899,10 @@ events.
 					<td>No</td>
 				</tr>
 				<tr>
+					<th>Composed</th>
+					<td>Yes</td>
+				</tr>
+				<tr>
 					<th>Default action</th>
 					<td>None</td>
 				</tr>
@@ -1946,6 +1982,10 @@ events.
 				</tr>
 				<tr>
 					<th>Cancelable</th>
+					<td>Yes</td>
+				</tr>
+				<tr>
+					<th>Composed</th>
 					<td>Yes</td>
 				</tr>
 				<tr>
@@ -2039,6 +2079,10 @@ events.
 					<td>Yes</td>
 				</tr>
 				<tr>
+					<th>Composed</th>
+					<td>Yes</td>
+				</tr>
+				<tr>
 					<th>Default action</th>
 					<td>None</td>
 				</tr>
@@ -2115,6 +2159,10 @@ events.
 					</tr>
 					<tr>
 						<th>Cancelable</th>
+						<td>Yes</td>
+					</tr>
+					<tr>
+						<th>Composed</th>
 						<td>Yes</td>
 					</tr>
 					<tr>
@@ -2195,6 +2243,10 @@ events.
 				</tr>
 				<tr>
 					<th>Cancelable</th>
+					<td>Yes</td>
+				</tr>
+				<tr>
+					<th>Composed</th>
 					<td>Yes</td>
 				</tr>
 				<tr>
@@ -2474,6 +2526,10 @@ events.
 					<td>Yes</td>
 				</tr>
 				<tr>
+					<th>Composed</th>
+					<td>Yes</td>
+				</tr>
+				<tr>
 					<th>Default action</th>
 					<td>Scroll (or zoom) the document</td>
 				</tr>
@@ -2654,6 +2710,10 @@ events.
 					<td>Yes</td>
 				</tr>
 				<tr>
+					<th>Composed</th>
+					<td>Yes</td>
+				</tr>
+				<tr>
 					<th>Default action</th>
 					<td>Update the DOM element</td>
 				</tr>
@@ -2709,6 +2769,10 @@ events.
 				<tr>
 					<th>Cancelable</th>
 					<td>No</td>
+				</tr>
+				<tr>
+					<th>Composed</th>
+					<td>Yes</td>
 				</tr>
 				<tr>
 					<th>Default action</th>
@@ -3223,6 +3287,10 @@ events.
 					<td>Yes</td>
 				</tr>
 				<tr>
+					<th>Composed</th>
+					<td>Yes</td>
+				</tr>
+				<tr>
 					<th>Default action</th>
 					<td>Varies:
 						EVENT{beforeinput} and
@@ -3336,6 +3404,10 @@ events.
 				</tr>
 				<tr>
 					<th>Cancelable</th>
+					<td>Yes</td>
+				</tr>
+				<tr>
+					<th>Composed</th>
 					<td>Yes</td>
 				</tr>
 				<tr>
@@ -3625,6 +3697,10 @@ events.
 					<td>Yes</td>
 				</tr>
 				<tr>
+					<th>Composed</th>
+					<td>Yes</td>
+				</tr>
+				<tr>
 					<th>Default action</th>
 					<td>Start a new composition session when a <a>text composition system</a> is enabled</td>
 				</tr>
@@ -3709,6 +3785,10 @@ events.
 					<td>No</td>
 				</tr>
 				<tr>
+					<th>Composed</th>
+					<td>Yes</td>
+				</tr>
+				<tr>
 					<th>Default action</th>
 					<td>None</td>
 				</tr>
@@ -3775,6 +3855,10 @@ events.
 				<tr>
 					<th>Cancelable</th>
 					<td>No</td>
+				</tr>
+				<tr>
+					<th>Composed</th>
+					<td>Yes</td>
 				</tr>
 				<tr>
 					<th>Default action</th>


### PR DESCRIPTION
Reflect the conclusion of https://github.com/w3c/webcomponents/issues/513.

Make the following events composed events:

- Focus Events: blur, focus, focusin, focusout
- Mouse Events: click, dblclick, mousedown, mouseenter, mouseleave,
                mousemove, mouseout, mouseover, mouseup
- Wheel Events: wheel
- Input Events: beforeinput, input
- Keyboard Events: keydown, keyup
- Composition Events: compositionstart, compositionupdate, compositionend

Other editorial fix: I replaced [[DOM4]] with [[DOM]] for consistency
because bikeshed complains as follows:

> FATAL ERROR: The biblio refs [[DOM4]] and [[DOM]] are both aliases
> of the same base reference [[WHATWG-DOM]]. Please choose one name and
> use it consistently.