### PR TITLE
Add a link to web-platform-tests to the top of the spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -15,6 +15,7 @@ Previous Version:
 Editor: Gary Kacmarcik, Google, garykac@google.com
 Editor: Travis Leithead, Microsoft, travil@microsoft.com
 Editor: Doug Schepers, Mar 2008 - May 2011
+!Tests: <a href=https://github.com/w3c/web-platform-tests/tree/master/uievents>web-platform-tests uievents/</a> (<a href=https://github.com/w3c/web-platform-tests/labels/uievents>ongoing work</a>)
 Abstract:
 	This specification defines UI Events which extend the DOM Event objects
 	defined in [[DOM]]. UI Events are those typically implemented by visual


### PR DESCRIPTION
Many other specs that have something similar:
https://fetch.spec.whatwg.org/
https://w3c.github.io/IndexedDB/
https://notifications.spec.whatwg.org/
https://w3c.github.io/ServiceWorker/
https://webaudio.github.io/web-audio-api/
https://xhr.spec.whatwg.org/