### PR TITLE
single character typo fix

### DIFF
--- a/sections/architecture.txt
+++ b/sections/architecture.txt
@@ -157,7 +157,7 @@ of the DOM event architecture</em>
 <h3 id="event-flow-activation">Activation triggers and behavior</h3>
 
     Certain <a>event targets</a> (such as a link or button element) may have
-    associated <a>activation behavior</a> (such a following a link) that
+    associated <a>activation behavior</a> (such as following a link) that
     implementations perform in response to an <em><a>activation
     trigger</a></em> (such as clicking a link).
 


### PR DESCRIPTION
`(such a following a link)` 
changed to 
`(such as following a link)`