### PR TITLE
Change initKeyboardEvent to be compatible with Blink/WebKit

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,8 @@
   <link href="../csslogo.ico" rel="shortcut icon" type="image/x-icon">
   <link href="styles.css" rel="stylesheet" type="text/css">
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-WD" rel="stylesheet" type="text/css">
-  <meta content="Bikeshed version 6465e1e635d337ce46d971a19374b9e5bbfa26b6" name="generator">
+  <meta content="Bikeshed version 760cc1c5c9221f585aba069d03f7e9f2a0ecb1df" name="generator">
+  <link href="http://www.w3.org/TR/uievents/" rel="canonical">
 <style>/* style-md-lists */
 
             /* This is a weird hack for me not yet following the commonmark spec
@@ -195,82 +196,82 @@
         </style>
 <style>/* style-syntax-highlighting */
 pre.idl.highlight { color: #708090; }
-        .highlight:not(.idl) { background: hsl(24, 20%, 95%); }
-        code.highlight { padding: .1em; border-radius: .3em; }
-        pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
-        .highlight .c { color: #708090 } /* Comment */
-        .highlight .k { color: #990055 } /* Keyword */
-        .highlight .l { color: #000000 } /* Literal */
-        .highlight .n { color: #0077aa } /* Name */
-        .highlight .o { color: #999999 } /* Operator */
-        .highlight .p { color: #999999 } /* Punctuation */
-        .highlight .cm { color: #708090 } /* Comment.Multiline */
-        .highlight .cp { color: #708090 } /* Comment.Preproc */
-        .highlight .c1 { color: #708090 } /* Comment.Single */
-        .highlight .cs { color: #708090 } /* Comment.Special */
-        .highlight .kc { color: #990055 } /* Keyword.Constant */
-        .highlight .kd { color: #990055 } /* Keyword.Declaration */
-        .highlight .kn { color: #990055 } /* Keyword.Namespace */
-        .highlight .kp { color: #990055 } /* Keyword.Pseudo */
-        .highlight .kr { color: #990055 } /* Keyword.Reserved */
-        .highlight .kt { color: #990055 } /* Keyword.Type */
-        .highlight .ld { color: #000000 } /* Literal.Date */
-        .highlight .m { color: #000000 } /* Literal.Number */
-        .highlight .s { color: #a67f59 } /* Literal.String */
-        .highlight .na { color: #0077aa } /* Name.Attribute */
-        .highlight .nc { color: #0077aa } /* Name.Class */
-        .highlight .no { color: #0077aa } /* Name.Constant */
-        .highlight .nd { color: #0077aa } /* Name.Decorator */
-        .highlight .ni { color: #0077aa } /* Name.Entity */
-        .highlight .ne { color: #0077aa } /* Name.Exception */
-        .highlight .nf { color: #0077aa } /* Name.Function */
-        .highlight .nl { color: #0077aa } /* Name.Label */
-        .highlight .nn { color: #0077aa } /* Name.Namespace */
-        .highlight .py { color: #0077aa } /* Name.Property */
-        .highlight .nt { color: #669900 } /* Name.Tag */
-        .highlight .nv { color: #222222 } /* Name.Variable */
-        .highlight .ow { color: #999999 } /* Operator.Word */
-        .highlight .mb { color: #000000 } /* Literal.Number.Bin */
-        .highlight .mf { color: #000000 } /* Literal.Number.Float */
-        .highlight .mh { color: #000000 } /* Literal.Number.Hex */
-        .highlight .mi { color: #000000 } /* Literal.Number.Integer */
-        .highlight .mo { color: #000000 } /* Literal.Number.Oct */
-        .highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
-        .highlight .sc { color: #a67f59 } /* Literal.String.Char */
-        .highlight .sd { color: #a67f59 } /* Literal.String.Doc */
-        .highlight .s2 { color: #a67f59 } /* Literal.String.Double */
-        .highlight .se { color: #a67f59 } /* Literal.String.Escape */
-        .highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
-        .highlight .si { color: #a67f59 } /* Literal.String.Interpol */
-        .highlight .sx { color: #a67f59 } /* Literal.String.Other */
-        .highlight .sr { color: #a67f59 } /* Literal.String.Regex */
-        .highlight .s1 { color: #a67f59 } /* Literal.String.Single */
-        .highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
-        .highlight .vc { color: #0077aa } /* Name.Variable.Class */
-        .highlight .vg { color: #0077aa } /* Name.Variable.Global */
-        .highlight .vi { color: #0077aa } /* Name.Variable.Instance */
-        .highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
-        </style>
+.highlight:not(.idl) { background: hsl(24, 20%, 95%); }
+code.highlight { padding: .1em; border-radius: .3em; }
+pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
+.highlight .c { color: #708090 } /* Comment */
+.highlight .k { color: #990055 } /* Keyword */
+.highlight .l { color: #000000 } /* Literal */
+.highlight .n { color: #0077aa } /* Name */
+.highlight .o { color: #999999 } /* Operator */
+.highlight .p { color: #999999 } /* Punctuation */
+.highlight .cm { color: #708090 } /* Comment.Multiline */
+.highlight .cp { color: #708090 } /* Comment.Preproc */
+.highlight .c1 { color: #708090 } /* Comment.Single */
+.highlight .cs { color: #708090 } /* Comment.Special */
+.highlight .kc { color: #990055 } /* Keyword.Constant */
+.highlight .kd { color: #990055 } /* Keyword.Declaration */
+.highlight .kn { color: #990055 } /* Keyword.Namespace */
+.highlight .kp { color: #990055 } /* Keyword.Pseudo */
+.highlight .kr { color: #990055 } /* Keyword.Reserved */
+.highlight .kt { color: #990055 } /* Keyword.Type */
+.highlight .ld { color: #000000 } /* Literal.Date */
+.highlight .m { color: #000000 } /* Literal.Number */
+.highlight .s { color: #a67f59 } /* Literal.String */
+.highlight .na { color: #0077aa } /* Name.Attribute */
+.highlight .nc { color: #0077aa } /* Name.Class */
+.highlight .no { color: #0077aa } /* Name.Constant */
+.highlight .nd { color: #0077aa } /* Name.Decorator */
+.highlight .ni { color: #0077aa } /* Name.Entity */
+.highlight .ne { color: #0077aa } /* Name.Exception */
+.highlight .nf { color: #0077aa } /* Name.Function */
+.highlight .nl { color: #0077aa } /* Name.Label */
+.highlight .nn { color: #0077aa } /* Name.Namespace */
+.highlight .py { color: #0077aa } /* Name.Property */
+.highlight .nt { color: #669900 } /* Name.Tag */
+.highlight .nv { color: #222222 } /* Name.Variable */
+.highlight .ow { color: #999999 } /* Operator.Word */
+.highlight .mb { color: #000000 } /* Literal.Number.Bin */
+.highlight .mf { color: #000000 } /* Literal.Number.Float */
+.highlight .mh { color: #000000 } /* Literal.Number.Hex */
+.highlight .mi { color: #000000 } /* Literal.Number.Integer */
+.highlight .mo { color: #000000 } /* Literal.Number.Oct */
+.highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
+.highlight .sc { color: #a67f59 } /* Literal.String.Char */
+.highlight .sd { color: #a67f59 } /* Literal.String.Doc */
+.highlight .s2 { color: #a67f59 } /* Literal.String.Double */
+.highlight .se { color: #a67f59 } /* Literal.String.Escape */
+.highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
+.highlight .si { color: #a67f59 } /* Literal.String.Interpol */
+.highlight .sx { color: #a67f59 } /* Literal.String.Other */
+.highlight .sr { color: #a67f59 } /* Literal.String.Regex */
+.highlight .s1 { color: #a67f59 } /* Literal.String.Single */
+.highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
+.highlight .vc { color: #0077aa } /* Name.Variable.Class */
+.highlight .vg { color: #0077aa } /* Name.Variable.Global */
+.highlight .vi { color: #0077aa } /* Name.Variable.Instance */
+.highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
+</style>
  <body class="h-entry">
   <div class="head">
    <header>
-    <p data-fill-with="logo"><a href="http://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"></a></p>
+    <p data-fill-with="logo"><a href="https://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"></a> </p>
     <h1>UI Events</h1>
-    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">W3C Working Draft, <time class="dt-updated" datetime="2017-04-27">27 April 2017</time></span></h2>
+    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">W3C Working Draft, <time class="dt-updated" datetime="2017-08-07">7 August 2017</time></span></h2>
    </header>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
-     <dd><a class="u-url" href="https://www.w3.org/TR/2017/WD-uievents-20170427/">https://www.w3.org/TR/2017/WD-uievents-20170427/</a>
+     <dd><a class="u-url" href="https://www.w3.org/TR/2017/WD-uievents-20170807/">https://www.w3.org/TR/2017/WD-uievents-20170807/</a>
      <dt>Latest published version:
      <dd><a href="http://www.w3.org/TR/uievents/">http://www.w3.org/TR/uievents/</a>
      <dt>Editor's Draft:
      <dd><a href="https://w3c.github.io/uievents/">https://w3c.github.io/uievents/</a>
      <dt>Previous Versions:
-     <dd><a href="" rel="previous"></a>
-     <dd><a href="https://www.w3.org/TR/2015/WD-uievents-20151215/" rel="previous">https://www.w3.org/TR/2015/WD-uievents-20151215/</a>
-     <dd><a href="http://www.w3.org/TR/2015/WD-uievents-20150428/" rel="previous">http://www.w3.org/TR/2015/WD-uievents-20150428/</a>
-     <dd><a href="http://www.w3.org/TR/2015/WD-uievents-20150319/" rel="previous">http://www.w3.org/TR/2015/WD-uievents-20150319/</a>
+     <dd><a href="" rel="prev"></a>
+     <dd><a href="https://www.w3.org/TR/2015/WD-uievents-20151215/" rel="prev">https://www.w3.org/TR/2015/WD-uievents-20151215/</a>
+     <dd><a href="http://www.w3.org/TR/2015/WD-uievents-20150428/" rel="prev">http://www.w3.org/TR/2015/WD-uievents-20150428/</a>
+     <dd><a href="http://www.w3.org/TR/2015/WD-uievents-20150319/" rel="prev">http://www.w3.org/TR/2015/WD-uievents-20150319/</a>
      <dt>Issue Tracking:
      <dd><a href="https://github.com/w3c/uievents/issues/">GitHub</a>
      <dt class="editor">Editors:
@@ -285,8 +286,8 @@ pre.idl.highlight { color: #708090; }
    <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
-  <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
   <div class="p-summary" data-fill-with="abstract">
+   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
    <p>This specification defines UI Events which extend the DOM Event objects
 
 defined in <a data-link-type="biblio" href="#biblio-dom">[DOM]</a>. UI Events are those typically implemented by visual
@@ -311,7 +312,8 @@ user agents for handling user interaction such as mouse and keyboard input.</p>
     includes instructions for disclosing a patent. An individual who has actual knowledge of a
     patent which the individual believes contains <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
     Claim(s)</a> must disclose the information in accordance with <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>. </p>
-   <p> This document is governed by the <a href="http://www.w3.org/2015/Process-20150901/" id="w3c_process_revision">1 September 2015 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>. </p>
+   <p> This document is governed by the <a href="https://www.w3.org/2017/Process-20170301/" id="w3c_process_revision">1 March 2017
+    W3C Process Document</a>. </p>
    <p></p>
   </div>
   <div data-fill-with="at-risk"></div>
@@ -955,10 +957,10 @@ events.</p>
     <p>To create an instance of the <code class="idl"><a data-link-type="idl" href="#uievent" id="ref-for-uievent-2">UIEvent</a></code> interface, use the UIEvent
 		constructor, passing an optional <code class="idl"><a data-link-type="idl" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit-1">UIEventInit</a></code> dictionary.</p>
     <h5 class="heading settled" data-level="4.1.1.1" id="idl-uievent"><span class="secno">4.1.1.1. </span><span class="content">UIEvent</span><a class="self-link" href="#idl-uievent"></a></h5>
-<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="UIEvent" data-dfn-type="constructor" data-export="" data-lt="UIEvent(type, eventInitDict)|UIEvent(type)" id="dom-uievent-uievent">Constructor<a class="self-link" href="#dom-uievent-uievent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="UIEvent/UIEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-uievent-uievent-type-eventinitdict-type">type<a class="self-link" href="#dom-uievent-uievent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit-2">UIEventInit</a> <dfn class="nv idl-code" data-dfn-for="UIEvent/UIEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-uievent-uievent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-uievent-uievent-type-eventinitdict-eventinitdict"></a></dfn>)]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="uievent">UIEvent</dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event">Event</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="UIEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="Window?" id="dom-uievent-view">view</dfn>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">long</span> <dfn class="nv dfn-paneled idl-code" data-dfn-for="UIEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="long" id="dom-uievent-detail">detail</dfn>;
+<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="UIEvent" data-dfn-type="constructor" data-export="" data-lt="UIEvent(type, eventInitDict)|UIEvent(type)" id="dom-uievent-uievent"><code>Constructor</code><a class="self-link" href="#dom-uievent-uievent"></a></dfn>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="UIEvent/UIEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-uievent-uievent-type-eventinitdict-type"><code>type</code><a class="self-link" href="#dom-uievent-uievent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit-2">UIEventInit</a> <dfn class="nv idl-code" data-dfn-for="UIEvent/UIEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-uievent-uievent-type-eventinitdict-eventinitdict"><code>eventInitDict</code><a class="self-link" href="#dom-uievent-uievent-type-eventinitdict-eventinitdict"></a></dfn>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="uievent"><code>UIEvent</code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event">Event</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="UIEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="Window?" id="dom-uievent-view"><code>view</code></dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt">long</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="UIEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="long" id="dom-uievent-detail"><code>detail</code></dfn>;
 };
 </pre>
     <dl>
@@ -973,9 +975,9 @@ events.</p>
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-2">un-initialized value</a> of this attribute MUST be <code>0</code>.</p>
     </dl>
     <h5 class="heading settled" data-level="4.1.1.2" id="idl-uieventinit"><span class="secno">4.1.1.2. </span><span class="content">UIEventInit</span><a class="self-link" href="#idl-uieventinit"></a></h5>
-<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-uieventinit">UIEventInit</dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit">EventInit</a> {
-  <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a>? <dfn class="nv idl-code" data-default="null" data-dfn-for="UIEventInit" data-dfn-type="dict-member" data-export="" data-type="Window? " id="dom-uieventinit-view">view<a class="self-link" href="#dom-uieventinit-view"></a></dfn> = <span class="kt">null</span>;
-  <span class="kt">long</span> <dfn class="nv idl-code" data-default="0" data-dfn-for="UIEventInit" data-dfn-type="dict-member" data-export="" data-type="long " id="dom-uieventinit-detail">detail<a class="self-link" href="#dom-uieventinit-detail"></a></dfn> = 0;
+<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-uieventinit"><code>UIEventInit</code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit">EventInit</a> {
+  <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a>? <dfn class="nv idl-code" data-default="null" data-dfn-for="UIEventInit" data-dfn-type="dict-member" data-export="" data-type="Window? " id="dom-uieventinit-view"><code>view</code><a class="self-link" href="#dom-uieventinit-view"></a></dfn> = <span class="kt">null</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt">long</span></a> <dfn class="nv idl-code" data-default="0" data-dfn-for="UIEventInit" data-dfn-type="dict-member" data-export="" data-type="long " id="dom-uieventinit-detail"><code>detail</code><a class="self-link" href="#dom-uieventinit-detail"></a></dfn> = 0;
 };
 </pre>
     <dl>
@@ -1203,9 +1205,9 @@ events.</p>
     <p>To create an instance of the <code class="idl"><a data-link-type="idl" href="#focusevent" id="ref-for-focusevent-2">FocusEvent</a></code> interface, use the
 		FocusEvent constructor, passing an optional <code class="idl"><a data-link-type="idl" href="#dictdef-focuseventinit" id="ref-for-dictdef-focuseventinit-1">FocusEventInit</a></code> dictionary.</p>
     <h5 class="heading settled" data-level="4.2.1.1" id="idl-focusevent"><span class="secno">4.2.1.1. </span><span class="content">FocusEvent</span><a class="self-link" href="#idl-focusevent"></a></h5>
-<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="FocusEvent" data-dfn-type="constructor" data-export="" data-lt="FocusEvent(type, eventInitDict)|FocusEvent(type)" id="dom-focusevent-focusevent">Constructor<a class="self-link" href="#dom-focusevent-focusevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="FocusEvent/FocusEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-focusevent-focusevent-type-eventinitdict-type">type<a class="self-link" href="#dom-focusevent-focusevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-focuseventinit" id="ref-for-dictdef-focuseventinit-2">FocusEventInit</a> <dfn class="nv idl-code" data-dfn-for="FocusEvent/FocusEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-focusevent-focusevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-focusevent-focusevent-type-eventinitdict-eventinitdict"></a></dfn>)]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="focusevent">FocusEvent</dfn> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent-19">UIEvent</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="FocusEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="EventTarget?" id="dom-focusevent-relatedtarget">relatedTarget</dfn>;
+<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="FocusEvent" data-dfn-type="constructor" data-export="" data-lt="FocusEvent(type, eventInitDict)|FocusEvent(type)" id="dom-focusevent-focusevent"><code>Constructor</code><a class="self-link" href="#dom-focusevent-focusevent"></a></dfn>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="FocusEvent/FocusEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-focusevent-focusevent-type-eventinitdict-type"><code>type</code><a class="self-link" href="#dom-focusevent-focusevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-focuseventinit" id="ref-for-dictdef-focuseventinit-2">FocusEventInit</a> <dfn class="nv idl-code" data-dfn-for="FocusEvent/FocusEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-focusevent-focusevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code><a class="self-link" href="#dom-focusevent-focusevent-type-eventinitdict-eventinitdict"></a></dfn>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="focusevent"><code>FocusEvent</code></dfn> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent-19">UIEvent</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="FocusEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="EventTarget?" id="dom-focusevent-relatedtarget"><code>relatedTarget</code></dfn>;
 };
 </pre>
     <dl>
@@ -1217,8 +1219,8 @@ events.</p>
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-3">un-initialized value</a> of this attribute MUST be <code>null</code>.</p>
     </dl>
     <h5 class="heading settled" data-level="4.2.1.2" id="idl-focuseventinit"><span class="secno">4.2.1.2. </span><span class="content">FocusEventInit</span><a class="self-link" href="#idl-focuseventinit"></a></h5>
-<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-focuseventinit">FocusEventInit</dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit-3">UIEventInit</a> {
-  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <dfn class="nv dfn-paneled idl-code" data-default="null" data-dfn-for="FocusEventInit" data-dfn-type="dict-member" data-export="" data-type="EventTarget? " id="dom-focuseventinit-relatedtarget">relatedTarget</dfn> = <span class="kt">null</span>;
+<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-focuseventinit"><code>FocusEventInit</code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit-3">UIEventInit</a> {
+  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <dfn class="nv dfn-paneled idl-code" data-default="null" data-dfn-for="FocusEventInit" data-dfn-type="dict-member" data-export="" data-type="EventTarget? " id="dom-focuseventinit-relatedtarget"><code>relatedTarget</code></dfn> = <span class="kt">null</span>;
 };
 </pre>
     <dl>
@@ -1490,7 +1492,7 @@ document.</p>
 			dispatched before the element loses focus.  The <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-20">event target</a> MUST be the element which is about to lose focus.  This event type
 			is similar to <a data-link-type="dfn" href="#blur" id="ref-for-blur-4"><code>blur</code></a>, but is dispatched before focus is			shifted, and does bubble.</p>
     <h3 class="heading settled" data-level="4.3" id="events-mouseevents"><span class="secno">4.3. </span><span class="content">Mouse Events</span><a class="self-link" href="#events-mouseevents"></a></h3>
-    <p>The mouse event module originates from the <a data-link-type="biblio" href="#biblio-html40">[HTML40]</a> <code>onclick</code>, <code>ondblclick</code>, <code>onmousedown</code>, <code>onmouseup</code>, <code>onmouseover</code>, <code>onmousemove</code>, and <code>onmouseout</code> attributes. This event module is specifically
+    <p>The mouse event module originates from the <a data-link-type="biblio" href="#biblio-html401">[HTML401]</a> <code>onclick</code>, <code>ondblclick</code>, <code>onmousedown</code>, <code>onmouseup</code>, <code>onmouseover</code>, <code>onmousemove</code>, and <code>onmouseout</code> attributes. This event module is specifically
 	designed for use with pointing input devices, such as a mouse or a trackball.</p>
     <h4 class="heading settled" data-level="4.3.1" id="interface-mouseevent"><span class="secno">4.3.1. </span><span class="content">Interface MouseEvent</span><a class="self-link" href="#interface-mouseevent"></a></h4>
     <p class="intro-dom">Introduced in DOM Level 2, modified in this
@@ -1508,64 +1510,64 @@ document.</p>
 		as target coordinates exposed by <a data-link-type="dfn" href="#dom-level-0" id="ref-for-dom-level-0-1">DOM Level 0</a> implementations or
 		other proprietary attributes, e.g., <code>pageX</code>). </p>
     <h5 class="heading settled" data-level="4.3.1.1" id="idl-mouseevent"><span class="secno">4.3.1.1. </span><span class="content">MouseEvent</span><a class="self-link" href="#idl-mouseevent"></a></h5>
-<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="MouseEvent" data-dfn-type="constructor" data-export="" data-lt="MouseEvent(type, eventInitDict)|MouseEvent(type)" id="dom-mouseevent-mouseevent">Constructor<a class="self-link" href="#dom-mouseevent-mouseevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="MouseEvent/MouseEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-mouseevent-mouseevent-type-eventinitdict-type">type<a class="self-link" href="#dom-mouseevent-mouseevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-mouseeventinit" id="ref-for-dictdef-mouseeventinit-2">MouseEventInit</a> <dfn class="nv idl-code" data-dfn-for="MouseEvent/MouseEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-mouseevent-mouseevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-mouseevent-mouseevent-type-eventinitdict-eventinitdict"></a></dfn>)]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="mouseevent">MouseEvent</dfn> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent-28">UIEvent</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="#dom-mouseevent-screenx" id="ref-for-dom-mouseevent-screenx-1">screenX</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="#dom-mouseevent-screeny" id="ref-for-dom-mouseevent-screeny-1">screenY</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="#dom-mouseevent-clientx" id="ref-for-dom-mouseevent-clientx-2">clientX</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="#dom-mouseevent-clienty" id="ref-for-dom-mouseevent-clienty-2">clientY</a>;
+<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="MouseEvent" data-dfn-type="constructor" data-export="" data-lt="MouseEvent(type, eventInitDict)|MouseEvent(type)" id="dom-mouseevent-mouseevent"><code>Constructor</code><a class="self-link" href="#dom-mouseevent-mouseevent"></a></dfn>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="MouseEvent/MouseEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-mouseevent-mouseevent-type-eventinitdict-type"><code>type</code><a class="self-link" href="#dom-mouseevent-mouseevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-mouseeventinit" id="ref-for-dictdef-mouseeventinit-2">MouseEventInit</a> <dfn class="nv idl-code" data-dfn-for="MouseEvent/MouseEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-mouseevent-mouseevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code><a class="self-link" href="#dom-mouseevent-mouseevent-type-eventinitdict-eventinitdict"></a></dfn>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="mouseevent"><code>MouseEvent</code></dfn> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent-28">UIEvent</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="#dom-mouseevent-screenx" id="ref-for-dom-mouseevent-screenx-1">screenX</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="#dom-mouseevent-screeny" id="ref-for-dom-mouseevent-screeny-1">screenY</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="#dom-mouseevent-clientx" id="ref-for-dom-mouseevent-clientx-2">clientX</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="#dom-mouseevent-clienty" id="ref-for-dom-mouseevent-clienty-2">clientY</a>;
 
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-mouseevent-ctrlkey" id="ref-for-dom-mouseevent-ctrlkey-1">ctrlKey</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-mouseevent-shiftkey" id="ref-for-dom-mouseevent-shiftkey-1">shiftKey</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-mouseevent-altkey" id="ref-for-dom-mouseevent-altkey-1">altKey</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-mouseevent-metakey" id="ref-for-dom-mouseevent-metakey-1">metaKey</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-mouseevent-ctrlkey" id="ref-for-dom-mouseevent-ctrlkey-1">ctrlKey</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-mouseevent-shiftkey" id="ref-for-dom-mouseevent-shiftkey-1">shiftKey</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-mouseevent-altkey" id="ref-for-dom-mouseevent-altkey-1">altKey</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-mouseevent-metakey" id="ref-for-dom-mouseevent-metakey-1">metaKey</a>;
 
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="short" href="#dom-mouseevent-button" id="ref-for-dom-mouseevent-button-1">button</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned short" href="#dom-mouseevent-buttons" id="ref-for-dom-mouseevent-buttons-1">buttons</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-short"><span class="kt">short</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="short" href="#dom-mouseevent-button" id="ref-for-dom-mouseevent-button-1">button</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short"><span class="kt">unsigned</span> <span class="kt">short</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned short" href="#dom-mouseevent-buttons" id="ref-for-dom-mouseevent-buttons-1">buttons</a>;
 
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="EventTarget?" href="#dom-mouseevent-relatedtarget" id="ref-for-dom-mouseevent-relatedtarget-1">relatedTarget</a>;
 
-  <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="method" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate-2">getModifierState</a>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="MouseEvent/getModifierState(keyArg)" data-dfn-type="argument" data-export="" id="dom-mouseevent-getmodifierstate-keyarg-keyarg">keyArg<a class="self-link" href="#dom-mouseevent-getmodifierstate-keyarg-keyarg"></a></dfn>);
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="method" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate-2">getModifierState</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="MouseEvent/getModifierState(keyArg)" data-dfn-type="argument" data-export="" id="dom-mouseevent-getmodifierstate-keyarg-keyarg"><code>keyArg</code><a class="self-link" href="#dom-mouseevent-getmodifierstate-keyarg-keyarg"></a></dfn>);
 };
 </pre>
     <dl>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-screenx">screenX</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long">long</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-screenx"><code>screenX</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long">long</a>, readonly</span>
      <dd>
        The horizontal coordinate at which the event occurred relative
 					to the origin of the screen coordinate system. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-4">un-initialized value</a> of this attribute MUST be <code>0</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-screeny">screenY</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long">long</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-screeny"><code>screenY</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long">long</a>, readonly</span>
      <dd>
        The vertical coordinate at which the event occurred relative to
 					the origin of the screen coordinate system. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-5">un-initialized value</a> of this attribute MUST be <code>0</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-clientx">clientX</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long">long</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-clientx"><code>clientX</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long">long</a>, readonly</span>
      <dd>
        The horizontal coordinate at which the event occurred relative
 					to the viewport associated with the event. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-6">un-initialized value</a> of this attribute MUST be <code>0</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-clienty">clientY</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long">long</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-clienty"><code>clientY</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long">long</a>, readonly</span>
      <dd>
        The vertical coordinate at which the event occurred relative
 					to the viewport associated with the event. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-7">un-initialized value</a> of this attribute MUST be <code>0</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-ctrlkey">ctrlKey</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-ctrlkey"><code>ctrlKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, readonly</span>
      <dd>
        Refer to the <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent-8">KeyboardEvent</a></code>'s <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-ctrlkey" id="ref-for-dom-keyboardevent-ctrlkey-1">ctrlKey</a></code> attribute. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-8">un-initialized value</a> of this attribute MUST be <code>false</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-shiftkey">shiftKey</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-shiftkey"><code>shiftKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, readonly</span>
      <dd>
        Refer to the <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent-9">KeyboardEvent</a></code>'s <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-shiftkey" id="ref-for-dom-keyboardevent-shiftkey-1">shiftKey</a></code> attribute. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-9">un-initialized value</a> of this attribute MUST be <code>false</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-altkey">altKey</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-altkey"><code>altKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, readonly</span>
      <dd>
        Refer to the <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent-10">KeyboardEvent</a></code>'s <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-altkey" id="ref-for-dom-keyboardevent-altkey-1">altKey</a></code> attribute. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-10">un-initialized value</a> of this attribute MUST be <code>false</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-metakey">metaKey</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-metakey"><code>metaKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, readonly</span>
      <dd>
        Refer to the <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent-11">KeyboardEvent</a></code>'s <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-metakey" id="ref-for-dom-keyboardevent-metakey-1">metaKey</a></code> attribute. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-11">un-initialized value</a> of this attribute MUST be <code>false</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-button">button</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-short">short</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-button"><code>button</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-short">short</a>, readonly</span>
      <dd>
        During mouse events caused by the depression or release of a mouse button, <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-button" id="ref-for-dom-mouseevent-button-2">button</a></code> MUST be used to indicate which pointer device button
 					changed state. 
@@ -1591,7 +1593,7 @@ un-initialized value.</p>
       <p class="note" role="note"> Some <a data-link-type="dfn" href="#default-action" id="ref-for-default-action-12">default actions</a> related
 					to events such as <a data-link-type="dfn" href="#mousedown" id="ref-for-mousedown-3"><code>mousedown</code></a> and <a data-link-type="dfn" href="#mouseup" id="ref-for-mouseup-1"><code>mouseup</code></a> depend on the specific mouse					button in use. </p>
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-13">un-initialized value</a> of this attribute MUST be <code>0</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-buttons">buttons</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-short">unsigned short</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-buttons"><code>buttons</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-short">unsigned short</a>, readonly</span>
      <dd>
        During any mouse events, <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-buttons" id="ref-for-dom-mouseevent-buttons-2">buttons</a></code> MUST be used to
 					indicate which combination of mouse buttons are currently being
@@ -1626,11 +1628,11 @@ used to activate a user interface control or select text).</p>
 					currently both pressed. </p>
       <p class="note" role="note"> Some <a data-link-type="dfn" href="#default-action" id="ref-for-default-action-13">default actions</a> related to events such as <a data-link-type="dfn" href="#mousedown" id="ref-for-mousedown-5"><code>mousedown</code></a> and <a data-link-type="dfn" href="#mouseup" id="ref-for-mouseup-3"><code>mouseup</code></a> depend on the specific mouse					button in use. </p>
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-14">un-initialized value</a> of this attribute MUST be <code>0</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-relatedtarget">relatedTarget</dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>, readonly, nullable</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-relatedtarget"><code>relatedTarget</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>, readonly, nullable</span>
      <dd>
        Used to identify a secondary <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a></code> related to a UI event, depending on the type of event. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-15">un-initialized value</a> of this attribute MUST be <code>null</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="method" data-export="" id="dom-mouseevent-getmodifierstate">getModifierState(keyArg)</dfn>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="method" data-export="" id="dom-mouseevent-getmodifierstate"><code>getModifierState(keyArg)</code></dfn>
      <dd>
       <p class="intro-dom">Introduced in this specification</p>
       <p>Queries the state of a modifier using a key value.
@@ -1644,43 +1646,43 @@ used to activate a user interface control or select text).</p>
       </dl>
     </dl>
     <h5 class="heading settled" data-level="4.3.1.2" id="idl-mouseeventinit"><span class="secno">4.3.1.2. </span><span class="content">MouseEventInit</span><a class="self-link" href="#idl-mouseeventinit"></a></h5>
-<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-mouseeventinit">MouseEventInit</dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-eventmodifierinit" id="ref-for-dictdef-eventmodifierinit-3">EventModifierInit</a> {
-  <span class="kt">long</span> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-screenx" id="ref-for-dom-mouseeventinit-screenx-1">screenX</a> = 0;
-  <span class="kt">long</span> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-screeny" id="ref-for-dom-mouseeventinit-screeny-1">screenY</a> = 0;
-  <span class="kt">long</span> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-clientx" id="ref-for-dom-mouseeventinit-clientx-1">clientX</a> = 0;
-  <span class="kt">long</span> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-clienty" id="ref-for-dom-mouseeventinit-clienty-1">clientY</a> = 0;
+<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-mouseeventinit"><code>MouseEventInit</code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-eventmodifierinit" id="ref-for-dictdef-eventmodifierinit-3">EventModifierInit</a> {
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt">long</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-screenx" id="ref-for-dom-mouseeventinit-screenx-1">screenX</a> = 0;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt">long</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-screeny" id="ref-for-dom-mouseeventinit-screeny-1">screenY</a> = 0;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt">long</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-clientx" id="ref-for-dom-mouseeventinit-clientx-1">clientX</a> = 0;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt">long</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-clienty" id="ref-for-dom-mouseeventinit-clienty-1">clientY</a> = 0;
 
-  <span class="kt">short</span> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="short " href="#dom-mouseeventinit-button" id="ref-for-dom-mouseeventinit-button-1">button</a> = 0;
-  <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned short " href="#dom-mouseeventinit-buttons" id="ref-for-dom-mouseeventinit-buttons-1">buttons</a> = 0;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-short"><span class="kt">short</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="short " href="#dom-mouseeventinit-button" id="ref-for-dom-mouseeventinit-button-1">button</a> = 0;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short"><span class="kt">unsigned</span> <span class="kt">short</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned short " href="#dom-mouseeventinit-buttons" id="ref-for-dom-mouseeventinit-buttons-1">buttons</a> = 0;
   <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <a class="nv idl-code" data-default="null" data-link-type="dict-member" data-type="EventTarget? " href="#dom-mouseeventinit-relatedtarget" id="ref-for-dom-mouseeventinit-relatedtarget-1">relatedTarget</a> = <span class="kt">null</span>;
 };
 </pre>
     <dl>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export="" id="dom-mouseeventinit-screenx">screenX</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long">long</a>, defaulting to <code>0</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export="" id="dom-mouseeventinit-screenx"><code>screenX</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long">long</a>, defaulting to <code>0</code></span>
      <dd>
        Initializes the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-screenx" id="ref-for-dom-mouseevent-screenx-2">screenX</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-10">MouseEvent</a></code> object to the desired horizontal relative position of the mouse
 					pointer on the user’s screen. 
       <p>Initializing the event object to the given mouse position must
 					not move the user’s mouse pointer to the initialized position.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export="" id="dom-mouseeventinit-screeny">screenY</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long">long</a>, defaulting to <code>0</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export="" id="dom-mouseeventinit-screeny"><code>screenY</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long">long</a>, defaulting to <code>0</code></span>
      <dd>
        Initializes the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-screeny" id="ref-for-dom-mouseevent-screeny-2">screenY</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-11">MouseEvent</a></code> object to the desired vertical relative position of the mouse
 					pointer on the user’s screen. 
       <p>Initializing the event object to the given mouse position must
 					not move the user’s mouse pointer to the initialized position.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export="" id="dom-mouseeventinit-clientx">clientX</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long">long</a>, defaulting to <code>0</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export="" id="dom-mouseeventinit-clientx"><code>clientX</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long">long</a>, defaulting to <code>0</code></span>
      <dd>
        Initializes the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-clientx" id="ref-for-dom-mouseevent-clientx-3">clientX</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-12">MouseEvent</a></code> object to the desired horizontal position of the mouse pointer
 					relative to the client window of the user’s browser. 
       <p>Initializing the event object to the given mouse position must
 					not move the user’s mouse pointer to the initialized position.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export="" id="dom-mouseeventinit-clienty">clientY</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long">long</a>, defaulting to <code>0</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export="" id="dom-mouseeventinit-clienty"><code>clientY</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long">long</a>, defaulting to <code>0</code></span>
      <dd>
        Initializes the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-clienty" id="ref-for-dom-mouseevent-clienty-3">clientY</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-13">MouseEvent</a></code> object to the desired vertical position of the mouse pointer
 					relative to the client window of the user’s browser. 
       <p>Initializing the event object to the given mouse position must
 					not move the user’s mouse pointer to the initialized position.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export="" id="dom-mouseeventinit-button">button</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-short">short</a>, defaulting to <code>0</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export="" id="dom-mouseeventinit-button"><code>button</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-short">short</a>, defaulting to <code>0</code></span>
      <dd>
        Initializes the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-button" id="ref-for-dom-mouseevent-button-7">button</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-14">MouseEvent</a></code> object to a number representing the desired state of the button(s)
 					of the mouse. 
@@ -1689,7 +1691,7 @@ used to activate a user interface control or select text).</p>
 					mouse button, and 2 to represent the right mouse button.
 					Numbers greater than 2 are also possible, but are not specified
 					in this document. </p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export="" id="dom-mouseeventinit-buttons">buttons</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-short">unsigned short</a>, defaulting to <code>0</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export="" id="dom-mouseeventinit-buttons"><code>buttons</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-short">unsigned short</a>, defaulting to <code>0</code></span>
      <dd>
        Initializes the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-buttons" id="ref-for-dom-mouseevent-buttons-6">buttons</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-15">MouseEvent</a></code> object to a number representing one <em>or more</em> of the button(s) of the mouse
 					that are to be considered active. 
@@ -1698,10 +1700,10 @@ used to activate a user interface control or select text).</p>
 					mask value of 2 is true when applied to the value of the bit field, then
 					the right mouse button is down. If a mask value of 4 is true when applied
 					to the value of the bit field, then the auxiliary/middle button is down. </p>
-      <p class="example" id="example-cd238785"><a class="self-link" href="#example-cd238785"></a> In JavaScript, to initialize the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-buttons" id="ref-for-dom-mouseevent-buttons-8">buttons</a></code> attribute as if the right (2) and middle
+      <p class="example" id="example-8d7b46d6"><a class="self-link" href="#example-8d7b46d6"></a> In JavaScript, to initialize the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-buttons" id="ref-for-dom-mouseevent-buttons-8">buttons</a></code> attribute as if the right (2) and middle
 					button (4) were being pressed simultaneously, the buttons value
 					can be assigned as either:<br> <code>  { buttons: 2 | 4 }</code><br> or:<br> <code>  { buttons: 6 }</code> </p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export="" id="dom-mouseeventinit-relatedtarget">relatedTarget</dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>, nullable, defaulting to <code>null</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export="" id="dom-mouseeventinit-relatedtarget"><code>relatedTarget</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>, nullable, defaulting to <code>null</code></span>
      <dd> The <code>relatedTarget</code> should be initialized to the element
 					whose bounds the mouse pointer just left (in the case of a <em>mouseover</em> or <em>mouseenter</em> event) or the element
 					whose bounds the mouse pointer is entering (in the case of a <em>mouseout</em> or <em>mouseleave</em> or <em>focusout</em> event). For other events, this value need not
@@ -1719,64 +1721,64 @@ used to activate a user interface control or select text).</p>
 		initialize keyboard modifier attributes of the <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-17">MouseEvent</a></code> and <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent-14">KeyboardEvent</a></code> interfaces, as well as the additional modifier states
 		queried via <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate-3">getModifierState()</a></code>. The steps for
 		constructing events using this dictionary are defined in the <a href="#event-constructors">event constructors</a> section.</p>
-<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-eventmodifierinit">EventModifierInit</dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit-4">UIEventInit</a> {
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-ctrlkey" id="ref-for-dom-eventmodifierinit-ctrlkey-1">ctrlKey</a> = <span class="kt">false</span>;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-shiftkey" id="ref-for-dom-eventmodifierinit-shiftkey-1">shiftKey</a> = <span class="kt">false</span>;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-altkey" id="ref-for-dom-eventmodifierinit-altkey-1">altKey</a> = <span class="kt">false</span>;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-metakey" id="ref-for-dom-eventmodifierinit-metakey-1">metaKey</a> = <span class="kt">false</span>;
+<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-eventmodifierinit"><code>EventModifierInit</code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit-4">UIEventInit</a> {
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-ctrlkey" id="ref-for-dom-eventmodifierinit-ctrlkey-1">ctrlKey</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-shiftkey" id="ref-for-dom-eventmodifierinit-shiftkey-1">shiftKey</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-altkey" id="ref-for-dom-eventmodifierinit-altkey-1">altKey</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-metakey" id="ref-for-dom-eventmodifierinit-metakey-1">metaKey</a> = <span class="kt">false</span>;
 
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifieraltgraph" id="ref-for-dom-eventmodifierinit-modifieraltgraph-1">modifierAltGraph</a> = <span class="kt">false</span>;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiercapslock" id="ref-for-dom-eventmodifierinit-modifiercapslock-1">modifierCapsLock</a> = <span class="kt">false</span>;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierfn" id="ref-for-dom-eventmodifierinit-modifierfn-1">modifierFn</a> = <span class="kt">false</span>;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierfnlock" id="ref-for-dom-eventmodifierinit-modifierfnlock-1">modifierFnLock</a> = <span class="kt">false</span>;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierhyper" id="ref-for-dom-eventmodifierinit-modifierhyper-1">modifierHyper</a> = <span class="kt">false</span>;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiernumlock" id="ref-for-dom-eventmodifierinit-modifiernumlock-1">modifierNumLock</a> = <span class="kt">false</span>;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierscrolllock" id="ref-for-dom-eventmodifierinit-modifierscrolllock-1">modifierScrollLock</a> = <span class="kt">false</span>;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiersuper" id="ref-for-dom-eventmodifierinit-modifiersuper-1">modifierSuper</a> = <span class="kt">false</span>;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiersymbol" id="ref-for-dom-eventmodifierinit-modifiersymbol-1">modifierSymbol</a> = <span class="kt">false</span>;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiersymbollock" id="ref-for-dom-eventmodifierinit-modifiersymbollock-1">modifierSymbolLock</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifieraltgraph" id="ref-for-dom-eventmodifierinit-modifieraltgraph-1">modifierAltGraph</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiercapslock" id="ref-for-dom-eventmodifierinit-modifiercapslock-1">modifierCapsLock</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierfn" id="ref-for-dom-eventmodifierinit-modifierfn-1">modifierFn</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierfnlock" id="ref-for-dom-eventmodifierinit-modifierfnlock-1">modifierFnLock</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierhyper" id="ref-for-dom-eventmodifierinit-modifierhyper-1">modifierHyper</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiernumlock" id="ref-for-dom-eventmodifierinit-modifiernumlock-1">modifierNumLock</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierscrolllock" id="ref-for-dom-eventmodifierinit-modifierscrolllock-1">modifierScrollLock</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiersuper" id="ref-for-dom-eventmodifierinit-modifiersuper-1">modifierSuper</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiersymbol" id="ref-for-dom-eventmodifierinit-modifiersymbol-1">modifierSymbol</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiersymbollock" id="ref-for-dom-eventmodifierinit-modifiersymbollock-1">modifierSymbolLock</a> = <span class="kt">false</span>;
 };
 </pre>
     <dl>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-ctrlkey">ctrlKey</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-ctrlkey"><code>ctrlKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
      <dd>
        Initializes the <code>ctrlKey</code> attribute of the <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-18">MouseEvent</a></code> or <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent-15">KeyboardEvent</a></code> objects to <code>true</code> if the <code class="keycap">Control</code> key modifier is to be considered active, <code>false</code> otherwise. 
       <p>When <code>true</code>, implementations must also initialize the event object’s key modifier
 				state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate-3">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate-4">getModifierState()</a></code> when provided with the parameter <code class="keycap">Control</code> must return <code>true</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-shiftkey">shiftKey</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-shiftkey"><code>shiftKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
      <dd>
        Initializes the <code>shiftKey</code> attribute of the <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-19">MouseEvent</a></code> or <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent-16">KeyboardEvent</a></code> objects to <code>true</code> if the <code class="keycap">Shift</code> key modifier is to be considered active, <code>false</code> otherwise. 
       <p>When <code>true</code>, implementations must also initialize the event object’s key modifier
 				state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate-4">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate-5">getModifierState()</a></code> when provided with the parameter <code class="keycap">Shift</code> must				return <code>true</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-altkey">altKey</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-altkey"><code>altKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
      <dd>
        Initializes the <code>altKey</code> attribute of the <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-20">MouseEvent</a></code> or <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent-17">KeyboardEvent</a></code> objects to <code>true</code> if the <code class="keycap">Alt</code> (alternative) (or <code class="keycap">Option</code>) key modifier				is to be considered active, <code>false</code> otherwise. 
       <p>When <code>true</code>, implementations must also initialize the event object’s key modifier
 				state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate-5">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate-6">getModifierState()</a></code> when provided with the parameter <code class="keycap">Alt</code> must				return <code>true</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-metakey">metaKey</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-metakey"><code>metaKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
      <dd>
        Initializes the <code>metaKey</code> attribute of the <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-21">MouseEvent</a></code> or <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent-18">KeyboardEvent</a></code> objects to <code>true</code> if the <code class="keycap">Meta</code> key modifier is to be considered active, <code>false</code> otherwise. 
       <p>When <code>true</code>, implementations must also initialize the event object’s
 				key modifier state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate-6">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate-7">getModifierState()</a></code> when provided with either the parameter <code class="keycap">Meta</code> must return <code>true</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifieraltgraph">modifierAltGraph</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifieraltgraph"><code>modifierAltGraph</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
      <dd> Initializes the event object’s key modifier state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate-7">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate-8">getModifierState()</a></code> when provided with the parameter <code class="keycap">AltGraph</code> must				return <code>true</code>. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifiercapslock">modifierCapsLock</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifiercapslock"><code>modifierCapsLock</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
      <dd> Initializes the event object’s key modifier state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate-8">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate-9">getModifierState()</a></code> when provided with the parameter <code class="keycap">CapsLock</code> must				return <code>true</code>. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifierfn">modifierFn</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifierfn"><code>modifierFn</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
      <dd> Initializes the event object’s key modifier state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate-9">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate-10">getModifierState()</a></code> when provided with the parameter <code class="keycap">Fn</code> must				return <code>true</code>. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifierfnlock">modifierFnLock</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifierfnlock"><code>modifierFnLock</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
      <dd> Initializes the event object’s key modifier state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate-10">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate-11">getModifierState()</a></code> when provided with the parameter <code class="keycap">FnLock</code> must				return <code>true</code>. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifierhyper">modifierHyper</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifierhyper"><code>modifierHyper</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
      <dd> Initializes the event object’s key modifier state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate-11">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate-12">getModifierState()</a></code> when provided with the parameter <code class="keycap">Hyper</code> must				return <code>true</code>. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifiernumlock">modifierNumLock</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifiernumlock"><code>modifierNumLock</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
      <dd> Initializes the event object’s key modifier state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate-12">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate-13">getModifierState()</a></code> when provided with the parameter <code class="keycap">NumLock</code> must				return <code>true</code>. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifierscrolllock">modifierScrollLock</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifierscrolllock"><code>modifierScrollLock</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
      <dd> Initializes the event object’s key modifier state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate-13">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate-14">getModifierState()</a></code> when provided with the parameter <code class="keycap">ScrollLock</code> must				return <code>true</code>. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifiersuper">modifierSuper</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifiersuper"><code>modifierSuper</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
      <dd> Initializes the event object’s key modifier state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate-14">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate-15">getModifierState()</a></code> when provided with the parameter <code class="keycap">Super</code> must				return <code>true</code>. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifiersymbol">modifierSymbol</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifiersymbol"><code>modifierSymbol</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
      <dd> Initializes the event object’s key modifier state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate-15">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate-16">getModifierState()</a></code> when provided with the parameter <code class="keycap">Symbol</code> must				return <code>true</code>. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifiersymbollock">modifierSymbolLock</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifiersymbollock"><code>modifierSymbolLock</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
      <dd> Initializes the event object’s key modifier state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate-16">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate-17">getModifierState()</a></code> when provided with the parameter <code class="keycap">SymbolLock</code> must				return <code>true</code>. 
     </dl>
     <h4 class="heading settled" data-level="4.3.3" id="events-mouseevent-event-order"><span class="secno">4.3.3. </span><span class="content">Mouse Event Order</span><a class="self-link" href="#events-mouseevent-event-order"></a></h4>
@@ -2731,31 +2733,31 @@ portions of that content.</p>
 		To create an instance of the <code class="idl"><a data-link-type="idl" href="#wheelevent" id="ref-for-wheelevent-3">WheelEvent</a></code> interface, use the <code class="idl"><a data-link-type="idl" href="#wheelevent" id="ref-for-wheelevent-4">WheelEvent</a></code> constructor,
 		passing an optional <code class="idl"><a data-link-type="idl" href="#dictdef-wheeleventinit" id="ref-for-dictdef-wheeleventinit-1">WheelEventInit</a></code> dictionary.</p>
     <h5 class="heading settled" data-level="4.4.1.1" id="idl-wheelevent"><span class="secno">4.4.1.1. </span><span class="content">WheelEvent</span><a class="self-link" href="#idl-wheelevent"></a></h5>
-<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="WheelEvent" data-dfn-type="constructor" data-export="" data-lt="WheelEvent(type, eventInitDict)|WheelEvent(type)" id="dom-wheelevent-wheelevent">Constructor<a class="self-link" href="#dom-wheelevent-wheelevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="WheelEvent/WheelEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-wheelevent-wheelevent-type-eventinitdict-type">type<a class="self-link" href="#dom-wheelevent-wheelevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-wheeleventinit" id="ref-for-dictdef-wheeleventinit-2">WheelEventInit</a> <dfn class="nv idl-code" data-dfn-for="WheelEvent/WheelEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-wheelevent-wheelevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-wheelevent-wheelevent-type-eventinitdict-eventinitdict"></a></dfn>)]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="wheelevent">WheelEvent</dfn> : <a class="n" data-link-type="idl-name" href="#mouseevent" id="ref-for-mouseevent-142">MouseEvent</a> {
+<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="WheelEvent" data-dfn-type="constructor" data-export="" data-lt="WheelEvent(type, eventInitDict)|WheelEvent(type)" id="dom-wheelevent-wheelevent"><code>Constructor</code><a class="self-link" href="#dom-wheelevent-wheelevent"></a></dfn>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="WheelEvent/WheelEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-wheelevent-wheelevent-type-eventinitdict-type"><code>type</code><a class="self-link" href="#dom-wheelevent-wheelevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-wheeleventinit" id="ref-for-dictdef-wheeleventinit-2">WheelEventInit</a> <dfn class="nv idl-code" data-dfn-for="WheelEvent/WheelEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-wheelevent-wheelevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code><a class="self-link" href="#dom-wheelevent-wheelevent-type-eventinitdict-eventinitdict"></a></dfn>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="wheelevent"><code>WheelEvent</code></dfn> : <a class="n" data-link-type="idl-name" href="#mouseevent" id="ref-for-mouseevent-142">MouseEvent</a> {
   // DeltaModeCode
-  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-wheelevent-dom_delta_pixel" id="ref-for-dom-wheelevent-dom_delta_pixel-1">DOM_DELTA_PIXEL</a> = 0x00;
-  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-wheelevent-dom_delta_line" id="ref-for-dom-wheelevent-dom_delta_line-1">DOM_DELTA_LINE</a>  = 0x01;
-  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-wheelevent-dom_delta_page" id="ref-for-dom-wheelevent-dom_delta_page-1">DOM_DELTA_PAGE</a>  = 0x02;
+  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-wheelevent-dom_delta_pixel" id="ref-for-dom-wheelevent-dom_delta_pixel-1">DOM_DELTA_PIXEL</a> = 0x00;
+  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-wheelevent-dom_delta_line" id="ref-for-dom-wheelevent-dom_delta_line-1">DOM_DELTA_LINE</a>  = 0x01;
+  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-wheelevent-dom_delta_page" id="ref-for-dom-wheelevent-dom_delta_page-1">DOM_DELTA_PAGE</a>  = 0x02;
 
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">double</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="double" href="#dom-wheelevent-deltax" id="ref-for-dom-wheelevent-deltax-1">deltaX</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">double</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="double" href="#dom-wheelevent-deltay" id="ref-for-dom-wheelevent-deltay-1">deltaY</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">double</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="double" href="#dom-wheelevent-deltaz" id="ref-for-dom-wheelevent-deltaz-1">deltaZ</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-wheelevent-deltamode" id="ref-for-dom-wheelevent-deltamode-1">deltaMode</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="double" href="#dom-wheelevent-deltax" id="ref-for-dom-wheelevent-deltax-1">deltaX</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="double" href="#dom-wheelevent-deltay" id="ref-for-dom-wheelevent-deltay-1">deltaY</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="double" href="#dom-wheelevent-deltaz" id="ref-for-dom-wheelevent-deltaz-1">deltaZ</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-wheelevent-deltamode" id="ref-for-dom-wheelevent-deltamode-1">deltaMode</a>;
 };
 </pre>
     <dl>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="const" data-export="" id="dom-wheelevent-dom_delta_pixel">DOM_DELTA_PIXEL</dfn>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="const" data-export="" id="dom-wheelevent-dom_delta_pixel"><code>DOM_DELTA_PIXEL</code></dfn>
      <dd> The units of measurement for the <a data-link-type="dfn" href="#delta" id="ref-for-delta-4">delta</a> MUST be pixels.
 					This is the most typical case in most operating system and
 					implementation configurations. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="const" data-export="" id="dom-wheelevent-dom_delta_line">DOM_DELTA_LINE</dfn>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="const" data-export="" id="dom-wheelevent-dom_delta_line"><code>DOM_DELTA_LINE</code></dfn>
      <dd> The units of measurement for the <a data-link-type="dfn" href="#delta" id="ref-for-delta-5">delta</a> MUST be individual
 					lines of text.  This is the case for many form controls. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="const" data-export="" id="dom-wheelevent-dom_delta_page">DOM_DELTA_PAGE</dfn>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="const" data-export="" id="dom-wheelevent-dom_delta_page"><code>DOM_DELTA_PAGE</code></dfn>
      <dd> The units of measurement for the <a data-link-type="dfn" href="#delta" id="ref-for-delta-6">delta</a> MUST be pages,
 					either defined as a single screen or as a demarcated page. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="attribute" data-export="" id="dom-wheelevent-deltax">deltaX</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double">double</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="attribute" data-export="" id="dom-wheelevent-deltax"><code>deltaX</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double">double</a>, readonly</span>
      <dd>
        In user agents where the default action of the <a data-link-type="dfn" href="#wheel" id="ref-for-wheel-4"><code>wheel</code></a> event is to scroll, the value MUST be the measurement along the
 					x-axis (in pixels, lines, or pages) to be scrolled in the case
@@ -2763,7 +2765,7 @@ portions of that content.</p>
 					implementation-specific measurement (in pixels, lines, or pages)
 					of the movement of a wheel device around the x-axis. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-16">un-initialized value</a> of this attribute MUST be <code>0.0</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="attribute" data-export="" id="dom-wheelevent-deltay">deltaY</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double">double</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="attribute" data-export="" id="dom-wheelevent-deltay"><code>deltaY</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double">double</a>, readonly</span>
      <dd>
        In user agents where the default action of the <a data-link-type="dfn" href="#wheel" id="ref-for-wheel-5"><code>wheel</code></a> event is to scroll, the value MUST be the measurement along the
 					y-axis (in pixels, lines, or pages) to be scrolled in the case
@@ -2771,7 +2773,7 @@ portions of that content.</p>
 					implementation-specific measurement (in pixels, lines, or pages)
 					of the movement of a wheel device around the y-axis. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-17">un-initialized value</a> of this attribute MUST be <code>0.0</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="attribute" data-export="" id="dom-wheelevent-deltaz">deltaZ</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double">double</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="attribute" data-export="" id="dom-wheelevent-deltaz"><code>deltaZ</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double">double</a>, readonly</span>
      <dd>
        In user agents where the default action of the <a data-link-type="dfn" href="#wheel" id="ref-for-wheel-6"><code>wheel</code></a> event is to scroll, the value MUST be the measurement along the
 					z-axis (in pixels, lines, or pages) to be scrolled in the case
@@ -2779,7 +2781,7 @@ portions of that content.</p>
 					implementation-specific measurement (in pixels, lines, or pages)
 					of the movement of a wheel device around the z-axis. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-18">un-initialized value</a> of this attribute MUST be <code>0.0</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="attribute" data-export="" id="dom-wheelevent-deltamode">deltaMode</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long">unsigned long</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="attribute" data-export="" id="dom-wheelevent-deltamode"><code>deltaMode</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long">unsigned long</a>, readonly</span>
      <dd>
        The <code>deltaMode</code> attribute contains an indication of
 					the units of measurement for the <a data-link-type="dfn" href="#delta" id="ref-for-delta-7">delta</a> values. The
@@ -2791,19 +2793,19 @@ portions of that content.</p>
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-19">un-initialized value</a> of this attribute MUST be <code>0</code>.</p>
     </dl>
     <h5 class="heading settled" data-level="4.4.1.2" id="idl-wheeleventinit"><span class="secno">4.4.1.2. </span><span class="content">WheelEventInit</span><a class="self-link" href="#idl-wheeleventinit"></a></h5>
-<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-wheeleventinit">WheelEventInit</dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-mouseeventinit" id="ref-for-dictdef-mouseeventinit-3">MouseEventInit</a> {
-  <span class="kt">double</span> <a class="nv idl-code" data-default="0.0" data-link-type="dict-member" data-type="double " href="#dom-wheeleventinit-deltax" id="ref-for-dom-wheeleventinit-deltax-1">deltaX</a> = 0.0;
-  <span class="kt">double</span> <a class="nv idl-code" data-default="0.0" data-link-type="dict-member" data-type="double " href="#dom-wheeleventinit-deltay" id="ref-for-dom-wheeleventinit-deltay-1">deltaY</a> = 0.0;
-  <span class="kt">double</span> <a class="nv idl-code" data-default="0.0" data-link-type="dict-member" data-type="double " href="#dom-wheeleventinit-deltaz" id="ref-for-dom-wheeleventinit-deltaz-1">deltaZ</a> = 0.0;
-  <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned long " href="#dom-wheeleventinit-deltamode" id="ref-for-dom-wheeleventinit-deltamode-1">deltaMode</a> = 0;
+<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-wheeleventinit"><code>WheelEventInit</code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-mouseeventinit" id="ref-for-dictdef-mouseeventinit-3">MouseEventInit</a> {
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <a class="nv idl-code" data-default="0.0" data-link-type="dict-member" data-type="double " href="#dom-wheeleventinit-deltax" id="ref-for-dom-wheeleventinit-deltax-1">deltaX</a> = 0.0;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <a class="nv idl-code" data-default="0.0" data-link-type="dict-member" data-type="double " href="#dom-wheeleventinit-deltay" id="ref-for-dom-wheeleventinit-deltay-1">deltaY</a> = 0.0;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <a class="nv idl-code" data-default="0.0" data-link-type="dict-member" data-type="double " href="#dom-wheeleventinit-deltaz" id="ref-for-dom-wheeleventinit-deltaz-1">deltaZ</a> = 0.0;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned long " href="#dom-wheeleventinit-deltamode" id="ref-for-dom-wheeleventinit-deltamode-1">deltaMode</a> = 0;
 };
 </pre>
     <dl>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEventInit" data-dfn-type="dict-member" data-export="" id="dom-wheeleventinit-deltax">deltaX</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double">double</a>, defaulting to <code>0.0</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEventInit" data-dfn-type="dict-member" data-export="" id="dom-wheeleventinit-deltax"><code>deltaX</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double">double</a>, defaulting to <code>0.0</code></span>
      <dd>See <code>deltaZ</code> attribute.
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEventInit" data-dfn-type="dict-member" data-export="" id="dom-wheeleventinit-deltay">deltaY</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double">double</a>, defaulting to <code>0.0</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEventInit" data-dfn-type="dict-member" data-export="" id="dom-wheeleventinit-deltay"><code>deltaY</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double">double</a>, defaulting to <code>0.0</code></span>
      <dd>See <code>deltaZ</code> attribute.
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEventInit" data-dfn-type="dict-member" data-export="" id="dom-wheeleventinit-deltaz">deltaZ</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double">double</a>, defaulting to <code>0.0</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEventInit" data-dfn-type="dict-member" data-export="" id="dom-wheeleventinit-deltaz"><code>deltaZ</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double">double</a>, defaulting to <code>0.0</code></span>
      <dd> Initializes the <code class="idl"><a data-link-type="idl" href="#dom-wheelevent-deltaz" id="ref-for-dom-wheelevent-deltaz-2">deltaZ</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#wheelevent" id="ref-for-wheelevent-5">WheelEvent</a></code> object. Relative positive values for this attribute (as well as
 					the <code class="idl"><a data-link-type="idl" href="#dom-wheelevent-deltax" id="ref-for-dom-wheelevent-deltax-2">deltaX</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-wheelevent-deltay" id="ref-for-dom-wheelevent-deltay-2">deltaY</a></code> attributes) are
 					given by a right-hand coordinate system where the X, Y, and Z
@@ -2811,7 +2813,7 @@ portions of that content.</p>
 					and farthest depth (away from the user) of the document,
 					respectively. Negative relative values are in the respective
 					opposite directions. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEventInit" data-dfn-type="dict-member" data-export="" id="dom-wheeleventinit-deltamode">deltaMode</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long">unsigned long</a>, defaulting to <code>0</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEventInit" data-dfn-type="dict-member" data-export="" id="dom-wheeleventinit-deltamode"><code>deltaMode</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long">unsigned long</a>, defaulting to <code>0</code></span>
      <dd> Initializes the <code class="idl"><a data-link-type="idl" href="#dom-wheelevent-deltamode" id="ref-for-dom-wheelevent-deltamode-2">deltaMode</a></code> attribute on the <code class="idl"><a data-link-type="idl" href="#wheelevent" id="ref-for-wheelevent-6">WheelEvent</a></code> object to the enumerated values 0, 1, or 2, which
 					represent the amount of pixels scrolled
 					(<code class="idl"><a data-link-type="idl" href="#dom-wheelevent-dom_delta_pixel" id="ref-for-dom-wheelevent-dom_delta_pixel-3">DOM_DELTA_PIXEL</a></code>), lines scrolled
@@ -2889,14 +2891,14 @@ portions of that content.</p>
     <h4 class="heading settled" data-level="4.5.1" id="interface-inputevent"><span class="secno">4.5.1. </span><span class="content">Interface InputEvent</span><a class="self-link" href="#interface-inputevent"></a></h4>
     <h5 class="heading settled" data-level="4.5.1.1" id="idl-inputevent"><span class="secno">4.5.1.1. </span><span class="content">InputEvent</span><a class="self-link" href="#idl-inputevent"></a></h5>
     <p class="intro-dom">Introduced in DOM Level 3</p>
-<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="InputEvent" data-dfn-type="constructor" data-export="" data-lt="InputEvent(type, eventInitDict)|InputEvent(type)" id="dom-inputevent-inputevent">Constructor<a class="self-link" href="#dom-inputevent-inputevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="InputEvent/InputEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-inputevent-inputevent-type-eventinitdict-type">type<a class="self-link" href="#dom-inputevent-inputevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-inputeventinit" id="ref-for-dictdef-inputeventinit-1">InputEventInit</a> <dfn class="nv idl-code" data-dfn-for="InputEvent/InputEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-inputevent-inputevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-inputevent-inputevent-type-eventinitdict-eventinitdict"></a></dfn>)]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="inputevent">InputEvent</dfn> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent-51">UIEvent</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span>? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString?" href="#dom-inputevent-data" id="ref-for-dom-inputevent-data-1">data</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-inputevent-iscomposing" id="ref-for-dom-inputevent-iscomposing-1">isComposing</a>;
+<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="InputEvent" data-dfn-type="constructor" data-export="" data-lt="InputEvent(type, eventInitDict)|InputEvent(type)" id="dom-inputevent-inputevent"><code>Constructor</code><a class="self-link" href="#dom-inputevent-inputevent"></a></dfn>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="InputEvent/InputEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-inputevent-inputevent-type-eventinitdict-type"><code>type</code><a class="self-link" href="#dom-inputevent-inputevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-inputeventinit" id="ref-for-dictdef-inputeventinit-1">InputEventInit</a> <dfn class="nv idl-code" data-dfn-for="InputEvent/InputEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-inputevent-inputevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code><a class="self-link" href="#dom-inputevent-inputevent-type-eventinitdict-eventinitdict"></a></dfn>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="inputevent"><code>InputEvent</code></dfn> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent-51">UIEvent</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a>? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString?" href="#dom-inputevent-data" id="ref-for-dom-inputevent-data-1">data</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-inputevent-iscomposing" id="ref-for-dom-inputevent-iscomposing-1">isComposing</a>;
 };
 </pre>
     <dl>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="InputEvent" data-dfn-type="attribute" data-export="" id="dom-inputevent-data">data</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>, readonly, nullable</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="InputEvent" data-dfn-type="attribute" data-export="" id="dom-inputevent-data"><code>data</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>, readonly, nullable</span>
      <dd>
        <code>data</code> holds the value of the characters generated by
 					an input method. This MAY be a single Unicode character or a
@@ -2905,21 +2907,21 @@ portions of that content.</p>
 					form <em>NFC</em>, defined in <a data-link-type="biblio" href="#biblio-uax15">[UAX15]</a>.
 					This attribute MAY contain the <a data-link-type="dfn" href="#empty-string" id="ref-for-empty-string-1">empty string</a>. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-20">un-initialized value</a> of this attribute MUST be <code>null</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="InputEvent" data-dfn-type="attribute" data-export="" id="dom-inputevent-iscomposing">isComposing</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="InputEvent" data-dfn-type="attribute" data-export="" id="dom-inputevent-iscomposing"><code>isComposing</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, readonly</span>
      <dd> <code>true</code> if the input event occurs as part of a
 					composition session, i.e., after a <a data-link-type="dfn" href="#compositionstart" id="ref-for-compositionstart-1"><code>compositionstart</code></a> event					and before the corresponding <a data-link-type="dfn" href="#compositionend" id="ref-for-compositionend-1"><code>compositionend</code></a> event.
 					The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-21">un-initialized value</a> of this attribute MUST be <code>false</code>. 
     </dl>
     <h5 class="heading settled" data-level="4.5.1.2" id="idl-inputeventinit"><span class="secno">4.5.1.2. </span><span class="content">InputEventInit</span><a class="self-link" href="#idl-inputeventinit"></a></h5>
-<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-inputeventinit">InputEventInit</dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit-5">UIEventInit</a> {
-  <span class="kt">DOMString</span>? <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString? " href="#dom-inputeventinit-data" id="ref-for-dom-inputeventinit-data-1">data</a> = "";
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-inputeventinit-iscomposing" id="ref-for-dom-inputeventinit-iscomposing-1">isComposing</a> = <span class="kt">false</span>;
+<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-inputeventinit"><code>InputEventInit</code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit-5">UIEventInit</a> {
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a>? <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString? " href="#dom-inputeventinit-data" id="ref-for-dom-inputeventinit-data-1">data</a> = "";
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-inputeventinit-iscomposing" id="ref-for-dom-inputeventinit-iscomposing-1">isComposing</a> = <span class="kt">false</span>;
 };
 </pre>
     <dl>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="InputEventInit" data-dfn-type="dict-member" data-export="" id="dom-inputeventinit-data">data</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>, nullable, defaulting to <code>""</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="InputEventInit" data-dfn-type="dict-member" data-export="" id="dom-inputeventinit-data"><code>data</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>, nullable, defaulting to <code>""</code></span>
      <dd> Initializes the <code>data</code> attribute of the InputEvent object. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="InputEventInit" data-dfn-type="dict-member" data-export="" id="dom-inputeventinit-iscomposing">isComposing</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="InputEventInit" data-dfn-type="dict-member" data-export="" id="dom-inputeventinit-iscomposing"><code>isComposing</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
      <dd> Initializes the <code>isComposing</code> attribute of the InputEvent object. 
     </dl>
     <h4 class="heading settled" data-level="4.5.2" id="events-inputevent-event-order"><span class="secno">4.5.2. </span><span class="content">Input Event Order</span><a class="self-link" href="#events-inputevent-event-order"></a></h4>
@@ -2979,7 +2981,7 @@ portions of that content.</p>
          <li><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#event">Event</a></code>.<code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-target">target</a></code> : <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-35">event target</a> that is about to be updated
          <li><code class="idl"><a data-link-type="idl" href="#uievent" id="ref-for-uievent-52">UIEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-uievent-view" id="ref-for-dom-uievent-view-21">view</a></code> : <a data-link-type="dfn" href="#window" id="ref-for-window-32"><code>Window</code></a>
          <li><code class="idl"><a data-link-type="idl" href="#uievent" id="ref-for-uievent-53">UIEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-uievent-detail" id="ref-for-dom-uievent-detail-22">detail</a></code> : <code>0</code>
-         <li><code class="idl"><a data-link-type="idl" href="#inputevent" id="ref-for-inputevent-2">InputEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-inputevent-data" id="ref-for-dom-inputevent-data-2">data</a></code> : the string containing the data that will be added to the element, which MAY be <code>null</code> if the content has been deleted
+         <li><code class="idl"><a data-link-type="idl" href="#inputevent" id="ref-for-inputevent-2">InputEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-inputevent-data" id="ref-for-dom-inputevent-data-2">data</a></code> : the string containing the data that will be added to the element, which MAY be <code>null</code> if the content will be deleted
          <li><code class="idl"><a data-link-type="idl" href="#inputevent" id="ref-for-inputevent-3">InputEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-inputevent-iscomposing" id="ref-for-dom-inputevent-iscomposing-2">isComposing</a></code> : <code>true</code> if this event is dispatched during a <a href="#keys-dead">dead key</a> sequence or while an <a data-link-type="dfn" href="#input-method-editor" id="ref-for-input-method-editor-1">input method editor</a> is active (such that <a href="#events-compositionevents">composition events</a> are being dispatched); <code>false</code> otherwise.
         </ul>
     </table>
@@ -3019,7 +3021,7 @@ portions of that content.</p>
          <li><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#event">Event</a></code>.<code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-target">target</a></code> : <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-36">event target</a> that was just updated
          <li><code class="idl"><a data-link-type="idl" href="#uievent" id="ref-for-uievent-54">UIEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-uievent-view" id="ref-for-dom-uievent-view-22">view</a></code> : <a data-link-type="dfn" href="#window" id="ref-for-window-33"><code>Window</code></a>
          <li><code class="idl"><a data-link-type="idl" href="#uievent" id="ref-for-uievent-55">UIEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-uievent-detail" id="ref-for-dom-uievent-detail-23">detail</a></code> : <code>0</code>
-         <li><code class="idl"><a data-link-type="idl" href="#inputevent" id="ref-for-inputevent-5">InputEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-inputevent-data" id="ref-for-dom-inputevent-data-3">data</a></code> : the string containing the data that will be added to the element, which MAY be the <a data-link-type="dfn" href="#empty-string" id="ref-for-empty-string-2">empty string</a> if the content has been deleted
+         <li><code class="idl"><a data-link-type="idl" href="#inputevent" id="ref-for-inputevent-5">InputEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-inputevent-data" id="ref-for-dom-inputevent-data-3">data</a></code> : the string containing the data that has been added to the element, which MAY be the <a data-link-type="dfn" href="#empty-string" id="ref-for-empty-string-2">empty string</a> if the content has been deleted
          <li><code class="idl"><a data-link-type="idl" href="#inputevent" id="ref-for-inputevent-6">InputEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-inputevent-iscomposing" id="ref-for-dom-inputevent-iscomposing-3">isComposing</a></code> : <code>true</code> if this event is dispatched during a <a href="#keys-dead">dead key</a> sequence or while an <a data-link-type="dfn" href="#input-method-editor" id="ref-for-input-method-editor-2">input method editor</a> is active (such that <a href="#events-compositionevents">composition events</a> are being dispatched); <code>false</code> otherwise.
         </ul>
     </table>
@@ -3045,68 +3047,68 @@ portions of that content.</p>
 		method <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate-18">getModifierState()</a></code> with <code class="keycap">Control</code>, <code class="keycap">Shift</code>, <code class="keycap">Alt</code>, or <code class="keycap">Meta</code> respectively.
 		To create an instance of the <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent-21">KeyboardEvent</a></code> interface, use the <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent-22">KeyboardEvent</a></code> constructor, passing an optional <code class="idl"><a data-link-type="idl" href="#dictdef-keyboardeventinit" id="ref-for-dictdef-keyboardeventinit-1">KeyboardEventInit</a></code> dictionary.</p>
     <h5 class="heading settled" data-level="4.6.1.1" id="idl-keyboardevent"><span class="secno">4.6.1.1. </span><span class="content">KeyboardEvent</span><a class="self-link" href="#idl-keyboardevent"></a></h5>
-<pre class="idl highlight def" data-highlight="webidl">[<dfn class="nv idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="constructor" data-export="" data-lt="KeyboardEvent(type, eventInitDict)|KeyboardEvent(type)" id="dom-keyboardevent-keyboardevent">Constructor<a class="self-link" href="#dom-keyboardevent-keyboardevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="KeyboardEvent/KeyboardEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-keyboardevent-keyboardevent-type-eventinitdict-type">type<a class="self-link" href="#dom-keyboardevent-keyboardevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-keyboardeventinit" id="ref-for-dictdef-keyboardeventinit-2">KeyboardEventInit</a> <dfn class="nv idl-code" data-dfn-for="KeyboardEvent/KeyboardEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-keyboardevent-keyboardevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-keyboardevent-keyboardevent-type-eventinitdict-eventinitdict"></a></dfn>)]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="keyboardevent">KeyboardEvent</dfn> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent-56">UIEvent</a> {
+<pre class="idl highlight def" data-highlight="webidl">[<dfn class="nv idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="constructor" data-export="" data-lt="KeyboardEvent(type, eventInitDict)|KeyboardEvent(type)" id="dom-keyboardevent-keyboardevent"><code>Constructor</code><a class="self-link" href="#dom-keyboardevent-keyboardevent"></a></dfn>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="KeyboardEvent/KeyboardEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-keyboardevent-keyboardevent-type-eventinitdict-type"><code>type</code><a class="self-link" href="#dom-keyboardevent-keyboardevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-keyboardeventinit" id="ref-for-dictdef-keyboardeventinit-2">KeyboardEventInit</a> <dfn class="nv idl-code" data-dfn-for="KeyboardEvent/KeyboardEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-keyboardevent-keyboardevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code><a class="self-link" href="#dom-keyboardevent-keyboardevent-type-eventinitdict-eventinitdict"></a></dfn>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="keyboardevent"><code>KeyboardEvent</code></dfn> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent-56">UIEvent</a> {
   // KeyLocationCode
-  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_standard" id="ref-for-dom-keyboardevent-dom_key_location_standard-1">DOM_KEY_LOCATION_STANDARD</a> = 0x00;
-  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_left" id="ref-for-dom-keyboardevent-dom_key_location_left-1">DOM_KEY_LOCATION_LEFT</a> = 0x01;
-  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_right" id="ref-for-dom-keyboardevent-dom_key_location_right-1">DOM_KEY_LOCATION_RIGHT</a> = 0x02;
-  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_numpad" id="ref-for-dom-keyboardevent-dom_key_location_numpad-1">DOM_KEY_LOCATION_NUMPAD</a> = 0x03;
+  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_standard" id="ref-for-dom-keyboardevent-dom_key_location_standard-1">DOM_KEY_LOCATION_STANDARD</a> = 0x00;
+  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_left" id="ref-for-dom-keyboardevent-dom_key_location_left-1">DOM_KEY_LOCATION_LEFT</a> = 0x01;
+  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_right" id="ref-for-dom-keyboardevent-dom_key_location_right-1">DOM_KEY_LOCATION_RIGHT</a> = 0x02;
+  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_numpad" id="ref-for-dom-keyboardevent-dom_key_location_numpad-1">DOM_KEY_LOCATION_NUMPAD</a> = 0x03;
 
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-keyboardevent-key" id="ref-for-dom-keyboardevent-key-4">key</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-keyboardevent-code" id="ref-for-dom-keyboardevent-code-3">code</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-keyboardevent-location" id="ref-for-dom-keyboardevent-location-1">location</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-keyboardevent-key" id="ref-for-dom-keyboardevent-key-4">key</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-keyboardevent-code" id="ref-for-dom-keyboardevent-code-3">code</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-keyboardevent-location" id="ref-for-dom-keyboardevent-location-1">location</a>;
 
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-ctrlkey" id="ref-for-dom-keyboardevent-ctrlkey-3">ctrlKey</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-shiftkey" id="ref-for-dom-keyboardevent-shiftkey-3">shiftKey</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-altkey" id="ref-for-dom-keyboardevent-altkey-3">altKey</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-metakey" id="ref-for-dom-keyboardevent-metakey-3">metaKey</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-ctrlkey" id="ref-for-dom-keyboardevent-ctrlkey-3">ctrlKey</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-shiftkey" id="ref-for-dom-keyboardevent-shiftkey-3">shiftKey</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-altkey" id="ref-for-dom-keyboardevent-altkey-3">altKey</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-metakey" id="ref-for-dom-keyboardevent-metakey-3">metaKey</a>;
 
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-repeat" id="ref-for-dom-keyboardevent-repeat-1">repeat</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-iscomposing" id="ref-for-dom-keyboardevent-iscomposing-1">isComposing</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-repeat" id="ref-for-dom-keyboardevent-repeat-1">repeat</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-iscomposing" id="ref-for-dom-keyboardevent-iscomposing-1">isComposing</a>;
 
-  <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="method" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate-19">getModifierState</a>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="KeyboardEvent/getModifierState(keyArg)" data-dfn-type="argument" data-export="" id="dom-keyboardevent-getmodifierstate-keyarg-keyarg">keyArg<a class="self-link" href="#dom-keyboardevent-getmodifierstate-keyarg-keyarg"></a></dfn>);
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="method" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate-19">getModifierState</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="KeyboardEvent/getModifierState(keyArg)" data-dfn-type="argument" data-export="" id="dom-keyboardevent-getmodifierstate-keyarg-keyarg"><code>keyArg</code><a class="self-link" href="#dom-keyboardevent-getmodifierstate-keyarg-keyarg"></a></dfn>);
 };
 </pre>
     <dl>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="const" data-export="" id="dom-keyboardevent-dom_key_location_standard">DOM_KEY_LOCATION_STANDARD</dfn>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="const" data-export="" id="dom-keyboardevent-dom_key_location_standard"><code>DOM_KEY_LOCATION_STANDARD</code></dfn>
      <dd>
        The key activation MUST NOT be distinguished as the left or
 					right version of the key, and (other than the <code class="keycap">NumLock</code> key) did not originate from the numeric keypad (or did not
 					originate with a virtual key corresponding to the numeric
 					keypad). 
       <p class="example" id="example-f0e6ef2c"><a class="self-link" href="#example-f0e6ef2c"></a> The <code class="keycap">Q</code> key on a PC 101 Key US keyboard.<br> The <code class="keycap">NumLock</code> key on a PC 101 Key US keyboard.<br> The <code class="keycap">1</code> key on a PC 101 Key US keyboard located in the					main section of the keyboard. </p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="const" data-export="" id="dom-keyboardevent-dom_key_location_left">DOM_KEY_LOCATION_LEFT</dfn>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="const" data-export="" id="dom-keyboardevent-dom_key_location_left"><code>DOM_KEY_LOCATION_LEFT</code></dfn>
      <dd>
        The key activated originated from the left key location (when
 					there is more than one possible location for this key). 
       <p class="example" id="example-4177010c"><a class="self-link" href="#example-4177010c"></a> The left <code class="keycap">Control</code> key on a PC 101 Key US keyboard. </p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="const" data-export="" id="dom-keyboardevent-dom_key_location_right">DOM_KEY_LOCATION_RIGHT</dfn>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="const" data-export="" id="dom-keyboardevent-dom_key_location_right"><code>DOM_KEY_LOCATION_RIGHT</code></dfn>
      <dd>
        The key activation originated from the right key location (when
 					there is more than one possible location for this key). 
       <p class="example" id="example-d09363d5"><a class="self-link" href="#example-d09363d5"></a> The right <code class="keycap">Shift</code> key on a PC 101 Key US keyboard. </p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="const" data-export="" id="dom-keyboardevent-dom_key_location_numpad">DOM_KEY_LOCATION_NUMPAD</dfn>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="const" data-export="" id="dom-keyboardevent-dom_key_location_numpad"><code>DOM_KEY_LOCATION_NUMPAD</code></dfn>
      <dd>
        The key activation originated on the numeric keypad or with a
 					virtual key corresponding to the numeric keypad (when there is
 					more than one possible location for this key). Note that the <code class="keycap">NumLock</code> key should always be encoded with a <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-location" id="ref-for-dom-keyboardevent-location-2">location</a></code> of <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-dom_key_location_standard" id="ref-for-dom-keyboardevent-dom_key_location_standard-2">DOM_KEY_LOCATION_STANDARD</a></code>. 
       <p class="example" id="example-54095ce0"><a class="self-link" href="#example-54095ce0"></a> The <code class="keycap">1</code> key on a PC 101 Key US keyboard located on the					numeric pad. </p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-key">key</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-key"><code>key</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>, readonly</span>
      <dd>
        <code>key</code> holds a <a data-link-type="dfn" href="http://www.w3.org/TR/uievents/#">key attribute value</a> corresponding to
 					the key pressed. 
       <p class="note" role="note"> The <code>key</code> attribute is not related to the legacy <code>keyCode</code> attribute and does not have the same set of
 					values. </p>
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-22">un-initialized value</a> of this attribute MUST be <code>""</code> (the empty string).</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-code">code</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-code"><code>code</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>, readonly</span>
      <dd>
        <code>code</code> holds a string that identifies the physical
 					key being pressed. The value is not affected by the current
 					keyboard layout or modifier state, so a particular key will
 					always return the same value. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-23">un-initialized value</a> of this attribute MUST be <code>""</code> (the empty string).</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-location">location</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long">unsigned long</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-location"><code>location</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long">unsigned long</a>, readonly</span>
      <dd>
        The <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-location" id="ref-for-dom-keyboardevent-location-3">location</a></code> attribute contains an indication
 					of the logical location of the key on the device. 
@@ -3117,23 +3119,23 @@ portions of that content.</p>
 					the <code class="code">"<a href="http://www.w3.org/TR/uievents-code/#code-ControlLeft">ControlLeft</a>"</code> key is mapped to the <code class="code">"<a href="http://www.w3.org/TR/uievents-code/#code-KeyQ">KeyQ</a>"</code> key, then					the <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-location" id="ref-for-dom-keyboardevent-location-5">location</a></code> attribute MUST be set to <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-dom_key_location_standard" id="ref-for-dom-keyboardevent-dom_key_location_standard-3">DOM_KEY_LOCATION_STANDARD</a></code>. Conversely, if the <code class="code">"<a href="http://www.w3.org/TR/uievents-code/#code-KeyQ">KeyQ</a>"</code> key is remapped to one of the <code class="keycap">Control</code> keys,					then the <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-location" id="ref-for-dom-keyboardevent-location-6">location</a></code> attribute MUST be set to
 					either <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-dom_key_location_left" id="ref-for-dom-keyboardevent-dom_key_location_left-2">DOM_KEY_LOCATION_LEFT</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-dom_key_location_right" id="ref-for-dom-keyboardevent-dom_key_location_right-2">DOM_KEY_LOCATION_RIGHT</a></code>.</p>
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-24">un-initialized value</a> of this attribute MUST be <code>0</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-ctrlkey">ctrlKey</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-ctrlkey"><code>ctrlKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, readonly</span>
      <dd>
        <code>true</code> if the <code class="keycap">Control</code> (control) key modifier					was active. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-25">un-initialized value</a> of this attribute MUST be <code>false</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-shiftkey">shiftKey</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-shiftkey"><code>shiftKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, readonly</span>
      <dd>
        <code>true</code> if the shift (<code class="keycap">Shift</code>) key modifier was					active. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-26">un-initialized value</a> of this attribute MUST be <code>false</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-altkey">altKey</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-altkey"><code>altKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, readonly</span>
      <dd> <code>true</code> if the <code class="keycap">Alt</code> (alternative) (or <code class="glyph">"Option"</code>) key modifier was active.
 					The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-27">un-initialized value</a> of this attribute MUST be <code>false</code>. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-metakey">metaKey</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-metakey"><code>metaKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, readonly</span>
      <dd>
        <code>true</code> if the meta (<code class="keycap">Meta</code>) key modifier was					active. 
       <p class="note" role="note"> The <code class="glyph">"Command"</code> (<code class="glyph">"⌘"</code>) key modifier on Macintosh					systems is represented using this key modifier. </p>
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-28">un-initialized value</a> of this attribute MUST be <code>false</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-repeat">repeat</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-repeat"><code>repeat</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, readonly</span>
      <dd>
        <code>true</code> if the key has been pressed in a sustained
 					manner.  Holding down a key MUST result in the repeating the
@@ -3143,11 +3145,11 @@ portions of that content.</p>
 					of <code>true</code> MUST serve as an indication of a <em>long-key-press</em>. The length of time that the key MUST be
 					pressed in order to begin repeating is configuration-dependent. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-29">un-initialized value</a> of this attribute MUST be <code>false</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-iscomposing">isComposing</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-iscomposing"><code>isComposing</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, readonly</span>
      <dd> <code>true</code> if the key event occurs as part of a
 					composition session, i.e., after a <a data-link-type="dfn" href="#compositionstart" id="ref-for-compositionstart-2"><code>compositionstart</code></a> event					and before the corresponding <a data-link-type="dfn" href="#compositionend" id="ref-for-compositionend-2"><code>compositionend</code></a> event.
 					The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-30">un-initialized value</a> of this attribute MUST be <code>false</code>. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="method" data-export="" id="dom-keyboardevent-getmodifierstate">getModifierState(keyArg)</dfn>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="method" data-export="" id="dom-keyboardevent-getmodifierstate"><code>getModifierState(keyArg)</code></dfn>
      <dd>
        Queries the state of a modifier using a key value. See <a href="#keys-modifiers">Modifier keys</a> for a list of valid
 					(case-sensitive) arguments to this method. 
@@ -3165,29 +3167,29 @@ portions of that content.</p>
       </dl>
     </dl>
     <h5 class="heading settled" data-level="4.6.1.2" id="idl-keyboardeventinit"><span class="secno">4.6.1.2. </span><span class="content">KeyboardEventInit</span><a class="self-link" href="#idl-keyboardeventinit"></a></h5>
-<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-keyboardeventinit">KeyboardEventInit</dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-eventmodifierinit" id="ref-for-dictdef-eventmodifierinit-4">EventModifierInit</a> {
-  <span class="kt">DOMString</span> <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-keyboardeventinit-key" id="ref-for-dom-keyboardeventinit-key-1">key</a> = "";
-  <span class="kt">DOMString</span> <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-keyboardeventinit-code" id="ref-for-dom-keyboardeventinit-code-1">code</a> = "";
-  <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned long " href="#dom-keyboardeventinit-location" id="ref-for-dom-keyboardeventinit-location-1">location</a> = 0;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-keyboardeventinit-repeat" id="ref-for-dom-keyboardeventinit-repeat-1">repeat</a> = <span class="kt">false</span>;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-keyboardeventinit-iscomposing" id="ref-for-dom-keyboardeventinit-iscomposing-1">isComposing</a> = <span class="kt">false</span>;
+<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-keyboardeventinit"><code>KeyboardEventInit</code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-eventmodifierinit" id="ref-for-dictdef-eventmodifierinit-4">EventModifierInit</a> {
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-keyboardeventinit-key" id="ref-for-dom-keyboardeventinit-key-1">key</a> = "";
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-keyboardeventinit-code" id="ref-for-dom-keyboardeventinit-code-1">code</a> = "";
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned long " href="#dom-keyboardeventinit-location" id="ref-for-dom-keyboardeventinit-location-1">location</a> = 0;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-keyboardeventinit-repeat" id="ref-for-dom-keyboardeventinit-repeat-1">repeat</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-keyboardeventinit-iscomposing" id="ref-for-dom-keyboardeventinit-iscomposing-1">isComposing</a> = <span class="kt">false</span>;
 };
 </pre>
     <dl>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export="" id="dom-keyboardeventinit-key">key</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>, defaulting to <code>""</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export="" id="dom-keyboardeventinit-key"><code>key</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>, defaulting to <code>""</code></span>
      <dd> Initializes the <code>key</code> attribute of the KeyboardEvent
 					object to the unicode character string representing the meaning
 					of a key after taking into account all keyboard modifiers
 					(such as shift-state). This value is the final effective value
 					of the key. If the key is not a printable character, then it
 					should be one of the key values defined in <a data-link-type="biblio" href="#biblio-uievents-key">[UIEvents-Key]</a>. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export="" id="dom-keyboardeventinit-code">code</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>, defaulting to <code>""</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export="" id="dom-keyboardeventinit-code"><code>code</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>, defaulting to <code>""</code></span>
      <dd> Initializes the <code>code</code> attribute of the KeyboardEvent
 					object to the unicode character string representing the key that
 					was pressed, ignoring any keyboard modifications such as
 					keyboard layout. This value should be one of the code values
 					defined in [UIEvents-Code]]. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export="" id="dom-keyboardeventinit-location">location</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long">unsigned long</a>, defaulting to <code>0</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export="" id="dom-keyboardeventinit-location"><code>location</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long">unsigned long</a>, defaulting to <code>0</code></span>
      <dd>
        Initializes the <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-location" id="ref-for-dom-keyboardevent-location-8">location</a></code> attribute of the
 					KeyboardEvent object to one of the following location numerical
@@ -3206,12 +3208,12 @@ portions of that content.</p>
         <p><code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-dom_key_location_numpad" id="ref-for-dom-keyboardevent-dom_key_location_numpad-2">DOM_KEY_LOCATION_NUMPAD</a></code> (numerical value 3)</p>
        <p></p>
       </ul>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export="" id="dom-keyboardeventinit-repeat">repeat</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export="" id="dom-keyboardeventinit-repeat"><code>repeat</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
      <dd> Initializes the <code>repeat</code> attribute of the
 					KeyboardEvent object. This attribute should be set to <code>true</code> if the the current KeyboardEvent is considered
 					part of a repeating sequence of similar events caused by the
 					long depression of any single key, <code>false</code> otherwise. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export="" id="dom-keyboardeventinit-iscomposing">isComposing</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export="" id="dom-keyboardeventinit-iscomposing"><code>isComposing</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>, defaulting to <code>false</code></span>
      <dd> Initializes the <code>isComposing</code> attribute of the
 					KeyboardEvent object. This attribute should be set to <code>true</code> if the event being constructed occurs as part
 					of a composition sequence, <code>false</code> otherwise. 
@@ -3478,13 +3480,13 @@ details)</p>
     <p>To create an instance of the <code class="idl"><a data-link-type="idl" href="#compositionevent" id="ref-for-compositionevent-2">CompositionEvent</a></code> interface,
 		use the <code class="idl"><a data-link-type="idl" href="#compositionevent" id="ref-for-compositionevent-3">CompositionEvent</a></code> constructor, passing an optional <code class="idl"><a data-link-type="idl" href="#dictdef-compositioneventinit" id="ref-for-dictdef-compositioneventinit-1">CompositionEventInit</a></code> dictionary.</p>
     <h5 class="heading settled" data-level="4.7.1.1" id="idl-compositionevent"><span class="secno">4.7.1.1. </span><span class="content">CompositionEvent</span><a class="self-link" href="#idl-compositionevent"></a></h5>
-<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="CompositionEvent" data-dfn-type="constructor" data-export="" data-lt="CompositionEvent(type, eventInitDict)|CompositionEvent(type)" id="dom-compositionevent-compositionevent">Constructor<a class="self-link" href="#dom-compositionevent-compositionevent"></a></dfn>(<span class="kt">DOMString</span> <dfn class="nv idl-code" data-dfn-for="CompositionEvent/CompositionEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-compositionevent-compositionevent-type-eventinitdict-type">type<a class="self-link" href="#dom-compositionevent-compositionevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-compositioneventinit" id="ref-for-dictdef-compositioneventinit-2">CompositionEventInit</a> <dfn class="nv idl-code" data-dfn-for="CompositionEvent/CompositionEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-compositionevent-compositionevent-type-eventinitdict-eventinitdict">eventInitDict<a class="self-link" href="#dom-compositionevent-compositionevent-type-eventinitdict-eventinitdict"></a></dfn>)]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="compositionevent">CompositionEvent</dfn> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent-61">UIEvent</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-compositionevent-data" id="ref-for-dom-compositionevent-data-2">data</a>;
+<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="CompositionEvent" data-dfn-type="constructor" data-export="" data-lt="CompositionEvent(type, eventInitDict)|CompositionEvent(type)" id="dom-compositionevent-compositionevent"><code>Constructor</code><a class="self-link" href="#dom-compositionevent-compositionevent"></a></dfn>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="CompositionEvent/CompositionEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-compositionevent-compositionevent-type-eventinitdict-type"><code>type</code><a class="self-link" href="#dom-compositionevent-compositionevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-compositioneventinit" id="ref-for-dictdef-compositioneventinit-2">CompositionEventInit</a> <dfn class="nv idl-code" data-dfn-for="CompositionEvent/CompositionEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-compositionevent-compositionevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code><a class="self-link" href="#dom-compositionevent-compositionevent-type-eventinitdict-eventinitdict"></a></dfn>)]
+<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="compositionevent"><code>CompositionEvent</code></dfn> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent-61">UIEvent</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-compositionevent-data" id="ref-for-dom-compositionevent-data-2">data</a>;
 };
 </pre>
     <dl>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="CompositionEvent" data-dfn-type="attribute" data-export="" id="dom-compositionevent-data">data</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="CompositionEvent" data-dfn-type="attribute" data-export="" id="dom-compositionevent-data"><code>data</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>, readonly</span>
      <dd>
        <code>data</code> holds the value of the characters generated by
 					an input method. This MAY be a single Unicode character or a
@@ -3495,12 +3497,12 @@ details)</p>
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-31">un-initialized value</a> of this attribute MUST be <code>""</code> (the empty string).</p>
     </dl>
     <h5 class="heading settled" data-level="4.7.1.2" id="idl-compositioneventinit"><span class="secno">4.7.1.2. </span><span class="content">CompositionEventInit</span><a class="self-link" href="#idl-compositioneventinit"></a></h5>
-<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-compositioneventinit">CompositionEventInit</dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit-6">UIEventInit</a> {
-  <span class="kt">DOMString</span> <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-compositioneventinit-data" id="ref-for-dom-compositioneventinit-data-1">data</a> = "";
+<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-compositioneventinit"><code>CompositionEventInit</code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit-6">UIEventInit</a> {
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-compositioneventinit-data" id="ref-for-dom-compositioneventinit-data-1">data</a> = "";
 };
 </pre>
     <dl>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="CompositionEventInit" data-dfn-type="dict-member" data-export="" id="dom-compositioneventinit-data">data</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>, defaulting to <code>""</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="CompositionEventInit" data-dfn-type="dict-member" data-export="" id="dom-compositioneventinit-data"><code>data</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>, defaulting to <code>""</code></span>
      <dd> Initializes the <code>data</code> attribute of the
 					CompositionEvent object to the characters generated by the IME
 					composition. 
@@ -3957,8 +3959,8 @@ of each key.</p>
 				the remote host). 
     </dl>
     <h4 class="heading settled" data-level="5.2.3" id="code-examples"><span class="secno">5.2.3. </span><span class="content"><code>code</code> Examples</span><a class="self-link" href="#code-examples"></a></h4>
-    <div class="example" id="example-e28e4bb2">
-     <a class="self-link" href="#example-e28e4bb2"></a> Handling the Left and Right Alt Keys 
+    <div class="example" id="example-fa6fb9e4">
+     <a class="self-link" href="#example-fa6fb9e4"></a> Handling the Left and Right Alt Keys 
      <table class="event-sequence-table">
       <tbody>
        <tr>
@@ -3993,8 +3995,8 @@ of each key.</p>
      <p>Note that, in the French example, the <code class="keycap">Alt</code> and <code class="keycap">AltGr</code> keys			retain their left and right location, even though there is only one of
 			each key.</p>
     </div>
-    <div class="example" id="example-36b874e8">
-     <a class="self-link" href="#example-36b874e8"></a> Handling the Single Quote Key 
+    <div class="example" id="example-374318b1">
+     <a class="self-link" href="#example-374318b1"></a> Handling the Single Quote Key 
      <table class="event-sequence-table">
       <tbody>
        <tr>
@@ -4233,8 +4235,8 @@ of each key.</p>
 		key. Like other keys, modifier keys generate <a data-link-type="dfn" href="#keydown" id="ref-for-keydown-23"><code>keydown</code></a> and <a data-link-type="dfn" href="#keyup" id="ref-for-keyup-18"><code>keyup</code></a> events, as shown in the example below. Some modifiers are		activated while the key is being pressed down or maintained pressed such
 		as <code class="keycap">Alt</code>, <code class="keycap">Control</code>, <code class="keycap">Shift</code>, <code class="keycap">AltGraph</code>, or <code class="keycap">Meta</code>. Other modifiers are activated depending on their state		such as <code class="keycap">CapsLock</code>, <code class="keycap">NumLock</code>, or <code class="keycap">ScrollLock</code>. Change		in the state happens when the modifier key is being pressed down. The <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent-55">KeyboardEvent</a></code> interface provides convenient attributes for some
 		common modifiers keys: <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-ctrlkey" id="ref-for-dom-keyboardevent-ctrlkey-6">ctrlKey</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-shiftkey" id="ref-for-dom-keyboardevent-shiftkey-12">shiftKey</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-altkey" id="ref-for-dom-keyboardevent-altkey-6">altKey</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-metakey" id="ref-for-dom-keyboardevent-metakey-6">metaKey</a></code>. Some operating systems simulate the <code class="keycap">AltGraph</code> modifier key with the combination of the <code class="keycap">Alt</code> and <code class="keycap">Control</code> modifier keys. Implementations are encouraged to use		the <code class="keycap">AltGraph</code> modifier key.</p>
-    <div class="example" id="example-a9019deb">
-     <a class="self-link" href="#example-a9019deb"></a> This example describes a possible sequence of events
+    <div class="example" id="example-183aa875">
+     <a class="self-link" href="#example-183aa875"></a> This example describes a possible sequence of events
 			associated with the generation of the Unicode character Q (Latin
 			Capital Letter Q, Unicode code point <code class="unicode">U+0051</code>) on a US			keyboard using a US mapping: 
      <table class="event-sequence-table">
@@ -4283,8 +4285,8 @@ of each key.</p>
         <td>
      </table>
     </div>
-    <div class="example" id="example-699f887b">
-     <a class="self-link" href="#example-699f887b"></a> Th example describes an alternate sequence of keys to the
+    <div class="example" id="example-ef48b2cb">
+     <a class="self-link" href="#example-ef48b2cb"></a> Th example describes an alternate sequence of keys to the
 			example above, where the <code class="keycap">Shift</code> key is released before the <code class="keycap">Q</code> key.  The key value for the <code class="keycap">Q</code> key will revert to its			unshifted value for the <a data-link-type="dfn" href="#keyup" id="ref-for-keyup-21"><code>keyup</code></a> event: 
      <table class="event-sequence-table">
       <tbody>
@@ -4332,8 +4334,8 @@ of each key.</p>
         <td>Latin Small Letter Q
      </table>
     </div>
-    <div class="example" id="example-f1676a05">
-     <a class="self-link" href="#example-f1676a05"></a> The following example describes a possible sequence of keys that
+    <div class="example" id="example-d906fea4">
+     <a class="self-link" href="#example-d906fea4"></a> The following example describes a possible sequence of keys that
 			does not generate a Unicode character (using the same configuration
 			as the previous example): 
      <table class="event-sequence-table">
@@ -4376,8 +4378,8 @@ of each key.</p>
         <td>
      </table>
     </div>
-    <div class="example" id="example-aa6d4cea">
-     <a class="self-link" href="#example-aa6d4cea"></a> The following example shows the sequence of events when both <code class="keycap">Shift</code> and <code class="keycap">Control</code> are pressed: 
+    <div class="example" id="example-3a075f28">
+     <a class="self-link" href="#example-3a075f28"></a> The following example shows the sequence of events when both <code class="keycap">Shift</code> and <code class="keycap">Control</code> are pressed: 
      <table class="event-sequence-table">
       <tbody>
        <tr>
@@ -4430,8 +4432,8 @@ of each key.</p>
         <td>
      </table>
     </div>
-    <div class="example" id="example-1c93427f">
-     <a class="self-link" href="#example-1c93427f"></a> For non-US keyboard layouts, the sequence of events is the same, but
+    <div class="example" id="example-f22edceb">
+     <a class="self-link" href="#example-f22edceb"></a> For non-US keyboard layouts, the sequence of events is the same, but
 			the value of the key is based on the current keyboard layout. This
 			example shows a sequence of events when an Arabic keyboard layout is
 			used: 
@@ -4501,8 +4503,8 @@ of each key.</p>
 		word <em>naïve</em>, using the combining diacritic <em>¨</em>, would be
 		represented sequentially in Unicode as <em>nai¨ve</em>, but MAY be typed <em>na¨ive</em>. The sequence of keystrokes <code class="unicode">U+0302</code> (Combining		Circumflex Accent key) and <code class="unicode">U+0065</code> (key marked with the Latin Small		Letter E) will likely produce (on a French keyboard using a french
 		mapping and without any modifier activated) the Unicode character <code class="glyph">"ê"</code> (Latin Small Letter E With Circumflex), as preferred by		the Unicode Normalization Form <em>NFC</em>.</p>
-    <div class="example" id="example-ecc52099">
-     <a class="self-link" href="#example-ecc52099"></a> 
+    <div class="example" id="example-cd416c1b">
+     <a class="self-link" href="#example-cd416c1b"></a> 
      <table class="event-sequence-table">
       <tbody>
        <tr>
@@ -4575,8 +4577,8 @@ of each key.</p>
     <p>This process might be aborted when a user types an unsupported base
 		character (that is, a base character for which the active
 		diacritical mark is not available) after pressing a <a data-link-type="dfn" href="#dead-key" id="ref-for-dead-key-8">dead key</a>:</p>
-    <div class="example" id="example-ebe6f557">
-     <a class="self-link" href="#example-ebe6f557"></a> 
+    <div class="example" id="example-48b830d5">
+     <a class="self-link" href="#example-48b830d5"></a> 
      <table class="event-sequence-table">
       <tbody>
        <tr>
@@ -4661,8 +4663,8 @@ of each key.</p>
 		the IME, e.g., it can be respectively <code class="unicode">U+0020</code> (Space key) and <code class="keycap">Enter</code>.</p>
     <p class="note" role="note"> <code class="glyph">"詩"</code> (<q>poem</q>) and <code class="glyph">"市"</code> (<q>city</q>) are		homophones, both pronounced し (<q>shi</q>/<q>si</q>), so the user
 		needs to use the <code class="keycap">Convert</code> key to select the proper option. </p>
-    <div class="example" id="example-91064bc0">
-     <a class="self-link" href="#example-91064bc0"></a> 
+    <div class="example" id="example-1c6a766c">
+     <a class="self-link" href="#example-1c6a766c"></a> 
      <table class="event-sequence-table">
       <tbody>
        <tr>
@@ -4873,8 +4875,8 @@ of each key.</p>
     <p>IME composition can also be canceled as in the following example, with
 		conditions identical to the previous example. The key <code class="keycap">Cancel</code> might also be replaced by others depending on the input device in use
 		and the configuration of the IME, e.g., it could be <code class="unicode">U+001B</code> (Escape		key).</p>
-    <div class="example" id="example-0fdb87bc">
-     <a class="self-link" href="#example-0fdb87bc"></a> 
+    <div class="example" id="example-5cae6ec8">
+     <a class="self-link" href="#example-5cae6ec8"></a> 
      <table class="event-sequence-table">
       <tbody>
        <tr>
@@ -5027,8 +5029,8 @@ of each key.</p>
     <p>Canceling the <a data-link-type="dfn" href="#default-action" id="ref-for-default-action-31">default action</a> of a <a data-link-type="dfn" href="#keydown" id="ref-for-keydown-52"><code>keydown</code></a> event MUST NOT		affect its respective <a data-link-type="dfn" href="#keyup" id="ref-for-keyup-46"><code>keyup</code></a> event, but it MUST prevent the		respective <a data-link-type="dfn" href="#beforeinput" id="ref-for-beforeinput-24"><code>beforeinput</code></a> and <a data-link-type="dfn" href="#input" id="ref-for-input-25"><code>input</code></a> (and <a data-link-type="dfn" href="#keypress" id="ref-for-keypress-4"><code>keypress</code></a> if		supported) events from being generated. The following example describes
 		a possible sequence of keys to generate the Unicode character Q (Latin
 		Capital Letter Q) on a US keyboard using a US mapping:</p>
-    <div class="example" id="example-b410f8f2">
-     <a class="self-link" href="#example-b410f8f2"></a> 
+    <div class="example" id="example-7131a905">
+     <a class="self-link" href="#example-7131a905"></a> 
      <table class="event-sequence-table">
       <tbody>
        <tr>
@@ -5079,8 +5081,8 @@ of each key.</p>
 		account for the modifiers states. The following example describes a
 		possible sequence of keys to generate the Unicode character Q (Latin
 		Capital Letter Q) on a US keyboard using a US mapping:</p>
-    <div class="example" id="example-ddf2a9be">
-     <a class="self-link" href="#example-ddf2a9be"></a> 
+    <div class="example" id="example-221bf7a5">
+     <a class="self-link" href="#example-221bf7a5"></a> 
      <table class="event-sequence-table">
       <tbody>
        <tr>
@@ -5137,8 +5139,8 @@ of each key.</p>
     <p>If the key is part of a sequence of several keystrokes, whether it is a <a data-link-type="dfn" href="#dead-key" id="ref-for-dead-key-9">dead key</a> or it is contributing to an Input Method Editor
 		sequence, the keystroke MUST be ignored (not taken into account) only if
 		the <a data-link-type="dfn" href="#default-action" id="ref-for-default-action-34">default action</a> is canceled on the <a data-link-type="dfn" href="#keydown" id="ref-for-keydown-57"><code>keydown</code></a> event.		Canceling a <a data-link-type="dfn" href="#dead-key" id="ref-for-dead-key-10">dead key</a> on a <a data-link-type="dfn" href="#keyup" id="ref-for-keyup-51"><code>keyup</code></a> event has no effect on <a data-link-type="dfn" href="#beforeinput" id="ref-for-beforeinput-27"><code>beforeinput</code></a> or <a data-link-type="dfn" href="#input" id="ref-for-input-28"><code>input</code></a> events. The following example uses		the dead key <code class="key">"<a href="http://www.w3.org/TR/uievents-key/#key-Dead">Dead</a>"</code> (<code class="unicode">U+0302</code> Combining Circumflex Accent key) and <code class="key">"e"</code> (<code class="unicode">U+0065</code>, Latin Small Letter E key) on a French		keyboard using a French mapping and without any modifier activated:</p>
-    <div class="example" id="example-8848eddb">
-     <a class="self-link" href="#example-8848eddb"></a> 
+    <div class="example" id="example-72d54285">
+     <a class="self-link" href="#example-72d54285"></a> 
      <table class="event-sequence-table">
       <tbody>
        <tr>
@@ -5213,7 +5215,7 @@ described in this Appendix.</p>
 };
 </pre>
     <dl>
-     <dt><dfn class="idl-code" data-dfn-for="UIEvent" data-dfn-type="method" data-export="" id="dom-uievent-inituievent">initUIEvent()<a class="self-link" href="#dom-uievent-inituievent"></a></dfn>
+     <dt><dfn class="idl-code" data-dfn-for="UIEvent" data-dfn-type="method" data-export="" id="dom-uievent-inituievent"><code>initUIEvent()</code><a class="self-link" href="#dom-uievent-inituievent"></a></dfn>
      <dd>
        Initializes attributes of an <code class="idl"><a data-link-type="idl" href="#uievent" id="ref-for-uievent-68">UIEvent</a></code> object.
 				This method has the same behavior as <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-initevent">initEvent()</a></code>. 
@@ -5240,7 +5242,7 @@ described in this Appendix.</p>
 };
 </pre>
     <dl>
-     <dt><dfn class="idl-code" data-dfn-for="MouseEvent" data-dfn-type="method" data-export="" id="dom-mouseevent-initmouseevent">initMouseEvent()<a class="self-link" href="#dom-mouseevent-initmouseevent"></a></dfn>
+     <dt><dfn class="idl-code" data-dfn-for="MouseEvent" data-dfn-type="method" data-export="" id="dom-mouseevent-initmouseevent"><code>initMouseEvent()</code><a class="self-link" href="#dom-mouseevent-initmouseevent"></a></dfn>
      <dd>
        Initializes attributes of a <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-154">MouseEvent</a></code> object. This
 				method has the same behavior as <code>UIEvent.initUIEvent()</code>. 
@@ -5288,7 +5290,7 @@ described in this Appendix.</p>
 };
 </pre>
     <dl>
-     <dt><dfn class="idl-code" data-dfn-for="WheelEvent" data-dfn-type="method" data-export="" id="dom-wheelevent-initwheelevent">initWheelEvent()<a class="self-link" href="#dom-wheelevent-initwheelevent"></a></dfn>
+     <dt><dfn class="idl-code" data-dfn-for="WheelEvent" data-dfn-type="method" data-export="" id="dom-wheelevent-initwheelevent"><code>initWheelEvent()</code><a class="self-link" href="#dom-wheelevent-initwheelevent"></a></dfn>
      <dd>
        Initializes attributes of a <code>WheelEvent</code> object. This
 				method has the same behavior as <code>MouseEvent.initMouseEvent()</code>. 
@@ -5339,11 +5341,20 @@ described in this Appendix.</p>
 		implementations. </p>
 <pre class="idl-ignore" data-highlight="webidl" data-no-idl="">partial interface KeyboardEvent {
   // Originally introduced (and deprecated) in this specification
-  void initKeyboardEvent();
+  void initKeyboardEvent(DOMString typeArg,
+                         optional boolean bubblesArg = false,
+                         optional boolean cancelableArg = false,
+                         optional Window? viewArg = null,
+                         optional DOMString keyArg = "",
+                         optional unsigned long locationArg = 0,
+                         optional boolean ctrlKey = false,
+                         optional boolean altKey = false,
+                         optional boolean shiftKey = false,
+                         optional boolean metaKey = false);
 };
 </pre>
     <dl>
-     <dt><dfn class="idl-code" data-dfn-for="KeyboardEveng" data-dfn-type="method" data-export="" id="dom-keyboardeveng-initkeyboardevent">initKeyboardEvent()<a class="self-link" href="#dom-keyboardeveng-initkeyboardevent"></a></dfn>
+     <dt><dfn class="idl-code" data-dfn-for="KeyboardEveng" data-dfn-type="method" data-export="" id="dom-keyboardeveng-initkeyboardevent"><code>initKeyboardEvent()</code><a class="self-link" href="#dom-keyboardeveng-initkeyboardevent"></a></dfn>
      <dd>
        Initializes attributes of a <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent-72">KeyboardEvent</a></code> object. This
 				method has the same behavior as <code>UIEvent.initUIEvent()</code>.
@@ -5362,14 +5373,14 @@ described in this Appendix.</p>
        <dd> Specifies <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-key" id="ref-for-dom-keyboardevent-key-44">key</a></code>. 
        <dt>unsigned long locationArg
        <dd> Specifies <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-location" id="ref-for-dom-keyboardevent-location-18">location</a></code>. 
-       <dt>DOMString modifiersListArg
-       <dd> A <a data-link-type="dfn" href="http://www.w3.org/TR/2004/REC-xml-20040204/#NT-S"><em>white space</em></a> separated list of modifier
-						key values to be activated on this object. As an
-						example, <code>"Control Alt"</code> marks the <code class="keycap">Control</code> and <code class="keycap">Alt</code> modifiers as activated. 
-       <dt>boolean repeat
-       <dd> Specifies whether the key event is repeating. See <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-repeat" id="ref-for-dom-keyboardevent-repeat-6">repeat</a></code>. 
-       <dt>DOMString locale
-       <dd> Specifies the <code>locale</code> attribute of the KeyboardEvent. 
+       <dt>boolean ctrlKey
+       <dd> Specifies whether the Control key modifier is active. 
+       <dt>boolean altKey
+       <dd> Specifies whether the Alt key modifier is active. 
+       <dt>boolean shiftKey
+       <dd> Specifies whether the Shift key modifier is active. 
+       <dt>boolean metaKey
+       <dd> Specifies whether the Meta key modifier is active. 
       </dl>
     </dl>
     <h4 class="heading settled" data-level="6.1.5" id="idl-interface-CompositionEvent-initializers"><span class="secno">6.1.5. </span><span class="content">Initializers for interface CompositionEvent</span><a class="self-link" href="#idl-interface-CompositionEvent-initializers"></a></h4>
@@ -5384,7 +5395,7 @@ described in this Appendix.</p>
 };
 </pre>
     <dl>
-     <dt><dfn class="idl-code" data-dfn-for="CompositionEvent" data-dfn-type="method" data-export="" id="dom-compositionevent-initcompositionevent">initCompositionEvent()<a class="self-link" href="#dom-compositionevent-initcompositionevent"></a></dfn>
+     <dt><dfn class="idl-code" data-dfn-for="CompositionEvent" data-dfn-type="method" data-export="" id="dom-compositionevent-initcompositionevent"><code>initCompositionEvent()</code><a class="self-link" href="#dom-compositionevent-initcompositionevent"></a></dfn>
      <dd>
        Initializes attributes of a <code>CompositionEvent</code> object. This method has the same behavior as <code>UIEvent.initUIEvent()</code>. The value of <code class="idl"><a data-link-type="idl" href="#dom-uievent-detail" id="ref-for-dom-uievent-detail-33">detail</a></code> remains undefined. 
       <p class="warning"> The <code>initCompositionEvent</code> method is deprecated. </p>
@@ -5434,11 +5445,11 @@ used.</p>
     <p>The partial <code class="idl"><a data-link-type="idl" href="#uievent" id="ref-for-uievent-71">UIEvent</a></code> interface is an informative extension of the <code class="idl"><a data-link-type="idl" href="#uievent" id="ref-for-uievent-72">UIEvent</a></code> interface, which adds the <code class="idl"><a data-link-type="idl" href="#dom-uievent-which" id="ref-for-dom-uievent-which-4">which</a></code> attribute.</p>
 <pre class="idl highlight def"><span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="#uievent" id="ref-for-uievent-73">UIEvent</a> {
   // The following support legacy user agents
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-uievent-which" id="ref-for-dom-uievent-which-5">which</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-uievent-which" id="ref-for-dom-uievent-which-5">which</a>;
 };
 </pre>
     <dl>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="UIEvent" data-dfn-type="attribute" data-export="" id="dom-uievent-which">which</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long">unsigned long</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="UIEvent" data-dfn-type="attribute" data-export="" id="dom-uievent-which"><code>which</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long">unsigned long</a>, readonly</span>
      <dd> For <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent-157">MouseEvent</a></code>s, this contains a value equal to the value stored in <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-button" id="ref-for-dom-mouseevent-button-26">button</a></code>+1.
 				For <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent-75">KeyboardEvent</a></code>s, this holds a system- and implementation-dependent
 				numerical code signifying the unmodified identifier associated
@@ -5472,16 +5483,16 @@ used.</p>
 		implementations that support this extension.</p>
 <pre class="idl highlight def"><span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="#keyboardevent" id="ref-for-keyboardevent-80">KeyboardEvent</a> {
   // The following support legacy user agents
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-keyboardevent-charcode" id="ref-for-dom-keyboardevent-charcode-5">charCode</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-keyboardevent-keycode" id="ref-for-dom-keyboardevent-keycode-6">keyCode</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-keyboardevent-charcode" id="ref-for-dom-keyboardevent-charcode-5">charCode</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-keyboardevent-keycode" id="ref-for-dom-keyboardevent-keycode-6">keyCode</a>;
 };
 </pre>
     <dl>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-charcode">charCode</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long">unsigned long</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-charcode"><code>charCode</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long">unsigned long</a>, readonly</span>
      <dd> <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-charcode" id="ref-for-dom-keyboardevent-charcode-6">charCode</a></code> holds a character value, for <a data-link-type="dfn" href="#keypress" id="ref-for-keypress-6"><code>keypress</code></a> events which generate character input. The value				is the Unicode reference number (code point) of that character
 				(e.g. <code>event.charCode = event.key.charCodeAt(0)</code> for
 				printable characters). For <a data-link-type="dfn" href="#keydown" id="ref-for-keydown-60"><code>keydown</code></a> or <a data-link-type="dfn" href="#keyup" id="ref-for-keyup-54"><code>keyup</code></a> events, the value of <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-charcode" id="ref-for-dom-keyboardevent-charcode-7">charCode</a></code> is <code>0</code>. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-keycode">keyCode</dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long">unsigned long</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-keycode"><code>keyCode</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long">unsigned long</a>, readonly</span>
      <dd> <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-keycode" id="ref-for-dom-keyboardevent-keycode-7">keyCode</a></code> holds a system- and
 				implementation-dependent numerical code signifying the
 				unmodified identifier associated with the key pressed. Unlike
@@ -5910,9 +5921,9 @@ completeness.</p>
     <p>Implementations which support the <a data-link-type="dfn" href="#domactivate" id="ref-for-domactivate-8"><code>DOMActivate</code></a> <a data-link-type="dfn" href="#event-type" id="ref-for-event-type-21">event type</a> SHOULD also dispatch a <a data-link-type="dfn" href="#domactivate" id="ref-for-domactivate-9"><code>DOMActivate</code></a> event as a <a data-link-type="dfn" href="#default-action" id="ref-for-default-action-36">default		action</a> of a <a data-link-type="dfn" href="#click" id="ref-for-click-37"><code>click</code></a> event which is associated with an <a data-link-type="dfn" href="#activation-trigger" id="ref-for-activation-trigger-6">activation trigger</a>. However, such implementations SHOULD only
 		initiate the associated <a data-link-type="dfn" href="#activation-behavior" id="ref-for-activation-behavior-3">activation behavior</a> once for any given
 		occurrence of an <a data-link-type="dfn" href="#activation-trigger" id="ref-for-activation-trigger-7">activation trigger</a>.</p>
-    <div class="example" id="example-742b8f4c">
-     <a class="self-link" href="#example-742b8f4c"></a> 
-     <p> The <a data-link-type="dfn" href="#domactivate" id="ref-for-domactivate-10"><code>DOMActivate</code></a> <a data-link-type="dfn" href="#event-type" id="ref-for-event-type-22">event type</a> is REQUIRED to be supported for		XForms <a data-link-type="biblio" href="#biblio-xforms">[XFORMS]</a>, which is intended for implementation within a <a data-link-type="dfn" href="#host-language" id="ref-for-host-language-11">host
+    <div class="example" id="example-af82986f">
+     <a class="self-link" href="#example-af82986f"></a> 
+     <p> The <a data-link-type="dfn" href="#domactivate" id="ref-for-domactivate-10"><code>DOMActivate</code></a> <a data-link-type="dfn" href="#event-type" id="ref-for-event-type-22">event type</a> is REQUIRED to be supported for		XForms <a data-link-type="biblio" href="#biblio-xforms11">[XFORMS11]</a>, which is intended for implementation within a <a data-link-type="dfn" href="#host-language" id="ref-for-host-language-11">host
 		language</a>. In a scenario where a plugin or script-based
 		implementation of XForms is intended for installation in a native
 		implementation of this specification which does not support the <a data-link-type="dfn" href="#domactivate" id="ref-for-domactivate-11"><code>DOMActivate</code></a> <a data-link-type="dfn" href="#event-type" id="ref-for-event-type-23">event type</a>, the XForms <a data-link-type="dfn" href="#user-agent" id="ref-for-user-agent-46">user agent</a> has		to synthesize and dispatch its own <a data-link-type="dfn" href="#domactivate" id="ref-for-domactivate-12"><code>DOMActivate</code></a> events based on		the appropriate <a data-link-type="dfn" href="#activation-trigger" id="ref-for-activation-trigger-8">activation triggers</a>. </p>
@@ -6172,7 +6183,7 @@ completeness.</p>
          <li><code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent-96">KeyboardEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-shiftkey" id="ref-for-dom-keyboardevent-shiftkey-27">shiftKey</a></code> : <code>true</code> if <code class="keycap">Shift</code> modifier was active, otherwise <code>false</code>
          <li><code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent-97">KeyboardEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-ctrlkey" id="ref-for-dom-keyboardevent-ctrlkey-18">ctrlKey</a></code> : <code>true</code> if <code class="keycap">Control</code> modifier was active, otherwise <code>false</code>
          <li><code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent-98">KeyboardEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-metakey" id="ref-for-dom-keyboardevent-metakey-7">metaKey</a></code> : <code>true</code> if <code class="keycap">Meta</code> modifier was active, otherwise <code>false</code>
-         <li><code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent-99">KeyboardEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-repeat" id="ref-for-dom-keyboardevent-repeat-7">repeat</a></code> : <code>false</code>
+         <li><code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent-99">KeyboardEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-repeat" id="ref-for-dom-keyboardevent-repeat-6">repeat</a></code> : <code>false</code>
          <li><code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent-100">KeyboardEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-iscomposing" id="ref-for-dom-keyboardevent-iscomposing-10">isComposing</a></code> : <code>true</code> if the key event occurs as part of a composition session, otherwise <code>false</code>
         </ul>
     </table>
@@ -6192,8 +6203,8 @@ completeness.</p>
      The <a data-link-type="dfn" href="#keypress" id="ref-for-keypress-18"><code>keypress</code></a> event type MUST be dispatched after the <a data-link-type="dfn" href="#keydown" id="ref-for-keydown-65"><code>keydown</code></a> event and before the <a data-link-type="dfn" href="#keyup" id="ref-for-keyup-57"><code>keyup</code></a> event associated with		the same key. 
     <p>The <a data-link-type="dfn" href="#keypress" id="ref-for-keypress-19"><code>keypress</code></a> event type MUST be dispatched after the <a data-link-type="dfn" href="#beforeinput" id="ref-for-beforeinput-32"><code>beforeinput</code></a> event and before the <a data-link-type="dfn" href="#input" id="ref-for-input-32"><code>input</code></a> event associated		with the same key.</p>
     <p>The sequence of key events for user-agents the support the <a data-link-type="dfn" href="#keypress" id="ref-for-keypress-20"><code>keypress</code></a> event is demonstrated in the following example:</p>
-    <div class="example" id="example-af3ceeb4">
-     <a class="self-link" href="#example-af3ceeb4"></a> 
+    <div class="example" id="example-7be963ec">
+     <a class="self-link" href="#example-7be963ec"></a> 
      <table class="event-sequence-table">
       <tbody>
        <tr>
@@ -6288,11 +6299,11 @@ completeness.</p>
 };
 </pre>
     <dl>
-     <dt><dfn class="idl-code" data-dfn-for="MutationEvent" data-dfn-type="const" data-export="" id="dom-mutationevent-modification">MODIFICATION<a class="self-link" href="#dom-mutationevent-modification"></a></dfn>
+     <dt><dfn class="idl-code" data-dfn-for="MutationEvent" data-dfn-type="const" data-export="" id="dom-mutationevent-modification"><code>MODIFICATION</code><a class="self-link" href="#dom-mutationevent-modification"></a></dfn>
      <dd> The <code>Attr</code> was modified in place. 
-     <dt><dfn class="idl-code" data-dfn-for="MutationEvent" data-dfn-type="const" data-export="" id="dom-mutationevent-addition">ADDITION<a class="self-link" href="#dom-mutationevent-addition"></a></dfn>
+     <dt><dfn class="idl-code" data-dfn-for="MutationEvent" data-dfn-type="const" data-export="" id="dom-mutationevent-addition"><code>ADDITION</code><a class="self-link" href="#dom-mutationevent-addition"></a></dfn>
      <dd> The <code>Attr</code> was just added. 
-     <dt><dfn class="idl-code" data-dfn-for="MutationEvent" data-dfn-type="const" data-export="" id="dom-mutationevent-removal">REMOVAL<a class="self-link" href="#dom-mutationevent-removal"></a></dfn>
+     <dt><dfn class="idl-code" data-dfn-for="MutationEvent" data-dfn-type="const" data-export="" id="dom-mutationevent-removal"><code>REMOVAL</code><a class="self-link" href="#dom-mutationevent-removal"></a></dfn>
      <dd> The <code>Attr</code> was just removed. 
      <dt><dfn data-dfn-for="MutationEvent" data-dfn-type="dfn" data-noexport="" id="mutationevent-relatednode" unknown="">relatedNode<a class="self-link" href="#mutationevent-relatednode"></a></dfn>
      <dd>
@@ -6320,7 +6331,7 @@ completeness.</p>
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value-36">un-initialized value</a> of this attribute MUST be <code>0</code>.</p>
       <p class="note" role="note"> There is no defined constant for the attrChange value of 0 (the
 				un-initialized value). </p>
-     <dt><dfn class="idl-code" data-dfn-for="MutationEvent" data-dfn-type="method" data-export="" id="dom-mutationevent-initmutationevent">initMutationEvent()<a class="self-link" href="#dom-mutationevent-initmutationevent"></a></dfn>
+     <dt><dfn class="idl-code" data-dfn-for="MutationEvent" data-dfn-type="method" data-export="" id="dom-mutationevent-initmutationevent"><code>initMutationEvent()</code><a class="self-link" href="#dom-mutationevent-initmutationevent"></a></dfn>
      <dd>
        Initializes attributes of a <code>MutationEvent</code> object.
 				This method has the same behavior as <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-initevent">initEvent()</a></code>. 
@@ -7104,8 +7115,7 @@ William Edney and
 similar definitions in other W3C or standards documents. See the links within
 the definitions for more information.</p>
     <dl>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="activation-behavior">activation behavior</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="activation-behavior">activation behavior</dfn>
      <dd data-md="">
       <p>The action taken when an <a data-link-type="dfn" href="#event" id="ref-for-event-2">event</a>, typically initiated by users through
 an input device, causes an element to fulfill a defined task.  The task MAY
@@ -7118,43 +7128,36 @@ specifying the browsing context for the traversal (such as the current
 window or tab, a named window, or a new window). The activation behavior of
 an HTML <code>&lt;input></code> element with the <code>type</code> attribute value <code>submit</code> is be to send the values of the form
 elements to an author-defined IRI by the author-defined HTTP method.  See <a href="#event-flow-activation">§3.5 Activation triggers and behavior</a> for more details.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="activation-trigger">activation trigger</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="activation-trigger">activation trigger</dfn>
      <dd data-md="">
       <p>An event which is defined to initiate an <a data-link-type="dfn" href="#activation-behavior" id="ref-for-activation-behavior-6">activation behavior</a>.  Refer
 to <a href="#event-flow-activation">§3.5 Activation triggers and behavior</a> for more details.</p>
-     <dt data-md="">
-      <p><dfn data-dfn-type="dfn" data-noexport="" id="author">author<a class="self-link" href="#author"></a></dfn></p>
+     <dt data-md=""><dfn data-dfn-type="dfn" data-noexport="" id="author">author<a class="self-link" href="#author"></a></dfn>
      <dd data-md="">
       <p>In the context of this specification, an <em>author</em>, <em>content
 author</em>, or <em>script author</em> is a person who writes script or
 other executable content that uses the interfaces, events, and event flow
 defined in this specification. See <a href="#conf-authors">§1.2.3 Content authors and content</a> conformance category
 for more details.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="body-element">body element</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="body-element">body element</dfn>
      <dd data-md="">
       <p>In HTML or XHTML documents, the body element represents the contents of the
 document. In a well-formed HTML document, the body element is a first
 descendant of the <a data-link-type="dfn" href="#root-element" id="ref-for-root-element-7">root element</a>.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="bubble phase|bubbling phase" data-noexport="" id="bubble-phase">bubbling phase</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="bubble phase|bubbling phase" data-noexport="" id="bubble-phase">bubbling phase</dfn>
      <dd data-md="">
       <p>The process by which an <a data-link-type="dfn" href="#event" id="ref-for-event-3">event</a> can be handled by one of the target’s
 ancestors <em>after</em> being handled by the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-51">event target</a>. See the
 description of the <a data-link-type="dfn" href="#bubble-phase" id="ref-for-bubble-phase-2">bubble phase</a> in the context of event flow for more
 details.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="capture-phase">capture phase</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="capture-phase">capture phase</dfn>
      <dd data-md="">
       <p>The process by which an <a data-link-type="dfn" href="#event" id="ref-for-event-4">event</a> can be handled by one of the target’s
 ancestors <em>before</em> being handled by the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-52">event target</a>. See the
 description of the <a href="#capture-phase" id="ref-for-capture-phase-2">capture phase</a> in the context
 of event flow for more details.</p>
-     <dt data-md="">
-      <p><dfn data-dfn-type="dfn" data-noexport="" id="candidate-event-handlers">candidate event handlers<a class="self-link" href="#candidate-event-handlers"></a></dfn></p>
-     <dt data-md="">
-      <p><dfn data-dfn-type="dfn" data-noexport="" id="candidate-event-listeners">candidate event listeners<a class="self-link" href="#candidate-event-listeners"></a></dfn></p>
+     <dt data-md=""><dfn data-dfn-type="dfn" data-noexport="" id="candidate-event-handlers">candidate event handlers<a class="self-link" href="#candidate-event-handlers"></a></dfn>
+     <dt data-md=""><dfn data-dfn-type="dfn" data-noexport="" id="candidate-event-listeners">candidate event listeners<a class="self-link" href="#candidate-event-listeners"></a></dfn>
      <dd data-md="">
       <p>The list of all <a data-link-type="dfn" href="#event-listener" id="ref-for-event-listener-1">event listeners</a> that have been registered on the
 target object in their order of registration. When an event is about to be
@@ -7166,8 +7169,7 @@ dispatch begins will be removed.</p>
       <p class="note" role="note"> Initially capturing the candidate event handlers and not allowing new
 listeners to be added prevents infinite loops of event listener dispatch on
 a given target object. </p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="character-value">character value</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="character-value">character value</dfn>
      <dd data-md="">
       <p>In the context of key values, a character value is a string representing one
 or more Unicode characters, such as a letter or symbol, or a set of letters.
@@ -7176,22 +7178,19 @@ In this specification, character values are denoted as a unicode string
       <p class="note" role="note"> In source code, some key values, such as non-graphic characters, can be
 represented using the character escape syntax of the programming language in
 use. </p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="current-event-target">current event target</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="current-event-target">current event target</dfn>
      <dd data-md="">
       <p>In an event flow, the current event target is the object associated with the <a data-link-type="dfn" href="#event-handler" id="ref-for-event-handler-1">event handler</a> that is currently being dispatched. This object MAY be
 the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-53">event target</a> itself or one of its ancestors. The current event
 target changes as the <a data-link-type="dfn" href="#event" id="ref-for-event-5">event</a> propagates from object to object through
 the various <a data-link-type="dfn" href="#phase" id="ref-for-phase-1">phases</a> of the event flow. The current event target is the
 value of the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-currenttarget">currentTarget</a></code> attribute.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dead-key">dead key</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dead-key">dead key</dfn>
      <dd data-md="">
       <p>A dead key is a key or combination of keys which produces no character by
 itself, but which in combination or sequence with another key produces a
 modified character, such as a character with diacritical marks (e.g., <code class="glyph">"ö"</code>, <code class="glyph">"é"</code>, <code class="glyph">"â"</code>).</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="default-action">default action</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="default-action">default action</dfn>
      <dd data-md="">
       <p>A <a data-link-type="dfn" href="#default-action" id="ref-for-default-action-45">default action</a> is an OPTIONAL supplementary behavior that an
 implementation MUST perform in combination with the dispatch of the event
@@ -7199,8 +7198,7 @@ object.  Each event type definition, and each specification, defines the <a data
 event MAY have more than one <a data-link-type="dfn" href="#default-action" id="ref-for-default-action-47">default action</a> under some circumstances,
 such as when associated with an <a data-link-type="dfn" href="#activation-trigger" id="ref-for-activation-trigger-9">activation trigger</a>.  A <a data-link-type="dfn" href="#default-action" id="ref-for-default-action-48">default
 action</a> MAY be cancelled through the invocation of the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-preventdefault">preventDefault()</a></code> method. For more details, see <a href="#event-flow-default-cancel">§3.2 Default actions and cancelable events</a>.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="delta">delta</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="delta">delta</dfn>
      <dd data-md="">
       <p>The estimated scroll amount (in pixels, lines, or pages) that the user agent
 will scroll or zoom the page in response to the physical movement of an
@@ -7211,8 +7209,7 @@ positive or negative is environment and device dependent. However, if a user
 agent scrolls as the <a data-link-type="dfn" href="#default-action" id="ref-for-default-action-49">default action</a> then the sign of the <a data-link-type="dfn" href="#delta" id="ref-for-delta-14">delta</a> is given by a right-hand coordinate system where positive X,Y, and Z axes
 are directed towards the right-most edge, bottom-most edge, and farthest
 depth (away from the user) of the document, respectively.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="deprecates|deprecated" data-noexport="" id="deprecates">deprecated</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="deprecates|deprecated" data-noexport="" id="deprecates">deprecated</dfn>
      <dd data-md="">
       <p>Features marked as deprecated are included in the specification as reference
 to older implementations or specifications, but are OPTIONAL and
@@ -7226,29 +7223,25 @@ specification SHOULD NOT use deprecated features, but SHOULD point instead
 to the replacements of which the feature is deprecated in favor.  Features
 marked as deprecated in this specification are expected to be dropped from
 future specifications.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dispatch">dispatch</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dispatch">dispatch</dfn>
      <dd data-md="">
       <p>To create an event with attributes and methods appropriate to its type and
 context, and propagate it through the DOM tree in the specified manner.
 Interchangeable with the term <q><a data-link-type="dfn" href="#fire" id="ref-for-fire-1">fire</a></q>, e.g., <q>fire a <a data-link-type="dfn" href="#click" id="ref-for-click-44"><code>click</code></a> event</q> or <q>dispatch a <a data-link-type="dfn" href="#load" id="ref-for-load-5"><code>load</code></a> event</q>.</p>
-     <dt data-md="">
-      <p><dfn data-dfn-type="dfn" data-noexport="" id="document">document<a class="self-link" href="#document"></a></dfn></p>
+     <dt data-md=""><dfn data-dfn-type="dfn" data-noexport="" id="document">document<a class="self-link" href="#document"></a></dfn>
      <dd data-md="">
       <p>An object instantiating the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code> interface <a data-link-type="biblio" href="#biblio-dom-level-3-core">[DOM-Level-3-Core]</a>,
 representing the entire HTML or XML text document.  Conceptually, it is the
 root of the document tree, and provides the primary access to the document’s
 data.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dom-application">DOM application</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dom-application">DOM application</dfn>
      <dd data-md="">
       <p>A DOM application is script or code, written by a content author or
 automatically generated, which takes advantage of the interfaces, methods,
 attributes, events, and other features described in this specification in
 order to make dynamic or interactive content, such as Web applications,
 exposed to users in a <a data-link-type="dfn" href="#user-agent" id="ref-for-user-agent-68">user agent</a>.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dom-level-0">DOM Level 0</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dom-level-0">DOM Level 0</dfn>
      <dd data-md="">
       <p>The term <q>DOM Level 0</q> refers to a mix of HTML document functionalities,
 often not formally specified but traditionally supported as de facto
@@ -7256,21 +7249,18 @@ standards, implemented originally by Netscape Navigator version 3.0 or
 Microsoft Internet Explorer version 3.0.  In many cases, attributes or
 methods have been included for reasons of backward compatibility with <q>DOM
 Level 0</q>.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="empty-string">empty string</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="empty-string">empty string</dfn>
      <dd data-md="">
       <p>The empty string is a value of type <code>DOMString</code> of length <code>0</code>, i.e., a string which contains no characters (neither
 printing nor control characters).</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event">event</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event">event</dfn>
      <dd data-md="">
       <p>An event is the representation of some occurrence (such as a mouse click on
 the presentation of an element, the removal of child node from an element,
 or any number of other possibilities) which is associated with its <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-54">event
 target</a>. Each event is an instantiation of one specific <a data-link-type="dfn" href="#event-type" id="ref-for-event-type-26">event
 type</a>.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-focus">event focus</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-focus">event focus</dfn>
      <dd data-md="">
       <p>Event focus is a special state of receptivity and concentration on a
 particular element or other <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-55">event target</a> within a document.  Each
@@ -7278,8 +7268,7 @@ element has different behavior when focused, depending on its functionality,
 such as priming the element for activation (as for a button or hyperlink) or
 toggling state (as for a checkbox), receiving text input (as for a text form
 field), or copying selected text.  For more details, see <a href="#events-focusevent-doc-focus">§4.2.3 Document Focus and Focus Context</a>.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="focus ring" data-noexport="" id="focus-ring">event focus ring</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="focus ring" data-noexport="" id="focus-ring">event focus ring</dfn>
      <dd data-md="">
       <p>An event focus ring is an ordered set of <a data-link-type="dfn" href="#event-focus" id="ref-for-event-focus-1">event focus</a> targets within a
 document.  A <a data-link-type="dfn" href="#host-language" id="ref-for-host-language-13">host language</a> MAY define one or more ways to determine
@@ -7289,10 +7278,8 @@ different models.  Each document MAY contain multiple focus rings, or
 conditional focus rings.  Typically, for document-order or indexed focus
 rings, focus <q>wraps around</q> from the last focus target to the
 first.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-handler">event handler</dfn></p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-listener">event listener</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-handler">event handler</dfn>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-listener">event listener</dfn>
      <dd data-md="">
       <p>An object that implements the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#callbackdef-eventlistener">EventListener</a></code> interface and provides an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-eventlistener-handleevent">handleEvent()</a></code> callback method. Event handlers are
 language-specific. Event handlers are invoked in the context of a particular
@@ -7301,8 +7288,7 @@ object itself.</p>
       <p class="note" role="note"> In JavaScript, user-defined functions are considered to implement the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#callbackdef-eventlistener">EventListener</a></code> interface. Thus the event object will be provided as the
 first parameter to the user-defined function when it is invoked.
 Additionally, JavaScript objects can also implement the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#callbackdef-eventlistener">EventListener</a></code> interface when they define a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-eventlistener-handleevent">handleEvent</a></code> method. </p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-order">event order</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-order">event order</dfn>
      <dd data-md="">
       <p>The sequence in which events from the same event source or process occur,
 using the same or related event interfaces. For example, in an environment
@@ -7314,29 +7300,24 @@ order. A <a data-link-type="dfn" href="#mousedown" id="ref-for-mousedown-21"><co
 user might change focus using the <code class="keycap">Tab</code> key, or by clicking the new	focused element with the mouse.  The event order in such cases depends on
 the state of the process, not on the state of the device that initiates the
 state change.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-phase">event phase</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-phase">event phase</dfn>
      <dd data-md="">
       <p>See <a data-link-type="dfn" href="#phase" id="ref-for-phase-2">phase</a>.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-target">event target</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-target">event target</dfn>
      <dd data-md="">
       <p>The object to which an <a data-link-type="dfn" href="#event" id="ref-for-event-6">event</a> is targeted using the <a href="#event-flow">§3.1 Event dispatch and DOM event flow</a>.
 The event target is the value of the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-target">target</a></code> attribute.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-type">event type</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-type">event type</dfn>
      <dd data-md="">
       <p>An <em>event type</em> is an <a data-link-type="dfn" href="#event" id="ref-for-event-7">event</a> object with a particular name and
 which defines particular trigger conditions, properties, and other
 characteristics which distinguish it from other event types.  For example,
 the <a data-link-type="dfn" href="#click" id="ref-for-click-48"><code>click</code></a> event type has different characteristics than the <a data-link-type="dfn" href="#mouseover" id="ref-for-mouseover-11"><code>mouseover</code></a> or <a data-link-type="dfn" href="#load" id="ref-for-load-6"><code>load</code></a> event types. The event type is exposed as	the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-type">type</a></code> attribute on the event object.  See <a href="#event-types">§4 Event Types</a> for
 more details.  Also loosely referred to as <em>"event"</em>, such as the <em><a data-link-type="dfn" href="#click" id="ref-for-click-49"><code>click</code></a> event</em>.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="fire">fire</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="fire">fire</dfn>
      <dd data-md="">
       <p>A synonym for <a data-link-type="dfn" href="#dispatch" id="ref-for-dispatch-3">dispatch</a>.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="host-language">host language</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="host-language">host language</dfn>
      <dd data-md="">
       <p>Any language which integrates the features of another language or API
 specification, while normatively referencing the origin specification rather
@@ -7346,8 +7327,7 @@ only intended to be implemented in the context of one or more host
 languages, not as a standalone language.  For example, XHTML, HTML, and SVG
 are host languages for UI Events, and they integrate and extend the objects
 and models defined in this specification.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="hysteresis">hysteresis</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="hysteresis">hysteresis</dfn>
      <dd data-md="">
       <p>A feature of human interface design to accept input values within a certain
 range of location or time, in order to improve the user experience.  For
@@ -7355,10 +7335,8 @@ example, allowing for small deviation in the time it takes for a user to
 double-click a mouse button is temporal hysteresis, and not immediately
 closing a nested menu if the user mouses out from the parent window when
 transitioning to the child menu is locative hysteresis.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="ime">IME</dfn></p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="input-method-editor">input method editor</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="ime">IME</dfn>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="input-method-editor">input method editor</dfn>
      <dd data-md="">
       <p>An <em>input method editor</em> (IME), also known as a <em>front end
 processor</em>, is an application that performs the conversion between
@@ -7367,88 +7345,74 @@ dictionary lookup, often used in East Asian languages (e.g., Chinese,
 Japanese, Korean).  An <a data-link-type="dfn" href="#ime" id="ref-for-ime-15">IME</a> MAY also be used for dictionary-based word
 completion, such as on mobile devices.  See <a href="#keys-IME">§5.3.3 Input Method Editors</a> for treatment of
 IMEs in this specification.  See also <a data-link-type="dfn" href="#text-composition-system" id="ref-for-text-composition-system-17">text composition system</a>.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="key-mapping">key mapping</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="key-mapping">key mapping</dfn>
      <dd data-md="">
       <p>Key mapping is the process of assigning a key value to a particular key, and
 is the result of a combination of several factors, including the operating
 system and the keyboard layout (e.g., <a data-link-type="dfn" href="#qwerty" id="ref-for-qwerty-3">QWERTY</a>, Dvorak, Spanish,
 InScript, Chinese, etc.), and after taking into account all <a data-link-type="dfn" href="#modifier-key" id="ref-for-modifier-key-2">modifier
 key</a> (<code class="keycap">Shift</code>, <code class="keycap">Alt</code>, et al.) and <a data-link-type="dfn" href="#dead-key" id="ref-for-dead-key-11">dead key</a> states.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="key-value">key value</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="key-value">key value</dfn>
      <dd data-md="">
       <p>A key value is a <a data-link-type="dfn" href="#character-value" id="ref-for-character-value-10">character value</a> or multi-character string (such as <code class="key">"<a href="http://www.w3.org/TR/uievents-key/#key-Enter">Enter</a>"</code>, <code class="key">"<a href="http://www.w3.org/TR/uievents-key/#key-Tab">Tab</a>"</code>, or <code class="key">"<a href="http://www.w3.org/TR/uievents-key/#key-MediaTrackNext">MediaTrackNext</a>"</code>) associated with a key in a	particular state. Every key has a key value, whether or not it has a <a data-link-type="dfn" href="#character-value" id="ref-for-character-value-11">character value</a>. This includes control keys, function keys, <a data-link-type="dfn" href="#modifier-key" id="ref-for-modifier-key-3">modifier keys</a>, <a data-link-type="dfn" href="#dead-key" id="ref-for-dead-key-12">dead keys</a>, and any other key. The key value of
 any given key at any given time depends upon the <a data-link-type="dfn" href="#key-mapping" id="ref-for-key-mapping-5">key mapping</a>.</p>
-     <dt data-md="">
-      <p><dfn data-dfn-type="dfn" data-noexport="" id="local-name">local name<a class="self-link" href="#local-name"></a></dfn></p>
+     <dt data-md=""><dfn data-dfn-type="dfn" data-noexport="" id="local-name">local name<a class="self-link" href="#local-name"></a></dfn>
      <dd data-md="">
       <p>See local name in <a data-link-type="biblio" href="#biblio-xml-names11">[XML-Names11]</a>.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="modifier-key">modifier key</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="modifier-key">modifier key</dfn>
      <dd data-md="">
       <p>A modifier key changes the normal behavior of a key, such as to produce a
 character of a different case (as with the <code class="keycap">Shift</code> key), or to alter	what functionality the key triggers (as with the <code class="keycap">Fn</code> or <code class="keycap">Alt</code> keys). Refer to <a href="#keys-modifiers">§5.3.1 Modifier keys</a> for a list of modifier keys.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="namespace URIs" data-noexport="" id="namespace-uris">namespace URI</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="namespace URIs" data-noexport="" id="namespace-uris">namespace URI</dfn>
      <dd data-md="">
       <p>A <em>namespace URI</em> is a URI that identifies an XML namespace. This is
 called the namespace name in <a data-link-type="biblio" href="#biblio-xml-names11">[XML-Names11]</a>. See also sections 1.3.2 <a class="normative" href="http://www.w3.org/TR/DOM-Level-3-Core/core.html#baseURIs-Considerations"><em>DOM URIs</em></a> and 1.3.3 <a class="normative" href="http://www.w3.org/TR/DOM-Level-3-Core/core.html#Namespaces-Considerations"><em>XML Namespaces</em></a> regarding URIs and namespace URIs handling and comparison in the DOM APIs.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="phase">phase</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="phase">phase</dfn>
      <dd data-md="">
       <p>In the context of <a data-link-type="dfn" href="#event" id="ref-for-event-8">events</a>, a phase is set of logical traversals from
 node to node along the DOM tree, from the <a data-link-type="dfn" href="#window" id="ref-for-window-50">Window</a> to the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Document</a></code> object, <a data-link-type="dfn" href="#root-element" id="ref-for-root-element-8">root element</a>, and down to the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-56">event target</a> (<a data-link-type="dfn" href="#capture-phase" id="ref-for-capture-phase-3">capture
 phase</a>), at the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-57">event target</a> itself (<a data-link-type="dfn" href="#target-phase" id="ref-for-target-phase-2">target phase</a>), and
 back up the same chain (<a data-link-type="dfn" href="#bubble-phase" id="ref-for-bubble-phase-3">bubbling phase</a>).</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="propagation-path">propagation path</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="propagation-path">propagation path</dfn>
      <dd data-md="">
       <p>The ordered set of <a data-link-type="dfn" href="#current-event-target" id="ref-for-current-event-target-3">current event targets</a> though which an <a data-link-type="dfn" href="#event" id="ref-for-event-9">event</a> object will pass sequentially on the way to and back from the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-58">event
 target</a>.  As the event propagates, each <a data-link-type="dfn" href="#current-event-target" id="ref-for-current-event-target-4">current event target</a> in
 the propagation path is in turn set as the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-currenttarget">currentTarget</a></code>. The
 propagation path is initially composed of one or more <a data-link-type="dfn" href="#event-phase" id="ref-for-event-phase-2">event phases</a> as
 defined by the <a data-link-type="dfn" href="#event-type" id="ref-for-event-type-27">event type</a>, but MAY be interrupted.  Also known as an <em>event target chain</em>.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="qwerty">QWERTY</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="qwerty">QWERTY</dfn>
      <dd data-md="">
       <p>QWERTY (pronounced <q>ˈkwɜrti</q>) is a common keyboard layout,
 so named because the first five character keys on the top row of letter keys
 are Q, W, E, R, T, and Y.  There are many other popular keyboard layouts
 (including the Dvorak and Colemak layouts), most designed for localization
 or ergonomics.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="root-element">root element</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="root-element">root element</dfn>
      <dd data-md="">
       <p>The first element node of a document, of which all other elements are
 children. The document element.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="rotation">rotation</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="rotation">rotation</dfn>
      <dd data-md="">
       <p>An indication of incremental change on an input device using the <code class="idl"><a data-link-type="idl" href="#wheelevent" id="ref-for-wheelevent-15">WheelEvent</a></code> interface. On some devices this MAY be a literal rotation of
 a wheel, while on others, it MAY be movement along a flat surface, or
 pressure on a particular button.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="target-phase">target phase</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="target-phase">target phase</dfn>
      <dd data-md="">
       <p>The process by which an <a data-link-type="dfn" href="#event" id="ref-for-event-10">event</a> can be handled by the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-59">event
 target</a>. See the description of the <a data-link-type="dfn" href="#target-phase" id="ref-for-target-phase-3">target phase</a> in the context of
 event flow for more details.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="text-composition-system">text composition system</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="text-composition-system">text composition system</dfn>
      <dd data-md="">
       <p>A software component that interprets some form of alternate input (such as a <a data-link-type="dfn" href="#input-method-editor" id="ref-for-input-method-editor-11">input method editor</a>, a speech processor, or a handwriting recognition
 system) and converts it to text.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="topmost-event-target">topmost event target</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="topmost-event-target">topmost event target</dfn>
      <dd data-md="">
       <p>The <a data-link-type="dfn" href="#topmost-event-target" id="ref-for-topmost-event-target-14">topmost event target</a> MUST be the element highest in the rendering
 order which is capable of being an <a data-link-type="dfn" href="#event-target" id="ref-for-event-target-60">event target</a>. In graphical user
 interfaces this is the element under the user’s pointing device. A user
 interface’s <q>hit testing</q> facility is used to determine the target. For
 specific details regarding hit testing and stacking order, refer to the <a data-link-type="dfn" href="#host-language" id="ref-for-host-language-14">host language</a>.</p>
-     <dt data-md="">
-      <p><dfn data-dfn-type="dfn" data-noexport="" id="tree">tree<a class="self-link" href="#tree"></a></dfn></p>
+     <dt data-md=""><dfn data-dfn-type="dfn" data-noexport="" id="tree">tree<a class="self-link" href="#tree"></a></dfn>
      <dd data-md="">
       <p>A data structure that represents a document as a hierarchical set of nodes
 with child-parent-sibling relationships, i.e., each node having one or more
@@ -7456,8 +7420,7 @@ possible ancestors (nodes higher in the hierarchy in a direct lineage), one
 or more possible descendants (nodes lower in the hierarchy in a direct
 lineage), and one or more possible peers (nodes of the same level in the
 hierarchy, with the same immediate ancestor).</p>
-     <dt data-md="">
-      <p><dfn data-dfn-type="dfn" data-noexport="" id="unicode-character-categories">Unicode character categories<a class="self-link" href="#unicode-character-categories"></a></dfn></p>
+     <dt data-md=""><dfn data-dfn-type="dfn" data-noexport="" id="unicode-character-categories">Unicode character categories<a class="self-link" href="#unicode-character-categories"></a></dfn>
      <dd data-md="">
       <p>A subset of the General Category values that are defined for each Unicode
 code point. This subset contains all the
@@ -7466,13 +7429,11 @@ Number (<abbr title="Number, Decimal Digit">Nd</abbr>, <abbr title="Number, Lett
 Punctuation (<abbr title="Punctuation, Connector">Pc</abbr>, <abbr title="Punctuation, Dash">Pd</abbr>, <abbr title="Punctuation, Close">Pe</abbr>, <abbr title="Punctuation, Final quote">Pf</abbr>, <abbr title="Punctuation, Initial quote">Pi</abbr>, <abbr title="Punctuation, Other">Po</abbr>, <abbr title="Punctuation, Open">Ps</abbr>)
 and Symbol (<abbr title="Symbol, Currency">Sc</abbr>, <abbr title="Symbol, Modifier">Sk</abbr>, <abbr title="Symbol, Math">Sm</abbr>, <abbr title="Symbol, Other">So</abbr>)
 category values.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="un-initialized-value">un-initialized value</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="un-initialized-value">un-initialized value</dfn>
      <dd data-md="">
       <p>The value of any event attribute (such as <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-bubbles">bubbles</a></code> or <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-currenttarget">currentTarget</a></code>) before the event has been initialized with <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-initevent">initEvent()</a></code>. The un-initialized values of an event apply
 immediately after a new event has been created using the method <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-document-createevent">createEvent()</a></code>.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="user-agent">user agent</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="user-agent">user agent</dfn>
      <dd data-md="">
       <p>A program, such as a browser or content authoring tool, normally running on
 a client machine, which acts on a user’s behalf in retrieving, interpreting,
@@ -7480,8 +7441,7 @@ executing, presenting, or creating content.  Users MAY act on the content
 using different user agents at different times, for different purposes.  See
 the <a href="#conf-interactive-ua">§1.2.1 Web browsers and other dynamic or interactive user agents</a> and <a href="#conf-author-tools">§1.2.2 Authoring tools</a> for details on the
 requirements for a <em>conforming</em> user agent.</p>
-     <dt data-md="">
-      <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="window">Window</dfn></p>
+     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="window">Window</dfn>
      <dd data-md="">
       <p>The <code>Window</code> is the object referred to by the current document’s
 browsing context’s Window Proxy object as defined in <a href="http://dev.w3.org/html5/spec/single-page.html#windowproxy" title="HTML5 WindowProxy description">HTML5</a> <a data-link-type="biblio" href="#biblio-html5">[HTML5]</a>.</p>
@@ -7838,7 +7798,7 @@ browsing context’s Window Proxy object as defined in <a href="http://dev.w3.or
      <li><a href="https://dom.spec.whatwg.org/#dom-eventtarget-dispatchevent">dispatchEvent(event)</a>
      <li><a href="https://dom.spec.whatwg.org/#dom-eventlistener-handleevent">handleEvent</a>
      <li><a href="https://dom.spec.whatwg.org/#dom-eventlistener-handleevent">handleEvent(event)</a>
-     <li><a href="https://dom.spec.whatwg.org/#dom-event-initevent">initEvent(type, bubbles, cancelable)</a>
+     <li><a href="https://dom.spec.whatwg.org/#dom-event-initevent">initEvent(type, bubbles)</a>
      <li><a href="https://dom.spec.whatwg.org/#dom-event-istrusted">isTrusted</a>
      <li><a href="https://dom.spec.whatwg.org/#dom-event-preventdefault">preventDefault()</a>
      <li><a href="https://dom.spec.whatwg.org/#dom-event-stopimmediatepropagation">stopImmediatePropagation()</a>
@@ -7893,19 +7853,19 @@ browsing context’s Window Proxy object as defined in <a href="http://dev.w3.or
    <dt id="biblio-html">[HTML]
    <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
    <dt id="biblio-html5">[HTML5]
-   <dd>Ian Hickson; et al. <a href="https://www.w3.org/TR/html5/">HTML5</a>. 28 October 2014. REC. URL: <a href="https://www.w3.org/TR/html5/">https://www.w3.org/TR/html5/</a>
+   <dd>Ian Hickson; et al. <a href="https://www.w3.org/TR/html5/">HTML5</a>. URL: <a href="https://www.w3.org/TR/html5/">https://www.w3.org/TR/html5/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
    <dt id="biblio-svg2">[SVG2]
-   <dd>Nikos Andronikos; et al. <a href="https://www.w3.org/TR/SVG2/">Scalable Vector Graphics (SVG) 2</a>. 15 September 2016. CR. URL: <a href="https://www.w3.org/TR/SVG2/">https://www.w3.org/TR/SVG2/</a>
+   <dd>Nikos Andronikos; et al. <a href="https://www.w3.org/TR/SVG2/">Scalable Vector Graphics (SVG) 2</a>. URL: <a href="https://www.w3.org/TR/SVG2/">https://www.w3.org/TR/SVG2/</a>
    <dt id="biblio-uievents">[UIEVENTS]
-   <dd>Gary Kacmarcik; Travis Leithead. <a href="https://www.w3.org/TR/uievents/">UI Events</a>. 4 August 2016. WD. URL: <a href="https://www.w3.org/TR/uievents/">https://www.w3.org/TR/uievents/</a>
+   <dd>Gary Kacmarcik; Travis Leithead. <a href="https://www.w3.org/TR/uievents/">UI Events</a>. URL: <a href="https://www.w3.org/TR/uievents/">https://www.w3.org/TR/uievents/</a>
    <dt id="biblio-uievents-code">[UIEvents-Code]
-   <dd>Gary Kacmarcik; Travis Leithead. <a href="https://www.w3.org/TR/uievents-code/">UI Events KeyboardEvent code Values</a>. 24 October 2016. WD. URL: <a href="https://www.w3.org/TR/uievents-code/">https://www.w3.org/TR/uievents-code/</a>
+   <dd>Gary Kacmarcik; Travis Leithead. <a href="https://www.w3.org/TR/uievents-code/">UI Events KeyboardEvent code Values</a>. URL: <a href="https://www.w3.org/TR/uievents-code/">https://www.w3.org/TR/uievents-code/</a>
    <dt id="biblio-uievents-key">[UIEvents-Key]
-   <dd>Gary Kacmarcik; Travis Leithead. <a href="https://www.w3.org/TR/uievents-key/">UI Events KeyboardEvent key Values</a>. 24 October 2016. WD. URL: <a href="https://www.w3.org/TR/uievents-key/">https://www.w3.org/TR/uievents-key/</a>
+   <dd>Gary Kacmarcik; Travis Leithead. <a href="https://www.w3.org/TR/uievents-key/">UI Events KeyboardEvent key Values</a>. URL: <a href="https://www.w3.org/TR/uievents-key/">https://www.w3.org/TR/uievents-key/</a>
    <dt id="biblio-webidl">[WebIDL]
-   <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. <a href="https://www.w3.org/TR/WebIDL-1/">Web IDL</a>. 15 December 2016. WD. URL: <a href="https://www.w3.org/TR/WebIDL-1/">https://www.w3.org/TR/WebIDL-1/</a>
+   <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. <a href="https://heycam.github.io/webidl/">Web IDL</a>. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
@@ -7915,175 +7875,175 @@ browsing context’s Window Proxy object as defined in <a href="http://dev.w3.or
    <dd>N. Kano. Developing International Software for Windows 95 and Windows NT: A Handbook for International Software Design. 1995. 
    <dt id="biblio-editing">[Editing]
    <dd>A. Gregor. <a href="https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html">HTML Editing APIs</a>. URL: <a href="https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html">https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html</a>
-   <dt id="biblio-html40">[HTML40]
-   <dd>Dave Raggett; Arnaud Le Hors; Ian Jacobs. <a href="https://www.w3.org/TR/html40">HTML 4.0 Recommendation</a>. 24 April 1998. REC. URL: <a href="https://www.w3.org/TR/html40">https://www.w3.org/TR/html40</a>
+   <dt id="biblio-html401">[HTML401]
+   <dd>Dave Raggett; Arnaud Le Hors; Ian Jacobs. <a href="https://www.w3.org/TR/html401">HTML 4.01 Specification</a>. 24 December 1999. REC. URL: <a href="https://www.w3.org/TR/html401">https://www.w3.org/TR/html401</a>
    <dt id="biblio-rfc20">[RFC20]
    <dd>V.G. Cerf. <a href="https://tools.ietf.org/html/rfc20">ASCII format for network interchange</a>. October 1969. Internet Standard. URL: <a href="https://tools.ietf.org/html/rfc20">https://tools.ietf.org/html/rfc20</a>
    <dt id="biblio-uaag20">[UAAG20]
-   <dd>James Allan; et al. <a href="https://www.w3.org/TR/UAAG20/">User Agent Accessibility Guidelines (UAAG) 2.0</a>. 15 December 2015. NOTE. URL: <a href="https://www.w3.org/TR/UAAG20/">https://www.w3.org/TR/UAAG20/</a>
+   <dd>James Allan; et al. <a href="https://www.w3.org/TR/UAAG20/">User Agent Accessibility Guidelines (UAAG) 2.0</a>. URL: <a href="https://www.w3.org/TR/UAAG20/">https://www.w3.org/TR/UAAG20/</a>
    <dt id="biblio-uax15">[UAX15]
-   <dd>Mark Davis; Ken Whistler. <a href="http://www.unicode.org/reports/tr15">Unicode Normalization Forms</a>. 31 August 2012. Unicode Standard Annex #15. URL: <a href="http://www.unicode.org/reports/tr15">http://www.unicode.org/reports/tr15</a>
+   <dd>Mark Davis; Ken Whistler. <a href="http://www.unicode.org/reports/tr15/tr15-44.html">Unicode Normalization Forms</a>. 24 February 2016. Unicode Standard Annex #15. URL: <a href="http://www.unicode.org/reports/tr15/tr15-44.html">http://www.unicode.org/reports/tr15/tr15-44.html</a>
    <dt id="biblio-unicode">[Unicode]
    <dd><a href="http://www.unicode.org/versions/latest/">The Unicode Standard</a>. URL: <a href="http://www.unicode.org/versions/latest/">http://www.unicode.org/versions/latest/</a>
    <dt id="biblio-us-ascii">[US-ASCII]
    <dd>Coded Character Set - 7-Bit American Standard Code for Information Interchange. 1986. 
    <dt id="biblio-win1252">[WIN1252]
    <dd><a href="http://www.microsoft.com/globaldev/reference/sbcs/1252.htm">Windows 1252 a Coded Character Set - 8-Bit</a>. URL: <a href="http://www.microsoft.com/globaldev/reference/sbcs/1252.htm">http://www.microsoft.com/globaldev/reference/sbcs/1252.htm</a>
-   <dt id="biblio-xforms">[XFORMS]
-   <dd>John Boyer. <a href="https://www.w3.org/TR/xforms/">XForms 1.0 (Third Edition)</a>. 29 October 2007. REC. URL: <a href="https://www.w3.org/TR/xforms/">https://www.w3.org/TR/xforms/</a>
+   <dt id="biblio-xforms11">[XFORMS11]
+   <dd>John Boyer. <a href="https://www.w3.org/TR/xforms11/">XForms 1.1</a>. 20 October 2009. REC. URL: <a href="https://www.w3.org/TR/xforms11/">https://www.w3.org/TR/xforms11/</a>
    <dt id="biblio-xml-names11">[XML-Names11]
    <dd>Tim Bray; et al. <a href="https://www.w3.org/TR/xml-names11/">Namespaces in XML 1.1 (Second Edition)</a>. 16 August 2006. REC. URL: <a href="https://www.w3.org/TR/xml-names11/">https://www.w3.org/TR/xml-names11/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl def">[<a class="nv" href="#dom-uievent-uievent">Constructor</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-uievent-uievent-type-eventinitdict-type">type</a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit">UIEventInit</a> <a class="nv" href="#dom-uievent-uievent-type-eventinitdict-eventinitdict">eventInitDict</a>)]
-<span class="kt">interface</span> <a class="nv" href="#uievent">UIEvent</a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event">Event</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a>? <a class="nv" data-readonly="" data-type="Window?" href="#dom-uievent-view">view</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">long</span> <a class="nv" data-readonly="" data-type="long" href="#dom-uievent-detail">detail</a>;
+<pre class="idl highlight def">[<a class="nv" href="#dom-uievent-uievent"><code>Constructor</code></a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-uievent-uievent-type-eventinitdict-type"><code>type</code></a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit">UIEventInit</a> <a class="nv" href="#dom-uievent-uievent-type-eventinitdict-eventinitdict"><code>eventInitDict</code></a>)]
+<span class="kt">interface</span> <a class="nv" href="#uievent"><code>UIEvent</code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event">Event</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a>? <a class="nv" data-readonly="" data-type="Window?" href="#dom-uievent-view"><code>view</code></a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt">long</span></a> <a class="nv" data-readonly="" data-type="long" href="#dom-uievent-detail"><code>detail</code></a>;
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-uieventinit">UIEventInit</a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit">EventInit</a> {
-  <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a>? <a class="nv" data-default="null" data-type="Window? " href="#dom-uieventinit-view">view</a> = <span class="kt">null</span>;
-  <span class="kt">long</span> <a class="nv" data-default="0" data-type="long " href="#dom-uieventinit-detail">detail</a> = 0;
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-uieventinit"><code>UIEventInit</code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit">EventInit</a> {
+  <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a>? <a class="nv" data-default="null" data-type="Window? " href="#dom-uieventinit-view"><code>view</code></a> = <span class="kt">null</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt">long</span></a> <a class="nv" data-default="0" data-type="long " href="#dom-uieventinit-detail"><code>detail</code></a> = 0;
 };
 
-[<a class="nv" href="#dom-focusevent-focusevent">Constructor</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-focusevent-focusevent-type-eventinitdict-type">type</a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-focuseventinit">FocusEventInit</a> <a class="nv" href="#dom-focusevent-focusevent-type-eventinitdict-eventinitdict">eventInitDict</a>)]
-<span class="kt">interface</span> <a class="nv" href="#focusevent">FocusEvent</a> : <a class="n" data-link-type="idl-name" href="#uievent">UIEvent</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <a class="nv" data-readonly="" data-type="EventTarget?" href="#dom-focusevent-relatedtarget">relatedTarget</a>;
+[<a class="nv" href="#dom-focusevent-focusevent"><code>Constructor</code></a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-focusevent-focusevent-type-eventinitdict-type"><code>type</code></a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-focuseventinit">FocusEventInit</a> <a class="nv" href="#dom-focusevent-focusevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code></a>)]
+<span class="kt">interface</span> <a class="nv" href="#focusevent"><code>FocusEvent</code></a> : <a class="n" data-link-type="idl-name" href="#uievent">UIEvent</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <a class="nv" data-readonly="" data-type="EventTarget?" href="#dom-focusevent-relatedtarget"><code>relatedTarget</code></a>;
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-focuseventinit">FocusEventInit</a> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit">UIEventInit</a> {
-  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <a class="nv" data-default="null" data-type="EventTarget? " href="#dom-focuseventinit-relatedtarget">relatedTarget</a> = <span class="kt">null</span>;
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-focuseventinit"><code>FocusEventInit</code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit">UIEventInit</a> {
+  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <a class="nv" data-default="null" data-type="EventTarget? " href="#dom-focuseventinit-relatedtarget"><code>relatedTarget</code></a> = <span class="kt">null</span>;
 };
 
-[<a class="nv" href="#dom-mouseevent-mouseevent">Constructor</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-mouseevent-mouseevent-type-eventinitdict-type">type</a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-mouseeventinit">MouseEventInit</a> <a class="nv" href="#dom-mouseevent-mouseevent-type-eventinitdict-eventinitdict">eventInitDict</a>)]
-<span class="kt">interface</span> <a class="nv" href="#mouseevent">MouseEvent</a> : <a class="n" data-link-type="idl-name" href="#uievent">UIEvent</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="#dom-mouseevent-screenx">screenX</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="#dom-mouseevent-screeny">screenY</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="#dom-mouseevent-clientx">clientX</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="#dom-mouseevent-clienty">clientY</a>;
+[<a class="nv" href="#dom-mouseevent-mouseevent"><code>Constructor</code></a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-mouseevent-mouseevent-type-eventinitdict-type"><code>type</code></a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-mouseeventinit">MouseEventInit</a> <a class="nv" href="#dom-mouseevent-mouseevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code></a>)]
+<span class="kt">interface</span> <a class="nv" href="#mouseevent"><code>MouseEvent</code></a> : <a class="n" data-link-type="idl-name" href="#uievent">UIEvent</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="#dom-mouseevent-screenx">screenX</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="#dom-mouseevent-screeny">screenY</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="#dom-mouseevent-clientx">clientX</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="#dom-mouseevent-clienty">clientY</a>;
 
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-mouseevent-ctrlkey">ctrlKey</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-mouseevent-shiftkey">shiftKey</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-mouseevent-altkey">altKey</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-mouseevent-metakey">metaKey</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-mouseevent-ctrlkey">ctrlKey</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-mouseevent-shiftkey">shiftKey</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-mouseevent-altkey">altKey</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-mouseevent-metakey">metaKey</a>;
 
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="short" href="#dom-mouseevent-button">button</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned short" href="#dom-mouseevent-buttons">buttons</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-short"><span class="kt">short</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="short" href="#dom-mouseevent-button">button</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short"><span class="kt">unsigned</span> <span class="kt">short</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned short" href="#dom-mouseevent-buttons">buttons</a>;
 
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="EventTarget?" href="#dom-mouseevent-relatedtarget">relatedTarget</a>;
 
-  <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="method" href="#dom-mouseevent-getmodifierstate">getModifierState</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-mouseevent-getmodifierstate-keyarg-keyarg">keyArg</a>);
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="method" href="#dom-mouseevent-getmodifierstate">getModifierState</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-mouseevent-getmodifierstate-keyarg-keyarg"><code>keyArg</code></a>);
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-mouseeventinit">MouseEventInit</a> : <a class="n" data-link-type="idl-name" href="#dictdef-eventmodifierinit">EventModifierInit</a> {
-  <span class="kt">long</span> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-screenx">screenX</a> = 0;
-  <span class="kt">long</span> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-screeny">screenY</a> = 0;
-  <span class="kt">long</span> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-clientx">clientX</a> = 0;
-  <span class="kt">long</span> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-clienty">clientY</a> = 0;
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-mouseeventinit"><code>MouseEventInit</code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-eventmodifierinit">EventModifierInit</a> {
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt">long</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-screenx">screenX</a> = 0;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt">long</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-screeny">screenY</a> = 0;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt">long</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-clientx">clientX</a> = 0;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><span class="kt">long</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-clienty">clientY</a> = 0;
 
-  <span class="kt">short</span> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="short " href="#dom-mouseeventinit-button">button</a> = 0;
-  <span class="kt">unsigned</span> <span class="kt">short</span> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned short " href="#dom-mouseeventinit-buttons">buttons</a> = 0;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-short"><span class="kt">short</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="short " href="#dom-mouseeventinit-button">button</a> = 0;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short"><span class="kt">unsigned</span> <span class="kt">short</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned short " href="#dom-mouseeventinit-buttons">buttons</a> = 0;
   <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>? <a class="nv idl-code" data-default="null" data-link-type="dict-member" data-type="EventTarget? " href="#dom-mouseeventinit-relatedtarget">relatedTarget</a> = <span class="kt">null</span>;
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-eventmodifierinit">EventModifierInit</a> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit">UIEventInit</a> {
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-ctrlkey">ctrlKey</a> = <span class="kt">false</span>;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-shiftkey">shiftKey</a> = <span class="kt">false</span>;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-altkey">altKey</a> = <span class="kt">false</span>;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-metakey">metaKey</a> = <span class="kt">false</span>;
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-eventmodifierinit"><code>EventModifierInit</code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit">UIEventInit</a> {
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-ctrlkey">ctrlKey</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-shiftkey">shiftKey</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-altkey">altKey</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-metakey">metaKey</a> = <span class="kt">false</span>;
 
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifieraltgraph">modifierAltGraph</a> = <span class="kt">false</span>;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiercapslock">modifierCapsLock</a> = <span class="kt">false</span>;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierfn">modifierFn</a> = <span class="kt">false</span>;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierfnlock">modifierFnLock</a> = <span class="kt">false</span>;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierhyper">modifierHyper</a> = <span class="kt">false</span>;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiernumlock">modifierNumLock</a> = <span class="kt">false</span>;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierscrolllock">modifierScrollLock</a> = <span class="kt">false</span>;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiersuper">modifierSuper</a> = <span class="kt">false</span>;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiersymbol">modifierSymbol</a> = <span class="kt">false</span>;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiersymbollock">modifierSymbolLock</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifieraltgraph">modifierAltGraph</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiercapslock">modifierCapsLock</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierfn">modifierFn</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierfnlock">modifierFnLock</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierhyper">modifierHyper</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiernumlock">modifierNumLock</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierscrolllock">modifierScrollLock</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiersuper">modifierSuper</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiersymbol">modifierSymbol</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiersymbollock">modifierSymbolLock</a> = <span class="kt">false</span>;
 };
 
-[<a class="nv" href="#dom-wheelevent-wheelevent">Constructor</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-wheelevent-wheelevent-type-eventinitdict-type">type</a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-wheeleventinit">WheelEventInit</a> <a class="nv" href="#dom-wheelevent-wheelevent-type-eventinitdict-eventinitdict">eventInitDict</a>)]
-<span class="kt">interface</span> <a class="nv" href="#wheelevent">WheelEvent</a> : <a class="n" data-link-type="idl-name" href="#mouseevent">MouseEvent</a> {
+[<a class="nv" href="#dom-wheelevent-wheelevent"><code>Constructor</code></a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-wheelevent-wheelevent-type-eventinitdict-type"><code>type</code></a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-wheeleventinit">WheelEventInit</a> <a class="nv" href="#dom-wheelevent-wheelevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code></a>)]
+<span class="kt">interface</span> <a class="nv" href="#wheelevent"><code>WheelEvent</code></a> : <a class="n" data-link-type="idl-name" href="#mouseevent">MouseEvent</a> {
   // DeltaModeCode
-  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-wheelevent-dom_delta_pixel">DOM_DELTA_PIXEL</a> = 0x00;
-  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-wheelevent-dom_delta_line">DOM_DELTA_LINE</a>  = 0x01;
-  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-wheelevent-dom_delta_page">DOM_DELTA_PAGE</a>  = 0x02;
+  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-wheelevent-dom_delta_pixel">DOM_DELTA_PIXEL</a> = 0x00;
+  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-wheelevent-dom_delta_line">DOM_DELTA_LINE</a>  = 0x01;
+  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-wheelevent-dom_delta_page">DOM_DELTA_PAGE</a>  = 0x02;
 
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">double</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="double" href="#dom-wheelevent-deltax">deltaX</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">double</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="double" href="#dom-wheelevent-deltay">deltaY</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">double</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="double" href="#dom-wheelevent-deltaz">deltaZ</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-wheelevent-deltamode">deltaMode</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="double" href="#dom-wheelevent-deltax">deltaX</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="double" href="#dom-wheelevent-deltay">deltaY</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="double" href="#dom-wheelevent-deltaz">deltaZ</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-wheelevent-deltamode">deltaMode</a>;
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-wheeleventinit">WheelEventInit</a> : <a class="n" data-link-type="idl-name" href="#dictdef-mouseeventinit">MouseEventInit</a> {
-  <span class="kt">double</span> <a class="nv idl-code" data-default="0.0" data-link-type="dict-member" data-type="double " href="#dom-wheeleventinit-deltax">deltaX</a> = 0.0;
-  <span class="kt">double</span> <a class="nv idl-code" data-default="0.0" data-link-type="dict-member" data-type="double " href="#dom-wheeleventinit-deltay">deltaY</a> = 0.0;
-  <span class="kt">double</span> <a class="nv idl-code" data-default="0.0" data-link-type="dict-member" data-type="double " href="#dom-wheeleventinit-deltaz">deltaZ</a> = 0.0;
-  <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned long " href="#dom-wheeleventinit-deltamode">deltaMode</a> = 0;
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-wheeleventinit"><code>WheelEventInit</code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-mouseeventinit">MouseEventInit</a> {
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <a class="nv idl-code" data-default="0.0" data-link-type="dict-member" data-type="double " href="#dom-wheeleventinit-deltax">deltaX</a> = 0.0;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <a class="nv idl-code" data-default="0.0" data-link-type="dict-member" data-type="double " href="#dom-wheeleventinit-deltay">deltaY</a> = 0.0;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><span class="kt">double</span></a> <a class="nv idl-code" data-default="0.0" data-link-type="dict-member" data-type="double " href="#dom-wheeleventinit-deltaz">deltaZ</a> = 0.0;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned long " href="#dom-wheeleventinit-deltamode">deltaMode</a> = 0;
 };
 
-[<a class="nv" href="#dom-inputevent-inputevent">Constructor</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-inputevent-inputevent-type-eventinitdict-type">type</a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-inputeventinit">InputEventInit</a> <a class="nv" href="#dom-inputevent-inputevent-type-eventinitdict-eventinitdict">eventInitDict</a>)]
-<span class="kt">interface</span> <a class="nv" href="#inputevent">InputEvent</a> : <a class="n" data-link-type="idl-name" href="#uievent">UIEvent</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span>? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString?" href="#dom-inputevent-data">data</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-inputevent-iscomposing">isComposing</a>;
+[<a class="nv" href="#dom-inputevent-inputevent"><code>Constructor</code></a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-inputevent-inputevent-type-eventinitdict-type"><code>type</code></a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-inputeventinit">InputEventInit</a> <a class="nv" href="#dom-inputevent-inputevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code></a>)]
+<span class="kt">interface</span> <a class="nv" href="#inputevent"><code>InputEvent</code></a> : <a class="n" data-link-type="idl-name" href="#uievent">UIEvent</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a>? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString?" href="#dom-inputevent-data">data</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-inputevent-iscomposing">isComposing</a>;
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-inputeventinit">InputEventInit</a> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit">UIEventInit</a> {
-  <span class="kt">DOMString</span>? <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString? " href="#dom-inputeventinit-data">data</a> = "";
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-inputeventinit-iscomposing">isComposing</a> = <span class="kt">false</span>;
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-inputeventinit"><code>InputEventInit</code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit">UIEventInit</a> {
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a>? <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString? " href="#dom-inputeventinit-data">data</a> = "";
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-inputeventinit-iscomposing">isComposing</a> = <span class="kt">false</span>;
 };
 
-[<a class="nv" href="#dom-keyboardevent-keyboardevent">Constructor</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-keyboardevent-keyboardevent-type-eventinitdict-type">type</a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-keyboardeventinit">KeyboardEventInit</a> <a class="nv" href="#dom-keyboardevent-keyboardevent-type-eventinitdict-eventinitdict">eventInitDict</a>)]
-<span class="kt">interface</span> <a class="nv" href="#keyboardevent">KeyboardEvent</a> : <a class="n" data-link-type="idl-name" href="#uievent">UIEvent</a> {
+[<a class="nv" href="#dom-keyboardevent-keyboardevent"><code>Constructor</code></a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-keyboardevent-keyboardevent-type-eventinitdict-type"><code>type</code></a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-keyboardeventinit">KeyboardEventInit</a> <a class="nv" href="#dom-keyboardevent-keyboardevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code></a>)]
+<span class="kt">interface</span> <a class="nv" href="#keyboardevent"><code>KeyboardEvent</code></a> : <a class="n" data-link-type="idl-name" href="#uievent">UIEvent</a> {
   // KeyLocationCode
-  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_standard">DOM_KEY_LOCATION_STANDARD</a> = 0x00;
-  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_left">DOM_KEY_LOCATION_LEFT</a> = 0x01;
-  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_right">DOM_KEY_LOCATION_RIGHT</a> = 0x02;
-  <span class="kt">const</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_numpad">DOM_KEY_LOCATION_NUMPAD</a> = 0x03;
+  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_standard">DOM_KEY_LOCATION_STANDARD</a> = 0x00;
+  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_left">DOM_KEY_LOCATION_LEFT</a> = 0x01;
+  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_right">DOM_KEY_LOCATION_RIGHT</a> = 0x02;
+  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_numpad">DOM_KEY_LOCATION_NUMPAD</a> = 0x03;
 
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-keyboardevent-key">key</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-keyboardevent-code">code</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-keyboardevent-location">location</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-keyboardevent-key">key</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-keyboardevent-code">code</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-keyboardevent-location">location</a>;
 
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-ctrlkey">ctrlKey</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-shiftkey">shiftKey</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-altkey">altKey</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-metakey">metaKey</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-ctrlkey">ctrlKey</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-shiftkey">shiftKey</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-altkey">altKey</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-metakey">metaKey</a>;
 
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-repeat">repeat</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-iscomposing">isComposing</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-repeat">repeat</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-iscomposing">isComposing</a>;
 
-  <span class="kt">boolean</span> <a class="nv idl-code" data-link-type="method" href="#dom-keyboardevent-getmodifierstate">getModifierState</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-keyboardevent-getmodifierstate-keyarg-keyarg">keyArg</a>);
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="method" href="#dom-keyboardevent-getmodifierstate">getModifierState</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-keyboardevent-getmodifierstate-keyarg-keyarg"><code>keyArg</code></a>);
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-keyboardeventinit">KeyboardEventInit</a> : <a class="n" data-link-type="idl-name" href="#dictdef-eventmodifierinit">EventModifierInit</a> {
-  <span class="kt">DOMString</span> <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-keyboardeventinit-key">key</a> = "";
-  <span class="kt">DOMString</span> <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-keyboardeventinit-code">code</a> = "";
-  <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned long " href="#dom-keyboardeventinit-location">location</a> = 0;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-keyboardeventinit-repeat">repeat</a> = <span class="kt">false</span>;
-  <span class="kt">boolean</span> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-keyboardeventinit-iscomposing">isComposing</a> = <span class="kt">false</span>;
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-keyboardeventinit"><code>KeyboardEventInit</code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-eventmodifierinit">EventModifierInit</a> {
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-keyboardeventinit-key">key</a> = "";
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-keyboardeventinit-code">code</a> = "";
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned long " href="#dom-keyboardeventinit-location">location</a> = 0;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-keyboardeventinit-repeat">repeat</a> = <span class="kt">false</span>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-keyboardeventinit-iscomposing">isComposing</a> = <span class="kt">false</span>;
 };
 
-[<a class="nv" href="#dom-compositionevent-compositionevent">Constructor</a>(<span class="kt">DOMString</span> <a class="nv" href="#dom-compositionevent-compositionevent-type-eventinitdict-type">type</a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-compositioneventinit">CompositionEventInit</a> <a class="nv" href="#dom-compositionevent-compositionevent-type-eventinitdict-eventinitdict">eventInitDict</a>)]
-<span class="kt">interface</span> <a class="nv" href="#compositionevent">CompositionEvent</a> : <a class="n" data-link-type="idl-name" href="#uievent">UIEvent</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-compositionevent-data">data</a>;
+[<a class="nv" href="#dom-compositionevent-compositionevent"><code>Constructor</code></a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-compositionevent-compositionevent-type-eventinitdict-type"><code>type</code></a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-compositioneventinit">CompositionEventInit</a> <a class="nv" href="#dom-compositionevent-compositionevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code></a>)]
+<span class="kt">interface</span> <a class="nv" href="#compositionevent"><code>CompositionEvent</code></a> : <a class="n" data-link-type="idl-name" href="#uievent">UIEvent</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-compositionevent-data">data</a>;
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-compositioneventinit">CompositionEventInit</a> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit">UIEventInit</a> {
-  <span class="kt">DOMString</span> <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-compositioneventinit-data">data</a> = "";
+<span class="kt">dictionary</span> <a class="nv" href="#dictdef-compositioneventinit"><code>CompositionEventInit</code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit">UIEventInit</a> {
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-compositioneventinit-data">data</a> = "";
 };
 
 <span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="#uievent">UIEvent</a> {
   // The following support legacy user agents
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-uievent-which">which</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-uievent-which">which</a>;
 };
 
 <span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="#keyboardevent">KeyboardEvent</a> {
   // The following support legacy user agents
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-keyboardevent-charcode">charCode</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unsigned</span> <span class="kt">long</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-keyboardevent-keycode">keyCode</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-keyboardevent-charcode">charCode</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-keyboardevent-keycode">keyCode</a>;
 };
 
 </pre>
@@ -9235,8 +9195,7 @@ browsing context’s Window Proxy object as defined in <a href="http://dev.w3.or
     <li><a href="#ref-for-dom-keyboardevent-repeat-3">4.6.3. Keyboard Event Order</a>
     <li><a href="#ref-for-dom-keyboardevent-repeat-4">4.6.4.1. keydown</a>
     <li><a href="#ref-for-dom-keyboardevent-repeat-5">4.6.4.2. keyup</a>
-    <li><a href="#ref-for-dom-keyboardevent-repeat-6">6.1.4. Initializers for interface KeyboardEvent</a>
-    <li><a href="#ref-for-dom-keyboardevent-repeat-7">8.3.1.1. keypress</a>
+    <li><a href="#ref-for-dom-keyboardevent-repeat-6">8.3.1.1. keypress</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-keyboardevent-iscomposing">

--- a/sections/event-types.txt
+++ b/sections/event-types.txt
@@ -513,7 +513,7 @@ events.
 
 <h3 id="events-mouseevents">Mouse Events</h3>
 
-	The mouse event module originates from the [[HTML40]] <code>onclick</code>,
+	The mouse event module originates from the [[HTML401]] <code>onclick</code>,
 	<code>ondblclick</code>, <code>onmousedown</code>, <code>onmouseup</code>,
 	<code>onmouseover</code>, <code>onmousemove</code>, and
 	<code>onmouseout</code> attributes. This event module is specifically

--- a/sections/legacy-event-initializers.txt
+++ b/sections/legacy-event-initializers.txt
@@ -307,7 +307,16 @@ described in this Appendix.
 		<pre class="idl-ignore" data-no-idl data-highlight="webidl">
 		partial interface KeyboardEvent {
 			// Originally introduced (and deprecated) in this specification
-			void initKeyboardEvent();
+			void initKeyboardEvent(DOMString typeArg,
+                             optional boolean bubblesArg = false,
+                             optional boolean cancelableArg = false,
+                             optional Window? viewArg = null,
+                             optional DOMString keyArg = "",
+                             optional unsigned long locationArg = 0,
+                             optional boolean ctrlKey = false,
+                             optional boolean altKey = false,
+                             optional boolean shiftKey = false,
+                             optional boolean metaKey = false);
 		};
 		</pre>
 
@@ -353,22 +362,24 @@ described in this Appendix.
 						Specifies {{KeyboardEvent/location}}.
 					</dd>
 
-					<dt>DOMString modifiersListArg</dt>
+					<dt>boolean ctrlKey</dt>
 					<dd>
-						A <a><em>white space</em></a> separated list of modifier
-						key values to be activated on this object. As an
-						example, <code>"Control Alt"</code> marks the
-						KEYCAP{Control} and KEYCAP{Alt} modifiers as activated.
+						Specifies whether the Control key modifier is active.
 					</dd>
 
-					<dt>boolean repeat</dt>
+					<dt>boolean altKey</dt>
 					<dd>
-						Specifies whether the key event is repeating. See {{KeyboardEvent/repeat}}.
+						Specifies whether the Alt key modifier is active.
 					</dd>
 
-					<dt>DOMString locale</dt>
+					<dt>boolean shiftKey</dt>
 					<dd>
-						Specifies the <code>locale</code> attribute of the KeyboardEvent.
+						Specifies whether the Shift key modifier is active.
+					</dd>
+
+					<dt>boolean metaKey</dt>
+					<dd>
+						Specifies whether the Meta key modifier is active.
 					</dd>
 				</dl>
 			</dd>

--- a/sections/legacy-event-types.txt
+++ b/sections/legacy-event-types.txt
@@ -141,7 +141,7 @@ completeness.
 		<div class="example">
 		<p>
 		The EVENT{DOMActivate} <a>event type</a> is REQUIRED to be supported for
-		XForms [[XFORMS]], which is intended for implementation within a <a>host
+		XForms [[XFORMS11]], which is intended for implementation within a <a>host
 		language</a>. In a scenario where a plugin or script-based
 		implementation of XForms is intended for installation in a native
 		implementation of this specification which does not support the


### PR DESCRIPTION
Gecko is the only UA that doesn't implement initKeyboardEvent, and is
looking to implement it to improve interoperability.  However, the
parameter list in Blink and WebKit differs from the list in the spec,
which seemingly matches IE.  We would like to implement the Blink/WebKit
version because we believe it would be more compatible, so we would like
the spec to change to match it.  This will also require only Edge to
change its existing implementation instead of both Blink and WebKit, so
it will be easier to achieve interoperability.  (Assuming Edge's
implementation matches Microsoft documentation.)

The parameters are taken from Blink's implementation, except that the
first parameter is left mandatory although in Blink it's optional.
Gecko tried implementing the method with all parameters mandatory but
had to revert it because of incompatibility.  WebKit adds one more
parameter "altGraphKey" that I didn't put in the spec.

References:

  Microsoft docs: https://msdn.microsoft.com/en-us/library/ff975297(v=vs.85).aspx
  Blink IDL: https://src.chromium.org/viewvc/blink/trunk/Source/core/events/KeyboardEvent.idl?revision=198345#l43
  WebKit IDL: https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/dom/KeyboardEvent.idl?rev=209895#L52
  Mozilla bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1387828

I also updated the HTML40 and XFORMS references to HTML401 and XFORMS11
to silence bikeshed errors that they were obsolete.

Related to #112.