### PR TITLE
Small tweak on the wording on InputEvent types

### DIFF
--- a/sections/event-types.txt
+++ b/sections/event-types.txt
@@ -2285,8 +2285,8 @@ myDiv.addEventListener("auxclick", function(e) {
 			 |                  | <li>{{UIEvent}}.{{UIEvent/view}} : <a><code>Window</code></a></li>                   |
 			 |                  | <li>{{UIEvent}}.{{UIEvent/detail}} : <code>0</code></li>                             |
 			 |                  | <li>{{InputEvent}}.{{InputEvent/data}} : the string containing the data that will    |
-			 |                  |     be added to the element, which MAY be <code>null</code> if the content has       |
-			 |                  |     been deleted</li>                                                                |
+			 |                  |     be added to the element, which MAY be <code>null</code> if the content will      |
+			 |                  |     be deleted</li>                                                                  |
 			 |                  | <li>{{InputEvent}}.{{InputEvent/isComposing}} : <code>true</code> if this event is   |
 			 |                  |     dispatched during a <a href="#keys-dead">dead key</a> sequence or while an       |
 			 |                  |     <a>input method editor</a> is active (such that                                  |
@@ -2317,9 +2317,9 @@ myDiv.addEventListener("auxclick", function(e) {
 			 | (trusted events) | <li>{{Event}}.{{Event/target}} : <a>event target</a> that was just updated</li>      |
 			 |                  | <li>{{UIEvent}}.{{UIEvent/view}} : <a><code>Window</code></a></li>                   |
 			 |                  | <li>{{UIEvent}}.{{UIEvent/detail}} : <code>0</code></li>                             |
-			 |                  | <li>{{InputEvent}}.{{InputEvent/data}} : the string containing the data that will    |
-			 |                  |     be added to the element, which MAY be the <a>empty string</a> if the content has |
-			 |                  |     been deleted</li>                                                                |
+			 |                  | <li>{{InputEvent}}.{{InputEvent/data}} : the string containing the data that has     |
+			 |                  |     been added to the element, which MAY be the <a>empty string</a> if the content   |
+			 |                  |     has been deleted</li>                                                            |
 			 |                  | <li>{{InputEvent}}.{{InputEvent/isComposing}} : <code>true</code> if this event is   |
 			 |                  |     dispatched during a <a href="#keys-dead">dead key</a> sequence or while an       |
 			 |                  |     <a>input method editor</a> is active (such that                                  |


### PR DESCRIPTION
They're just basically changes to reflect the fact that `beforeinput` happens before the text got inserted, and `input` happens after. CMIIW.