### PR TITLE
Fix #89. Make some of legacy UIEvents composed events

### DIFF
--- a/index.html
+++ b/index.html
@@ -256,12 +256,12 @@ pre.idl.highlight { color: #708090; }
    <header>
     <p data-fill-with="logo"><a href="http://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"></a></p>
     <h1>UI Events</h1>
-    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">W3C Working Draft, <time class="dt-updated" datetime="2016-06-23">23 June 2016</time></span></h2>
+    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">W3C Working Draft, <time class="dt-updated" datetime="2016-07-12">12 July 2016</time></span></h2>
    </header>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
-     <dd><a class="u-url" href="http://www.w3.org/TR/2016/WD-uievents-20160623/">http://www.w3.org/TR/2016/WD-uievents-20160623/</a>
+     <dd><a class="u-url" href="http://www.w3.org/TR/2016/WD-uievents-20160712/">http://www.w3.org/TR/2016/WD-uievents-20160712/</a>
      <dt>Latest published version:
      <dd><a href="http://www.w3.org/TR/uievents/">http://www.w3.org/TR/uievents/</a>
      <dt>Editor's Draft:
@@ -6142,6 +6142,7 @@ completeness.</p>
        <th style="text-align:center">Trusted event target types
        <th style="text-align:center">DOM Interface
        <th style="text-align:center">Cancelable
+       <th style="text-align:center">Composed
        <th>Default Action
       <tr>
        <td><a data-link-type="dfn" href="#domactivate" id="ref-for-domactivate-2"><code>DOMActivate</code></a>
@@ -6149,6 +6150,7 @@ completeness.</p>
        <td style="text-align:center">Yes
        <td style="text-align:center"><code>Element</code>
        <td style="text-align:center"><code class="idl"><a data-link-type="idl" href="#uievent-uievent" id="ref-for-uievent-uievent-67">UIEvent</a></code>
+       <td style="text-align:center">Yes
        <td style="text-align:center">Yes
        <td>None
       <tr>
@@ -6158,6 +6160,7 @@ completeness.</p>
        <td style="text-align:center"><code>Element</code>
        <td style="text-align:center"><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#mutationevent">MutationEvent</a></code>
        <td style="text-align:center">No
+       <td style="text-align:center">No
        <td>None
       <tr>
        <td><a data-link-type="dfn" href="#domcharacterdatamodified" id="ref-for-domcharacterdatamodified-1"><code>DOMCharacterDataModified</code></a>
@@ -6165,6 +6168,7 @@ completeness.</p>
        <td style="text-align:center">Yes
        <td style="text-align:center"><code>Text</code>, <code>Comment</code>, <code>ProcessingInstruction</code>
        <td style="text-align:center"><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#mutationevent">MutationEvent</a></code>
+       <td style="text-align:center">No
        <td style="text-align:center">No
        <td>None
       <tr>
@@ -6174,6 +6178,7 @@ completeness.</p>
        <td style="text-align:center"><a data-link-type="dfn" href="#window" id="ref-for-window-47"><code>Window</code></a>, <code>Element</code>
        <td style="text-align:center"><code class="idl"><a data-link-type="idl" href="#focusevent" id="ref-for-focusevent-15">FocusEvent</a></code>
        <td style="text-align:center">No
+       <td style="text-align:center">Yes
        <td>None
       <tr>
        <td><a data-link-type="dfn" href="#domfocusout" id="ref-for-domfocusout-1"><code>DOMFocusOut</code></a>
@@ -6182,6 +6187,7 @@ completeness.</p>
        <td style="text-align:center"><a data-link-type="dfn" href="#window" id="ref-for-window-48"><code>Window</code></a>, <code>Element</code>
        <td style="text-align:center"><code class="idl"><a data-link-type="idl" href="#focusevent" id="ref-for-focusevent-16">FocusEvent</a></code>
        <td style="text-align:center">No
+       <td style="text-align:center">Yes
        <td>None
       <tr>
        <td><a data-link-type="dfn" href="#domnodeinserted" id="ref-for-domnodeinserted-1"><code>DOMNodeInserted</code></a>
@@ -6189,6 +6195,7 @@ completeness.</p>
        <td style="text-align:center">Yes
        <td style="text-align:center"><code>Element</code>, <code>Attr</code>, <code>Text</code>, <code>Comment</code>, <code>DocumentType</code>, <code>ProcessingInstruction</code>
        <td style="text-align:center"><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#mutationevent">MutationEvent</a></code>
+       <td style="text-align:center">No
        <td style="text-align:center">No
        <td>None
       <tr>
@@ -6198,6 +6205,7 @@ completeness.</p>
        <td style="text-align:center"><code>Element</code>, <code>Attr</code>, <code>Text</code>, <code>Comment</code>, <code>DocumentType</code>, <code>ProcessingInstruction</code>
        <td style="text-align:center"><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#mutationevent">MutationEvent</a></code>
        <td style="text-align:center">No
+       <td style="text-align:center">No
        <td>None
       <tr>
        <td><a data-link-type="dfn" href="#domnoderemoved" id="ref-for-domnoderemoved-1"><code>DOMNodeRemoved</code></a>
@@ -6205,6 +6213,7 @@ completeness.</p>
        <td style="text-align:center">Yes
        <td style="text-align:center"><code>Element</code>, <code>Attr</code>, <code>Text</code>, <code>Comment</code>, <code>DocumentType</code>, <code>ProcessingInstruction</code>
        <td style="text-align:center"><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#mutationevent">MutationEvent</a></code>
+       <td style="text-align:center">No
        <td style="text-align:center">No
        <td>None
       <tr>
@@ -6214,6 +6223,7 @@ completeness.</p>
        <td style="text-align:center"><code>Element</code>, <code>Attr</code>, <code>Text</code>, <code>Comment</code>, <code>DocumentType</code>, <code>ProcessingInstruction</code>
        <td style="text-align:center"><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#mutationevent">MutationEvent</a></code>
        <td style="text-align:center">No
+       <td style="text-align:center">No
        <td>None
       <tr>
        <td><a data-link-type="dfn" href="#domsubtreemodified" id="ref-for-domsubtreemodified-1"><code>DOMSubtreeModified</code></a>
@@ -6222,6 +6232,7 @@ completeness.</p>
        <td style="text-align:center"><a data-link-type="dfn" href="#window" id="ref-for-window-49"><code>Window</code></a>, <code>Document</code>, <code>DocumentFragment</code>, <code>Element</code>, <code>Attr</code>
        <td style="text-align:center"><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#mutationevent">MutationEvent</a></code>
        <td style="text-align:center">No
+       <td style="text-align:center">No
        <td>None
       <tr>
        <td><a data-link-type="dfn" href="#keypress" id="ref-for-keypress-10"><code>keypress</code></a>
@@ -6229,6 +6240,7 @@ completeness.</p>
        <td style="text-align:center">Yes
        <td style="text-align:center"><code>Element</code>
        <td style="text-align:center"><code class="idl"><a data-link-type="idl" href="#keyboardevent-keyboardevent" id="ref-for-keyboardevent-keyboardevent-81">KeyboardEvent</a></code>
+       <td style="text-align:center">Yes
        <td style="text-align:center">Yes
        <td>Varies: launch <a data-link-type="dfn" href="#text-composition-system" id="ref-for-text-composition-system-17">text composition system</a>; <a data-link-type="dfn" href="#blur" id="ref-for-blur-8"><code>blur</code></a> and <a data-link-type="dfn" href="#focus" id="ref-for-focus-9"><code>focus</code></a> events; <a data-link-type="dfn" href="#domactivate" id="ref-for-domactivate-3"><code>DOMActivate</code></a> event; other event
     </table>
@@ -6254,6 +6266,9 @@ completeness.</p>
        <td><code>Element</code>
       <tr>
        <th>Cancelable
+       <td>Yes
+      <tr>
+       <th>Composed
        <td>Yes
       <tr>
        <th>Default action
@@ -6360,6 +6375,9 @@ completeness.</p>
        <th>Cancelable
        <td>No
       <tr>
+       <th>Composed
+       <td>Yes
+      <tr>
        <th>Default action
        <td>None
       <tr>
@@ -6400,6 +6418,9 @@ completeness.</p>
       <tr>
        <th>Cancelable
        <td>No
+      <tr>
+       <th>Composed
+       <td>Yes
       <tr>
        <th>Default action
        <td>None
@@ -6500,6 +6521,9 @@ completeness.</p>
        <td><code>Element</code>
       <tr>
        <th>Cancelable
+       <td>Yes
+      <tr>
+       <th>Composed
        <td>Yes
       <tr>
        <th>Default action
@@ -6727,6 +6751,9 @@ completeness.</p>
        <th>Cancelable
        <td>No
       <tr>
+       <th>Composed
+       <td>No
+      <tr>
        <th>Default action
        <td>None
       <tr>
@@ -6775,6 +6802,9 @@ completeness.</p>
        <th>Cancelable
        <td>No
       <tr>
+       <th>Composed
+       <td>No
+      <tr>
        <th>Default action
        <td>None
       <tr>
@@ -6819,6 +6849,9 @@ completeness.</p>
        <td><code>Element</code>, <code>Attr</code>, <code>Text</code>, <code>Comment</code>, <code>DocumentType</code>, <code>ProcessingInstruction</code>
       <tr>
        <th>Cancelable
+       <td>No
+      <tr>
+       <th>Composed
        <td>No
       <tr>
        <th>Default action
@@ -6866,6 +6899,9 @@ completeness.</p>
        <td><code>Element</code>, <code>Attr</code>, <code>Text</code>, <code>Comment</code>, <code>DocumentType</code>, <code>ProcessingInstruction</code>
       <tr>
        <th>Cancelable
+       <td>No
+      <tr>
+       <th>Composed
        <td>No
       <tr>
        <th>Default action
@@ -6917,6 +6953,9 @@ completeness.</p>
        <th>Cancelable
        <td>No
       <tr>
+       <th>Composed
+       <td>No
+      <tr>
        <th>Default action
        <td>None
       <tr>
@@ -6961,6 +7000,9 @@ completeness.</p>
        <td><code>Element</code>, <code>Attr</code>, <code>Text</code>, <code>Comment</code>, <code>DocumentType</code>, <code>ProcessingInstruction</code>
       <tr>
        <th>Cancelable
+       <td>No
+      <tr>
+       <th>Composed
        <td>No
       <tr>
        <th>Default action
@@ -7011,6 +7053,9 @@ completeness.</p>
        <td><a data-link-type="dfn" href="#window" id="ref-for-window-56"><code>Window</code></a>, <code>Document</code>, <code>DocumentFragment</code>, <code>Element</code>, <code>Attr</code> 
       <tr>
        <th>Cancelable
+       <td>No
+      <tr>
+       <th>Composed
        <td>No
       <tr>
        <th>Default action

--- a/sections/legacy-event-types.txt
+++ b/sections/legacy-event-types.txt
@@ -15,43 +15,43 @@ The following table provides an informative summary of the event types which are
 deprecated in this specification. They are included here for reference and
 completeness.
 
-++-----------------------------+--------+----------+------------------------------------------+------------------+------------+------------------------------------------------+
-=|	  Event Type			   | Sync / | Bubbling | Trusted event							  |	 DOM Interface	 | Cancelable | Default Action								   |
- |							   | Async	|  Phase   | target types							  |					 |			  |												   |
- +-----------------------------+----o---+----o-----+--------------------o---------------------+--------o---------+------o-----+------------------------------------------------+
-+| DOMActivate				   | Sync	| Yes	   | <code>Element</code>					  | UIEvent			 | Yes		  | None										   |
-+| DOMAttrModified			   | Sync	| Yes	   | <code>Element</code>					  | MutationEvent	 | No		  | None										   |
-+| DOMCharacterDataModified	   | Sync	| Yes	   | <code>Text</code>,						  | MutationEvent	 | No		  | None										   |
- |							   |		|		   | <code>Comment</code>,					  |					 |			  |												   |
- |							   |		|		   | <code>ProcessingInstruction</code>		  |					 |			  |												   |
-+| DOMFocusIn				   | Sync	| Yes	   | <a><code>Window</code></a>,			  | FocusEvent		 | No		  | None										   |
- |							   |		|		   | <code>Element</code></td>				  |					 |			  |												   |
-+| DOMFocusOut				   | Sync	| Yes	   | <a><code>Window</code></a>,			  | FocusEvent		 | No		  | None										   |
- |							   |		|		   | <code>Element</code></td>				  |					 |			  |												   |
-+| DOMNodeInserted			   | Sync	| Yes	   | <code>Element</code>, <code>Attr</code>, | MutationEvent	 | No		  | None										   |
- |							   |		|		   | <code>Text</code>, <code>Comment</code>, |					 |			  |												   |
- |							   |		|		   | <code>DocumentType</code>,				  |					 |			  |												   |
- |							   |		|		   | <code>ProcessingInstruction</code>		  |					 |			  |												   |
-+| DOMNodeInsertedIntoDocument | Sync	| No	   | <code>Element</code>, <code>Attr</code>, | MutationEvent	 | No		  | None										   |
- |							   |		|		   | <code>Text</code>, <code>Comment</code>, |					 |			  |												   |
- |							   |		|		   | <code>DocumentType</code>,				  |					 |			  |												   |
- |							   |		|		   | <code>ProcessingInstruction</code>		  |					 |			  |												   |
-+| DOMNodeRemoved			   | Sync	| Yes	   | <code>Element</code>, <code>Attr</code>, | MutationEvent	 | No		  | None										   |
- |							   |		|		   | <code>Text</code>, <code>Comment</code>, |					 |			  |												   |
- |							   |		|		   | <code>DocumentType</code>,				  |					 |			  |												   |
- |							   |		|		   | <code>ProcessingInstruction</code>		  |					 |			  |												   |
-+| DOMNodeRemovedFromDocument  | Sync	| No	   | <code>Element</code>, <code>Attr</code>, | MutationEvent	 | No		  | None										   |
- |							   |		|		   | <code>Text</code>, <code>Comment</code>, |					 |			  |												   |
- |							   |		|		   | <code>DocumentType</code>,				  |					 |			  |												   |
- |							   |		|		   | <code>ProcessingInstruction</code>		  |					 |			  |												   |
-+| DOMSubtreeModified		   | Sync	| Yes	   | <a><code>Window</code></a>,			  | MutationEvent	 | No		  | None										   |
- |							   |		|		   | <code>Document</code>,					  |					 |			  |												   |
- |							   |		|		   | <code>DocumentFragment</code>,			  |					 |			  |												   |
- |							   |		|		   | <code>Element</code>, <code>Attr</code>  |					 |			  |												   |
-+| keypress					   | Sync	| Yes	   | <code>Element</code>					  | KeyboardEvent	 | Yes		  | Varies: launch <a>text composition system</a>; |
- |							   |		|		   |										  |					 |			  | EVENT{blur} and EVENT{focus} events;		   |
- |							   |		|		   |										  |					 |			  | EVENT{DOMActivate} event; other event		   |
-++-----------------------------+--------+----------+------------------------------------------+------------------+------------+------------------------------------------------+
+++-----------------------------+--------+----------+------------------------------------------+------------------+------------+-----------+------------------------------------------------+
+=|	  Event Type			   | Sync / | Bubbling | Trusted event							  |	 DOM Interface	 | Cancelable | Composed  | Default Action								   |
+ |							   | Async	|  Phase   | target types							  |					 |			  |			  |						 						   |
+ +-----------------------------+----o---+----o-----+--------------------o---------------------+--------o---------+------o-----+------o----+------------------------------------------------+
++| DOMActivate				   | Sync	| Yes	   | <code>Element</code>					  | UIEvent			 | Yes		  | Yes		  | None										   |
++| DOMAttrModified			   | Sync	| Yes	   | <code>Element</code>					  | MutationEvent	 | No		  | No		  | None										   |
++| DOMCharacterDataModified	   | Sync	| Yes	   | <code>Text</code>,						  | MutationEvent	 | No		  | No		  | None										   |
+ |							   |		|		   | <code>Comment</code>,					  |					 |			  |			  |												   |
+ |							   |		|		   | <code>ProcessingInstruction</code>		  |					 |			  |			  |												   |
++| DOMFocusIn				   | Sync	| Yes	   | <a><code>Window</code></a>,			  | FocusEvent		 | No		  | Yes		  | None										   |
+ |							   |		|		   | <code>Element</code></td>				  |					 |			  |			  |												   |
++| DOMFocusOut				   | Sync	| Yes	   | <a><code>Window</code></a>,			  | FocusEvent		 | No		  | Yes		  | None										   |
+ |							   |		|		   | <code>Element</code></td>				  |					 |			  |			  |												   |
++| DOMNodeInserted			   | Sync	| Yes	   | <code>Element</code>, <code>Attr</code>, | MutationEvent	 | No		  | No		  | None										   |
+ |							   |		|		   | <code>Text</code>, <code>Comment</code>, |					 |			  |			  |												   |
+ |							   |		|		   | <code>DocumentType</code>,				  |					 |			  |			  |												   |
+ |							   |		|		   | <code>ProcessingInstruction</code>		  |					 |			  |			  |												   |
++| DOMNodeInsertedIntoDocument | Sync	| No	   | <code>Element</code>, <code>Attr</code>, | MutationEvent	 | No		  | No		  | None										   |
+ |							   |		|		   | <code>Text</code>, <code>Comment</code>, |					 |			  |			  |												   |
+ |							   |		|		   | <code>DocumentType</code>,				  |					 |			  |			  |												   |
+ |							   |		|		   | <code>ProcessingInstruction</code>		  |					 |			  |			  |												   |
++| DOMNodeRemoved			   | Sync	| Yes	   | <code>Element</code>, <code>Attr</code>, | MutationEvent	 | No		  | No		  | None										   |
+ |							   |		|		   | <code>Text</code>, <code>Comment</code>, |					 |			  |			  |												   |
+ |							   |		|		   | <code>DocumentType</code>,				  |					 |			  |			  |												   |
+ |							   |		|		   | <code>ProcessingInstruction</code>		  |					 |			  |			  |												   |
++| DOMNodeRemovedFromDocument  | Sync	| No	   | <code>Element</code>, <code>Attr</code>, | MutationEvent	 | No		  | No		  | None										   |
+ |							   |		|		   | <code>Text</code>, <code>Comment</code>, |					 |			  |			  |												   |
+ |							   |		|		   | <code>DocumentType</code>,				  |					 |			  |			  |												   |
+ |							   |		|		   | <code>ProcessingInstruction</code>		  |					 |			  |			  |												   |
++| DOMSubtreeModified		   | Sync	| Yes	   | <a><code>Window</code></a>,			  | MutationEvent	 | No		  | No		  | None										   |
+ |							   |		|		   | <code>Document</code>,					  |					 |			  |			  |												   |
+ |							   |		|		   | <code>DocumentFragment</code>,			  |					 |			  |			  |												   |
+ |							   |		|		   | <code>Element</code>, <code>Attr</code>  |					 |			  |			  |												   |
++| keypress					   | Sync	| Yes	   | <code>Element</code>					  | KeyboardEvent	 | Yes		  | Yes		  | Varies: launch <a>text composition system</a>; |
+ |							   |		|		   |										  |					 |			  |			  | EVENT{blur} and EVENT{focus} events;		   |
+ |							   |		|		   |										  |					 |			  |			  | EVENT{DOMActivate} event; other event		   |
+++-----------------------------+--------+----------+------------------------------------------+------------------+------------+------------+------------------------------------------------+
 
 
 <h3 id="legacy-uievent-events">Legacy {{UIEvent}} events</h3>
@@ -83,6 +83,10 @@ completeness.
 				</tr>
 				<tr>
 					<th>Cancelable</th>
+					<td>Yes</td>
+				</tr>
+				<tr>
+					<th>Composed</th>
 					<td>Yes</td>
 				</tr>
 				<tr>
@@ -236,6 +240,10 @@ completeness.
 					<td>No</td>
 				</tr>
 				<tr>
+					<th>Composed</th>
+					<td>Yes</td>
+				</tr>
+				<tr>
 					<th>Default action</th>
 					<td>None</td>
 				</tr>
@@ -294,6 +302,10 @@ completeness.
 				<tr>
 					<th>Cancelable</th>
 					<td>No</td>
+				</tr>
+				<tr>
+					<th>Composed</th>
+					<td>Yes</td>
 				</tr>
 				<tr>
 					<th>Default action</th>
@@ -392,6 +404,10 @@ completeness.
 				</tr>
 				<tr>
 					<th>Cancelable</th>
+					<td>Yes</td>
+				</tr>
+				<tr>
+					<th>Composed</th>
 					<td>Yes</td>
 				</tr>
 				<tr>
@@ -730,6 +746,10 @@ completeness.
 					<td>No</td>
 				</tr>
 				<tr>
+					<th>Composed</th>
+					<td>No</td>
+				</tr>
+				<tr>
 					<th>Default action</th>
 					<td>None</td>
 				</tr>
@@ -797,6 +817,10 @@ completeness.
 					<td>No</td>
 				</tr>
 				<tr>
+					<th>Composed</th>
+					<td>No</td>
+				</tr>
+				<tr>
 					<th>Default action</th>
 					<td>None</td>
 				</tr>
@@ -860,6 +884,10 @@ completeness.
 				</tr>
 				<tr>
 					<th>Cancelable</th>
+					<td>No</td>
+				</tr>
+				<tr>
+					<th>Composed</th>
 					<td>No</td>
 				</tr>
 				<tr>
@@ -935,6 +963,10 @@ completeness.
 					<td>No</td>
 				</tr>
 				<tr>
+					<th>Composed</th>
+					<td>No</td>
+				</tr>
+				<tr>
 					<th>Default action</th>
 					<td>None</td>
 				</tr>
@@ -1001,6 +1033,10 @@ completeness.
 				</tr>
 				<tr>
 					<th>Cancelable</th>
+					<td>No</td>
+				</tr>
+				<tr>
+					<th>Composed</th>
 					<td>No</td>
 				</tr>
 				<tr>
@@ -1076,6 +1112,10 @@ completeness.
 					<td>No</td>
 				</tr>
 				<tr>
+					<th>Composed</th>
+					<td>No</td>
+				</tr>
+				<tr>
 					<th>Default action</th>
 					<td>None</td>
 				</tr>
@@ -1147,6 +1187,10 @@ completeness.
 				</tr>
 				<tr>
 					<th>Cancelable</th>
+					<td>No</td>
+				</tr>
+				<tr>
+					<th>Composed</th>
 					<td>No</td>
 				</tr>
 				<tr>


### PR DESCRIPTION
Reflect the conclusion of https://github.com/w3c/webcomponents/issues/513.

Make the following legacy UIEvents composed events:

- UIEvents: DOMActivate
- FocusEvents: DOMFocusIn, DOMFocusOut
- KeyboardEvents: keypress

Make it also clear that MutationEvents are un-composed events.