### PR TITLE
Fix link for `key attribute value`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -32,7 +32,7 @@ urlPrefix: http://w3c.github.io/selection-api/#widl-Window-getSelection-Selectio
 	text: getSelection()
 url: http://www.w3.org/TR/2004/REC-xml-20040204/#NT-S; type: dfn;
     text: white space
-url: http://www.w3.org/TR/uievents/#; type: dfn; spec: uievents-key;
+url: https://www.w3.org/TR/uievents-key/#key-attribute-value; type: dfn; spec: uievents-key;
 	text: key attribute value
 url: https://www.w3.org/TR/uievents-key/#keys-modifier; type: dfn; spec: uievents-key;
 	text: modifier keys table


### PR DESCRIPTION
There is a link to `key attribute value` in description of [`KeyboardEvent.key`](https://www.w3.org/TR/uievents/#dom-keyboardevent-key). However currently this link leads to the same page (https://www.w3.org/TR/uievents/). This pull request fixes this link.