### PR TITLE
fix hide of column 'proposed'

### DIFF
--- a/tools/key-event-viewer.js
+++ b/tools/key-event-viewer.js
@@ -239,7 +239,7 @@ function addEvent(eventinfo) {
 	addTableCellBoolean(row, eventinfo["isComposing"], "uievents");
 	addTableCellText(row, eventinfo["inputType"], "uievents");
 	addTableCellText(row, eventinfo["data"], "uievents");
-	addTableCellText(row, eventinfo["locale"], "uievents");
+	addTableCellText(row, eventinfo["locale"], "proposed");
 	addInputCell(row);
 }
 


### PR DESCRIPTION
the value of the last argument must be ``proposed`` or all fields inside the table body of this column stays visible when the ``proposed`` column is hidden.