### PR TITLE
Update index.html with the latest bikeshed

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,9 +8,9 @@
   <link href="../csslogo.ico" rel="shortcut icon" type="image/x-icon">
   <link href="styles.css" rel="stylesheet" type="text/css">
   <link href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED" rel="stylesheet" type="text/css">
-  <meta content="Bikeshed version eef4acd901f774f3d130c245844f8ea23319c1b2" name="generator">
+  <meta content="Bikeshed version b43aa594f5014ff14748da1aace9afaa73d2b3e6" name="generator">
   <link href="http://www.w3.org/TR/uievents/" rel="canonical">
-  <meta content="514288afbb3f71023f468d455feb353490753029" name="document-revision">
+  <meta content="a6c23519703ea7c2b62af9e161e39fd799c2eaae" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -160,105 +160,105 @@ pre .property::before, pre .property::after {
 }</style>
 <style>/* style-dfn-panel */
 
-        .dfn-panel {
-            position: absolute;
-            z-index: 35;
-            height: auto;
-            width: -webkit-fit-content;
-            width: fit-content;
-            max-width: 300px;
-            max-height: 500px;
-            overflow: auto;
-            padding: 0.5em 0.75em;
-            font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
-            background: #DDDDDD;
-            color: black;
-            border: outset 0.2em;
-        }
-        .dfn-panel:not(.on) { display: none; }
-        .dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
-        .dfn-panel > b { display: block; }
-        .dfn-panel a { color: black; }
-        .dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
-        .dfn-panel > b + b { margin-top: 0.25em; }
-        .dfn-panel ul { padding: 0; }
-        .dfn-panel li { list-style: inside; }
-        .dfn-panel.activated {
-            display: inline-block;
-            position: fixed;
-            left: .5em;
-            bottom: 2em;
-            margin: 0 auto;
-            max-width: calc(100vw - 1.5em - .4em - .5em);
-            max-height: 30vh;
-        }
+.dfn-panel {
+    position: absolute;
+    z-index: 35;
+    height: auto;
+    width: -webkit-fit-content;
+    width: fit-content;
+    max-width: 300px;
+    max-height: 500px;
+    overflow: auto;
+    padding: 0.5em 0.75em;
+    font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
+    background: #DDDDDD;
+    color: black;
+    border: outset 0.2em;
+}
+.dfn-panel:not(.on) { display: none; }
+.dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
+.dfn-panel > b { display: block; }
+.dfn-panel a { color: black; }
+.dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
+.dfn-panel > b + b { margin-top: 0.25em; }
+.dfn-panel ul { padding: 0; }
+.dfn-panel li { list-style: inside; }
+.dfn-panel.activated {
+    display: inline-block;
+    position: fixed;
+    left: .5em;
+    bottom: 2em;
+    margin: 0 auto;
+    max-width: calc(100vw - 1.5em - .4em - .5em);
+    max-height: 30vh;
+}
 
-        .dfn-paneled { cursor: pointer; }
-        </style>
+.dfn-paneled { cursor: pointer; }
+</style>
 <style>/* style-syntax-highlighting */
 pre.idl.highlight { color: #708090; }
 .highlight:not(.idl) { background: hsl(24, 20%, 95%); }
 code.highlight { padding: .1em; border-radius: .3em; }
 pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
-.highlight .c { color: #708090 } /* Comment */
-.highlight .k { color: #990055 } /* Keyword */
-.highlight .l { color: #000000 } /* Literal */
-.highlight .n { color: #0077aa } /* Name */
-.highlight .o { color: #999999 } /* Operator */
-.highlight .p { color: #999999 } /* Punctuation */
-.highlight .cm { color: #708090 } /* Comment.Multiline */
-.highlight .cp { color: #708090 } /* Comment.Preproc */
-.highlight .c1 { color: #708090 } /* Comment.Single */
-.highlight .cs { color: #708090 } /* Comment.Special */
-.highlight .kc { color: #990055 } /* Keyword.Constant */
-.highlight .kd { color: #990055 } /* Keyword.Declaration */
-.highlight .kn { color: #990055 } /* Keyword.Namespace */
-.highlight .kp { color: #990055 } /* Keyword.Pseudo */
-.highlight .kr { color: #990055 } /* Keyword.Reserved */
-.highlight .kt { color: #990055 } /* Keyword.Type */
-.highlight .ld { color: #000000 } /* Literal.Date */
-.highlight .m { color: #000000 } /* Literal.Number */
-.highlight .s { color: #a67f59 } /* Literal.String */
-.highlight .na { color: #0077aa } /* Name.Attribute */
-.highlight .nc { color: #0077aa } /* Name.Class */
-.highlight .no { color: #0077aa } /* Name.Constant */
-.highlight .nd { color: #0077aa } /* Name.Decorator */
-.highlight .ni { color: #0077aa } /* Name.Entity */
-.highlight .ne { color: #0077aa } /* Name.Exception */
-.highlight .nf { color: #0077aa } /* Name.Function */
-.highlight .nl { color: #0077aa } /* Name.Label */
-.highlight .nn { color: #0077aa } /* Name.Namespace */
-.highlight .py { color: #0077aa } /* Name.Property */
-.highlight .nt { color: #669900 } /* Name.Tag */
-.highlight .nv { color: #222222 } /* Name.Variable */
-.highlight .ow { color: #999999 } /* Operator.Word */
-.highlight .mb { color: #000000 } /* Literal.Number.Bin */
-.highlight .mf { color: #000000 } /* Literal.Number.Float */
-.highlight .mh { color: #000000 } /* Literal.Number.Hex */
-.highlight .mi { color: #000000 } /* Literal.Number.Integer */
-.highlight .mo { color: #000000 } /* Literal.Number.Oct */
-.highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
-.highlight .sc { color: #a67f59 } /* Literal.String.Char */
-.highlight .sd { color: #a67f59 } /* Literal.String.Doc */
-.highlight .s2 { color: #a67f59 } /* Literal.String.Double */
-.highlight .se { color: #a67f59 } /* Literal.String.Escape */
-.highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
-.highlight .si { color: #a67f59 } /* Literal.String.Interpol */
-.highlight .sx { color: #a67f59 } /* Literal.String.Other */
-.highlight .sr { color: #a67f59 } /* Literal.String.Regex */
-.highlight .s1 { color: #a67f59 } /* Literal.String.Single */
-.highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
-.highlight .vc { color: #0077aa } /* Name.Variable.Class */
-.highlight .vg { color: #0077aa } /* Name.Variable.Global */
-.highlight .vi { color: #0077aa } /* Name.Variable.Instance */
-.highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
+c-[a] { color: #990055 } /* Keyword.Declaration */
+c-[b] { color: #990055 } /* Keyword.Type */
+c-[c] { color: #708090 } /* Comment */
+c-[d] { color: #708090 } /* Comment.Multiline */
+c-[e] { color: #0077aa } /* Name.Attribute */
+c-[f] { color: #669900 } /* Name.Tag */
+c-[g] { color: #222222 } /* Name.Variable */
+c-[k] { color: #990055 } /* Keyword */
+c-[l] { color: #000000 } /* Literal */
+c-[m] { color: #000000 } /* Literal.Number */
+c-[n] { color: #0077aa } /* Name */
+c-[o] { color: #999999 } /* Operator */
+c-[p] { color: #999999 } /* Punctuation */
+c-[s] { color: #a67f59 } /* Literal.String */
+c-[t] { color: #a67f59 } /* Literal.String.Single */
+c-[u] { color: #a67f59 } /* Literal.String.Double */
+c-[cp] { color: #708090 } /* Comment.Preproc */
+c-[c1] { color: #708090 } /* Comment.Single */
+c-[cs] { color: #708090 } /* Comment.Special */
+c-[kc] { color: #990055 } /* Keyword.Constant */
+c-[kn] { color: #990055 } /* Keyword.Namespace */
+c-[kp] { color: #990055 } /* Keyword.Pseudo */
+c-[kr] { color: #990055 } /* Keyword.Reserved */
+c-[ld] { color: #000000 } /* Literal.Date */
+c-[nc] { color: #0077aa } /* Name.Class */
+c-[no] { color: #0077aa } /* Name.Constant */
+c-[nd] { color: #0077aa } /* Name.Decorator */
+c-[ni] { color: #0077aa } /* Name.Entity */
+c-[ne] { color: #0077aa } /* Name.Exception */
+c-[nf] { color: #0077aa } /* Name.Function */
+c-[nl] { color: #0077aa } /* Name.Label */
+c-[nn] { color: #0077aa } /* Name.Namespace */
+c-[py] { color: #0077aa } /* Name.Property */
+c-[ow] { color: #999999 } /* Operator.Word */
+c-[mb] { color: #000000 } /* Literal.Number.Bin */
+c-[mf] { color: #000000 } /* Literal.Number.Float */
+c-[mh] { color: #000000 } /* Literal.Number.Hex */
+c-[mi] { color: #000000 } /* Literal.Number.Integer */
+c-[mo] { color: #000000 } /* Literal.Number.Oct */
+c-[sb] { color: #a67f59 } /* Literal.String.Backtick */
+c-[sc] { color: #a67f59 } /* Literal.String.Char */
+c-[sd] { color: #a67f59 } /* Literal.String.Doc */
+c-[se] { color: #a67f59 } /* Literal.String.Escape */
+c-[sh] { color: #a67f59 } /* Literal.String.Heredoc */
+c-[si] { color: #a67f59 } /* Literal.String.Interpol */
+c-[sx] { color: #a67f59 } /* Literal.String.Other */
+c-[sr] { color: #a67f59 } /* Literal.String.Regex */
+c-[ss] { color: #a67f59 } /* Literal.String.Symbol */
+c-[vc] { color: #0077aa } /* Name.Variable.Class */
+c-[vg] { color: #0077aa } /* Name.Variable.Global */
+c-[vi] { color: #0077aa } /* Name.Variable.Instance */
+c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 </style>
  <body class="h-entry">
   <div class="head">
    <header>
     <p data-fill-with="logo"><a href="https://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"></a> </p>
     <h1>UI Events</h1>
-    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-10-14">14 October 2018</time></span></h2>
+    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2020-02-13">13 February 2020</time></span></h2>
    </header>
    <div data-fill-with="spec-metadata">
     <dl>
@@ -281,15 +281,15 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2018 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" rel="license">permissive document license</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2020 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="https://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" rel="license">permissive document license</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
   <div class="p-summary" data-fill-with="abstract">
    <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
    <p>This specification defines UI Events which extend the DOM Event objects
 
-defined in <a data-link-type="biblio" href="#biblio-dom">[DOM]</a>. UI Events are those typically implemented by visual
-user agents for handling user interaction such as mouse and keyboard input.</p>
+	defined in <a data-link-type="biblio" href="#biblio-dom">[DOM]</a>. UI Events are those typically implemented by visual
+	user agents for handling user interaction such as mouse and keyboard input.</p>
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="status"><span class="content">Status of this document</span></h2>
   <div data-fill-with="status">
@@ -661,28 +661,28 @@ user agents for handling user interaction such as mouse and keyboard input.</p>
         application, or other similar program), conforms to UI Events if it
         supports:</p>
     <ul>
-     <li data-md="">
+     <li data-md>
       <p>the Core module defined in <a data-link-type="biblio" href="#biblio-dom-level-3-core">[DOM-Level-3-Core]</a></p>
-     <li data-md="">
-      <p>the <a href="#event-flow">§3.1 Event dispatch and DOM event flow</a> mechanism</p>
-     <li data-md="">
+     <li data-md>
+      <p>the <a href="#event-flow">§ 3.1 Event dispatch and DOM event flow</a> mechanism</p>
+     <li data-md>
       <p>all the interfaces and events with their associated methods,
 attributes, and semantics defined in this specification with the
 exception of those marked as <a data-link-type="dfn" href="#deprecates" id="ref-for-deprecates">deprecated</a> (a conforming user
 agent MAY implement the deprecated interfaces, events, or APIs for
 backwards compatibility, but is not required to do so in order to be
 conforming)</p>
-     <li data-md="">
+     <li data-md>
       <p>the complete set of <code>key</code> and <code>code</code> values defined in <a data-link-type="biblio" href="#biblio-uievents-key">[UIEvents-Key]</a> and <a data-link-type="biblio" href="#biblio-uievents-code">[UIEvents-Code]</a> (subject to
 platform availability), and</p>
-     <li data-md="">
+     <li data-md>
       <p>all other normative requirements defined in this specification.</p>
     </ul>
     <p>A conforming browser MUST <a data-link-type="dfn" href="#dispatch" id="ref-for-dispatch">dispatch</a> events appropriate to the
         given <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget">EventTarget</a></code> when the conditions defined for that <a data-link-type="dfn" href="#event-type" id="ref-for-event-type">event
         type</a> have been met.</p>
     <p>A browser conforms specifically to UI Events if it implements the
-        interfaces and related <a data-link-type="dfn" href="#event-type" id="ref-for-event-type①">event types</a> specified in <a href="#event-types">§4 Event Types</a>.</p>
+        interfaces and related <a data-link-type="dfn" href="#event-type" id="ref-for-event-type①">event types</a> specified in <a href="#event-types">§ 4 Event Types</a>.</p>
     <p>A conforming browser MUST support scripting, declarative interactivity,
         or some other means of detecting and dispatching events in the manner
         described by this specification, and MUST support the APIs specified for
@@ -691,7 +691,7 @@ platform availability), and</p>
         browser MAY implement features of this specification marked as <a data-link-type="dfn" href="#deprecates" id="ref-for-deprecates①">deprecated</a>, for backwards compatibility with existing content,
         but such implementation is discouraged.</p>
     <p>A conforming browser MAY also support features not found in this
-        specification, but which use the <a href="#event-flow">§3.1 Event dispatch and DOM event flow</a> mechanism, interfaces,
+        specification, but which use the <a href="#event-flow">§ 3.1 Event dispatch and DOM event flow</a> mechanism, interfaces,
         events, or other features defined in this specification, and MAY
         implement additional interfaces and <a data-link-type="dfn" href="#event-type" id="ref-for-event-type③">event types</a> appropriate to
         that implementation. Such features can be later standardized in future
@@ -705,7 +705,7 @@ platform availability), and</p>
         specification <a data-link-type="biblio" href="#biblio-webidl">[WebIDL]</a>.</p>
     <h4 class="heading settled" data-level="1.2.2" id="conf-author-tools"><span class="secno">1.2.2. </span><span class="content">Authoring tools</span><a class="self-link" href="#conf-author-tools"></a></h4>
     <p>A content authoring tool conforms to UI Events if it produces content
-        which uses the <a data-link-type="dfn" href="#event-type" id="ref-for-event-type④">event types</a> and <a href="#event-flow">§3.1 Event dispatch and DOM event flow</a> model, consistent
+        which uses the <a data-link-type="dfn" href="#event-type" id="ref-for-event-type④">event types</a> and <a href="#event-flow">§ 3.1 Event dispatch and DOM event flow</a> model, consistent
         in a manner as defined in this specification.</p>
     <p>A content authoring tool MUST NOT claim conformance to UI Events for
         content it produces which uses features of this specification marked as <a data-link-type="dfn" href="#deprecates" id="ref-for-deprecates②">deprecated</a> in this specification.</p>
@@ -713,7 +713,7 @@ platform availability), and</p>
         a means to use all <a data-link-type="dfn" href="#event-type" id="ref-for-event-type⑤">event types</a> and interfaces appropriate to all <a data-link-type="dfn" href="#host-language" id="ref-for-host-language">host languages</a> in the content document being produced.</p>
     <h4 class="heading settled" data-level="1.2.3" id="conf-authors"><span class="secno">1.2.3. </span><span class="content">Content authors and content</span><a class="self-link" href="#conf-authors"></a></h4>
     <p>A content author creates conforming UI Events content if that
-            content uses the <a data-link-type="dfn" href="#event-type" id="ref-for-event-type⑥">event types</a> and <a href="#event-flow">§3.1 Event dispatch and DOM event flow</a> model,
+            content uses the <a data-link-type="dfn" href="#event-type" id="ref-for-event-type⑥">event types</a> and <a href="#event-flow">§ 3.1 Event dispatch and DOM event flow</a> model,
             consistent in a manner as defined in this specification.</p>
     <p>A content author SHOULD NOT use features of this specification
             marked as <a data-link-type="dfn" href="#deprecates" id="ref-for-deprecates③">deprecated</a>, but SHOULD rely instead upon
@@ -722,12 +722,12 @@ platform availability), and</p>
     <p class="note" role="note"> Content authors are advised to follow best practices as described in <a href="http://www.w3.org/TR/WAI-WEBCONTENT/">accessibility</a> and <a href="http://www.w3.org/standards/techs/i18n">internationalization</a> guideline specifications. </p>
     <h4 class="heading settled" data-level="1.2.4" id="conf-specs"><span class="secno">1.2.4. </span><span class="content">Specifications and host languages</span><a class="self-link" href="#conf-specs"></a></h4>
     <p>A specification or <a data-link-type="dfn" href="#host-language" id="ref-for-host-language①">host language</a> conforms to UI Events if it
-        references and uses the <a href="#event-flow">§3.1 Event dispatch and DOM event flow</a> mechanism, interfaces, events,
+        references and uses the <a href="#event-flow">§ 3.1 Event dispatch and DOM event flow</a> mechanism, interfaces, events,
         or other features defined in <a data-link-type="biblio" href="#biblio-dom">[DOM]</a>, and does not extend
         these features in incompatible ways.</p>
     <p>A specification or <a data-link-type="dfn" href="#host-language" id="ref-for-host-language②">host language</a> conforms specifically to UI
         Events if it references and uses the interfaces and related <a data-link-type="dfn" href="#event-type" id="ref-for-event-type⑧">event
-        types</a> specified in <a href="#event-types">§4 Event Types</a>. A conforming specification MAY
+        types</a> specified in <a href="#event-types">§ 4 Event Types</a>. A conforming specification MAY
         define additional interfaces and <a data-link-type="dfn" href="#event-type" id="ref-for-event-type⑨">event types</a> appropriate to that
         specification, or MAY extend the UI Events interfaces and <a data-link-type="dfn" href="#event-type" id="ref-for-event-type①⓪">event
         types</a> in a manner that does not contradict or conflict with the
@@ -742,17 +742,17 @@ platform availability), and</p>
     <p>This specification follows the <a href="http://www.w3.org/People/Schepers/spec-conventions.html">Proposed W3C Specification Conventions</a>,
 with the following supplemental additions:</p>
     <ul>
-     <li data-md="">
+     <li data-md>
       <p>The <a href="#key-legends"><em>key cap</em></a> printed on a key is shown as <code class="keycap">↓</code>, <code class="keycap">=</code> or <code class="keycap">Q</code>. This is used to refer to a
 key from the user’s perspective without regard for the <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-key" id="ref-for-dom-keyboardevent-key">key</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-code" id="ref-for-dom-keyboardevent-code">code</a></code> values in the
 generated <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent">KeyboardEvent</a></code>.</p>
-     <li data-md="">
+     <li data-md>
       <p>Glyphs representing character are shown as: <code class="glyph">"𣧂"</code>.</p>
-     <li data-md="">
+     <li data-md>
       <p>Unicode character encodings are shown as: <code class="unicode">U+003d</code>.</p>
-     <li data-md="">
+     <li data-md>
       <p>Names of key values generated by a key press (i.e., the value of <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent①">KeyboardEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-key" id="ref-for-dom-keyboardevent-key①">key</a></code>) are shown as: <code class="key">"<a href="http://www.w3.org/TR/uievents-key/#key-ArrowDown">ArrowDown</a>"</code>, <code class="key">"="</code>, <code class="key">"q"</code> or <code class="key">"Q"</code>.</p>
-     <li data-md="">
+     <li data-md>
       <p>Names of key codes associated with the physical keys (i.e., the
 value of <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent②">KeyboardEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-code" id="ref-for-dom-keyboardevent-code①">code</a></code>) are shown as: <code class="code">"<a href="http://www.w3.org/TR/uievents-code/#code-ArrowDown">ArrowDown</a>"</code>, <code class="code">"<a href="http://www.w3.org/TR/uievents-code/#code-Equal">Equal</a>"</code> or <code class="code">"<a href="http://www.w3.org/TR/uievents-code/#code-KeyQ">KeyQ</a>"</code>.</p>
     </ul>
@@ -768,7 +768,7 @@ the person who uses those Web applications in an implementation.</p>
     <p></p>
     <p class="XXX">This is an open issue.</p>
     <p class="warning">This is a warning.</p>
-<pre class="idl-ignore" data-highlight="webidl" data-no-idl="">interface <b>Example</b> {
+<pre class="idl-ignore" data-highlight="webidl" data-no-idl>interface <b>Example</b> {
     // This is an IDL definition.
 };
 </pre>
@@ -804,16 +804,16 @@ of the DOM event architecture</em></p>
     been stopped. For example, if the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-bubbles" id="ref-for-dom-event-bubbles">bubbles</a></code> attribute is set to
     false, the bubble phase will be skipped, and if <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-stoppropagation" id="ref-for-dom-event-stoppropagation">stopPropagation()</a></code> has been called prior to the dispatch, all phases will be skipped.</p>
     <ul>
-     <li data-md="">
+     <li data-md>
       <p>The <strong>capture phase</strong>: The event object propagates
 through the target’s ancestors from the <a data-link-type="dfn" href="#window" id="ref-for-window">Window</a> to the target’s
 parent. This phase is also known as the <em>capturing phase</em>.</p>
-     <li data-md="">
+     <li data-md>
       <p>The <strong>target phase</strong>: The event object arrives at the event
 object’s <a data-link-type="dfn" href="#event-target" id="ref-for-event-target②">event target</a>. This phase is also known as the <em>at-target phase</em>. If the <a data-link-type="dfn" href="#event-type" id="ref-for-event-type①②">event type</a> indicates that the
 event doesn’t bubble, then the event object will halt after completion
 of this phase.</p>
-     <li data-md="">
+     <li data-md>
       <p>The <strong>bubble phase</strong>: The event object propagates through
 the target’s ancestors in reverse order, starting with the target’s
 parent and ending with the <a data-link-type="dfn" href="#window" id="ref-for-window①">Window</a>. This phase is also known as
@@ -912,19 +912,19 @@ the <em>bubbling phase</em>.</p>
     initializing the internal state of the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#event" id="ref-for-event③">Event</a></code> object’s key modifiers:
     specifically, the internal state queried for using the <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate">getModifierState()</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate">getModifierState()</a></code> methods. This section supplements the DOM4 steps for intializing a new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#event" id="ref-for-event④">Event</a></code> object with these optional modifier states.</p>
     <p>For the purposes of constructing a <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent④">KeyboardEvent</a></code>, <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent①">MouseEvent</a></code>, or
-    object derived from these objects using the algorithm below, all <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent⑤">KeyboardEvent</a></code>, <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent②">MouseEvent</a></code>, and derived objects have <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="internal-key-modifier-state">internal key modifier state</dfn> which can be set and
+    object derived from these objects using the algorithm below, all <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent⑤">KeyboardEvent</a></code>, <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent②">MouseEvent</a></code>, and derived objects have <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="internal-key-modifier-state">internal key modifier state</dfn> which can be set and
     retrieved using the <a href="#keys-modifiers">key modifier names</a> described in the <a href="http://www.w3.org/TR/uievents-key/#keys-modifier">Modifier Keys table</a> in <a data-link-type="biblio" href="#biblio-uievents-key">[UIEvents-Key]</a>.</p>
     <p>The following steps supplement the algorithm defined for constructing
     events in DOM4:</p>
     <ul>
-     <li data-md="">
+     <li data-md>
       <p>If the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#event" id="ref-for-event⑤">Event</a></code> being constructed is a <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent⑥">KeyboardEvent</a></code> or <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent③">MouseEvent</a></code> object or an object that derives from either of these,
 and a <code class="idl"><a data-link-type="idl" href="#dictdef-eventmodifierinit" id="ref-for-dictdef-eventmodifierinit">EventModifierInit</a></code> argument was provided to the constructor,
 then run the following sub-steps:</p>
       <ul>
-       <li data-md="">
+       <li data-md>
         <p>For each <code class="idl"><a data-link-type="idl" href="#dictdef-eventmodifierinit" id="ref-for-dictdef-eventmodifierinit①">EventModifierInit</a></code> argument, if the dictionary member
-begins with the string <code>"modifier"</code>, then let the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="modifier-key-name">key modifier name</dfn> be the
+begins with the string <code>"modifier"</code>, then let the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="modifier-key-name">key modifier name</dfn> be the
 dictionary member’s name excluding the prefix <code>"modifier"</code>, and set the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#event" id="ref-for-event⑥">Event</a></code> object’s <a href="#internal-key-modifier-state" id="ref-for-internal-key-modifier-state">internal key modifier state</a> that matches the <a href="#modifier-key-name" id="ref-for-modifier-key-name">key modifier name</a> to the corresponding value.</p>
       </ul>
     </ul>
@@ -949,10 +949,10 @@ events.</p>
     <p class="note" role="note"> For newly defined events, you don’t have to inherit <code class="idl"><a data-link-type="idl" href="#uievent" id="ref-for-uievent②">UIEvent</a></code> interface just
 		because they are related to user interface.  Inherit only when members of <code class="idl"><a data-link-type="idl" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit①">UIEventInit</a></code> make sense to those events. </p>
     <h5 class="heading settled" data-level="4.1.1.1" id="idl-uievent"><span class="secno">4.1.1.1. </span><span class="content">UIEvent</span><a class="self-link" href="#idl-uievent"></a></h5>
-<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="UIEvent" data-dfn-type="constructor" data-export="" data-lt="UIEvent(type, eventInitDict)|UIEvent(type)" id="dom-uievent-uievent"><code>Constructor</code><a class="self-link" href="#dom-uievent-uievent"></a></dfn>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="UIEvent/UIEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-uievent-uievent-type-eventinitdict-type"><code>type</code><a class="self-link" href="#dom-uievent-uievent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit②">UIEventInit</a> <dfn class="nv idl-code" data-dfn-for="UIEvent/UIEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-uievent-uievent-type-eventinitdict-eventinitdict"><code>eventInitDict</code><a class="self-link" href="#dom-uievent-uievent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed">Exposed</a>=<span class="n">Window</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="uievent"><code>UIEvent</code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event" id="ref-for-event⑦">Event</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window②">Window</a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="UIEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="Window?" id="dom-uievent-view"><code>view</code></dfn>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long"><span class="kt">long</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="UIEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="long" id="dom-uievent-detail"><code>detail</code></dfn>;
+<pre class="idl highlight def">[<dfn class="idl-code" data-dfn-for="UIEvent" data-dfn-type="constructor" data-export data-lt="UIEvent(type, eventInitDict)|UIEvent(type)" id="dom-uievent-uievent"><code><c- g>Constructor</c-></code><a class="self-link" href="#dom-uievent-uievent"></a></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="UIEvent/UIEvent(type, eventInitDict)" data-dfn-type="argument" data-export id="dom-uievent-uievent-type-eventinitdict-type"><code><c- g>type</c-></code><a class="self-link" href="#dom-uievent-uievent-type-eventinitdict-type"></a></dfn>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit②"><c- n>UIEventInit</c-></a> <dfn class="idl-code" data-dfn-for="UIEvent/UIEvent(type, eventInitDict)" data-dfn-type="argument" data-export id="dom-uievent-uievent-type-eventinitdict-eventinitdict"><code><c- g>eventInitDict</c-></code><a class="self-link" href="#dom-uievent-uievent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="uievent"><code><c- g>UIEvent</c-></code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event" id="ref-for-event⑦"><c- n>Event</c-></a> {
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window②"><c- n>Window</c-></a>? <dfn class="dfn-paneled idl-code" data-dfn-for="UIEvent" data-dfn-type="attribute" data-export data-readonly data-type="Window?" id="dom-uievent-view"><code><c- g>view</c-></code></dfn>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long"><c- b>long</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="UIEvent" data-dfn-type="attribute" data-export data-readonly data-type="long" id="dom-uievent-detail"><code><c- g>detail</c-></code></dfn>;
 };
 </pre>
     <dl>
@@ -967,9 +967,9 @@ events.</p>
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value①">un-initialized value</a> of this attribute MUST be <code>0</code>.</p>
     </dl>
     <h5 class="heading settled" data-level="4.1.1.2" id="idl-uieventinit"><span class="secno">4.1.1.2. </span><span class="content">UIEventInit</span><a class="self-link" href="#idl-uieventinit"></a></h5>
-<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-uieventinit"><code>UIEventInit</code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit" id="ref-for-dictdef-eventinit">EventInit</a> {
-  <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window③">Window</a>? <dfn class="nv idl-code" data-default="null" data-dfn-for="UIEventInit" data-dfn-type="dict-member" data-export="" data-type="Window? " id="dom-uieventinit-view"><code>view</code><a class="self-link" href="#dom-uieventinit-view"></a></dfn> = <span class="kt">null</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①"><span class="kt">long</span></a> <dfn class="nv idl-code" data-default="0" data-dfn-for="UIEventInit" data-dfn-type="dict-member" data-export="" data-type="long " id="dom-uieventinit-detail"><code>detail</code><a class="self-link" href="#dom-uieventinit-detail"></a></dfn> = 0;
+<pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-uieventinit"><code><c- g>UIEventInit</c-></code></dfn> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit" id="ref-for-dictdef-eventinit"><c- n>EventInit</c-></a> {
+  <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window③"><c- n>Window</c-></a>? <dfn class="idl-code" data-default="null" data-dfn-for="UIEventInit" data-dfn-type="dict-member" data-export data-type="Window? " id="dom-uieventinit-view"><code><c- g>view</c-></code><a class="self-link" href="#dom-uieventinit-view"></a></dfn> = <c- b>null</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①"><c- b>long</c-></a> <dfn class="idl-code" data-default="0" data-dfn-for="UIEventInit" data-dfn-type="dict-member" data-export data-type="long " id="dom-uieventinit-detail"><code><c- g>detail</c-></code><a class="self-link" href="#dom-uieventinit-detail"></a></dfn> = 0;
 };
 </pre>
     <dl>
@@ -986,7 +986,7 @@ events.</p>
     <p>The User Interface event types are listed below.  Some of these events
 		use the <code class="idl"><a data-link-type="idl" href="#uievent" id="ref-for-uievent③">UIEvent</a></code> interface if generated from a user interface, but
 		the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#event" id="ref-for-event⑨">Event</a></code> interface otherwise, as detailed in each event.</p>
-    <h5 class="heading settled" data-level="4.1.2.1" id="event-type-load"><span class="secno">4.1.2.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="load">load</dfn></span><a class="self-link" href="#event-type-load"></a></h5>
+    <h5 class="heading settled" data-level="4.1.2.1" id="event-type-load"><span class="secno">4.1.2.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="load">load</dfn></span><a class="self-link" href="#event-type-load"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -1031,7 +1031,7 @@ events.</p>
 			document (e.g., images) do not include the <a data-link-type="dfn" href="#window" id="ref-for-window⑥">Window</a> in the
 			propagation path in HTML implementations. See <a data-link-type="biblio" href="#biblio-html5">[HTML5]</a> for more
 			information. </p>
-    <h5 class="heading settled" data-level="4.1.2.2" id="event-type-unload"><span class="secno">4.1.2.2. </span><span class="content"><dfn data-dfn-type="dfn" data-noexport="" id="unload">unload<a class="self-link" href="#unload"></a></dfn></span><a class="self-link" href="#event-type-unload"></a></h5>
+    <h5 class="heading settled" data-level="4.1.2.2" id="event-type-unload"><span class="secno">4.1.2.2. </span><span class="content"><dfn data-dfn-type="dfn" data-noexport id="unload">unload<a class="self-link" href="#unload"></a></dfn></span><a class="self-link" href="#event-type-unload"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -1071,7 +1071,7 @@ events.</p>
 			of this event type. If this event type is dispatched,
 			implementations are REQUIRED to dispatch this event at least on
 			the <code>Document</code> node.</p>
-    <h5 class="heading settled" data-level="4.1.2.3" id="event-type-abort"><span class="secno">4.1.2.3. </span><span class="content"><dfn data-dfn-type="dfn" data-noexport="" id="abort">abort<a class="self-link" href="#abort"></a></dfn></span><a class="self-link" href="#event-type-abort"></a></h5>
+    <h5 class="heading settled" data-level="4.1.2.3" id="event-type-abort"><span class="secno">4.1.2.3. </span><span class="content"><dfn data-dfn-type="dfn" data-noexport id="abort">abort<a class="self-link" href="#abort"></a></dfn></span><a class="self-link" href="#event-type-abort"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -1107,7 +1107,7 @@ events.</p>
     <p>A <a data-link-type="dfn" href="#user-agent" id="ref-for-user-agent①⓪">user agent</a> MUST dispatch this event when the loading of a
 			resource has been aborted, such as by a user canceling the load
 			while it is still in progress.</p>
-    <h5 class="heading settled" data-level="4.1.2.4" id="event-type-error"><span class="secno">4.1.2.4. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="error">error</dfn></span><a class="self-link" href="#event-type-error"></a></h5>
+    <h5 class="heading settled" data-level="4.1.2.4" id="event-type-error"><span class="secno">4.1.2.4. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="error">error</dfn></span><a class="self-link" href="#event-type-error"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -1144,7 +1144,7 @@ events.</p>
 			to load, or has been loaded but cannot be interpreted according to
 			its semantics, such as an invalid image, a script execution error,
 			or non-well-formed XML.</p>
-    <h5 class="heading settled" data-level="4.1.2.5" id="event-type-select"><span class="secno">4.1.2.5. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="select">select</dfn></span><a class="self-link" href="#event-type-select"></a></h5>
+    <h5 class="heading settled" data-level="4.1.2.5" id="event-type-select"><span class="secno">4.1.2.5. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="select">select</dfn></span><a class="self-link" href="#event-type-select"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -1193,7 +1193,7 @@ events.</p>
 			deemed appropriate, including text selections outside of form
 			controls, or image or markup selections such as in SVG. </p>
     <h3 class="heading settled" data-level="4.2" id="events-focusevent"><span class="secno">4.2. </span><span class="content">Focus Events</span><a class="self-link" href="#events-focusevent"></a></h3>
-    <p class="note" role="note"> This interface and its associated event types and <a href="#events-focusevent-event-order">§4.2.2 Focus Event Order</a> were designed in accordance to the concepts and guidelines defined in <a href="http://www.w3.org/WAI/UA/2010/ED-UAAG20-20100308/">User Agent Accessibility Guidelines 2.0</a> <a data-link-type="biblio" href="#biblio-uaag20">[UAAG20]</a>,
+    <p class="note" role="note"> This interface and its associated event types and <a href="#events-focusevent-event-order">§ 4.2.2 Focus Event Order</a> were designed in accordance to the concepts and guidelines defined in <a href="http://www.w3.org/WAI/UA/2010/ED-UAAG20-20100308/">User Agent Accessibility Guidelines 2.0</a> <a data-link-type="biblio" href="#biblio-uaag20">[UAAG20]</a>,
 	with particular attention on the <a href="http://www.w3.org/WAI/UA/2010/ED-UAAG20-20100308/#gl-focus-mechanism">focus mechanism</a> and the terms defined in the <a href="http://www.w3.org/WAI/UA/2010/ED-UAAG20-20100308/#def-focus">glossary entry for focus</a>. </p>
     <h4 class="heading settled" data-level="4.2.1" id="interface-focusevent"><span class="secno">4.2.1. </span><span class="content">Interface FocusEvent</span><a class="self-link" href="#interface-focusevent"></a></h4>
     <p class="intro-dom">Introduced in this specification</p>
@@ -1202,9 +1202,9 @@ events.</p>
     <p>To create an instance of the <code class="idl"><a data-link-type="idl" href="#focusevent" id="ref-for-focusevent①">FocusEvent</a></code> interface, use the
 		FocusEvent constructor, passing an optional <code class="idl"><a data-link-type="idl" href="#dictdef-focuseventinit" id="ref-for-dictdef-focuseventinit">FocusEventInit</a></code> dictionary.</p>
     <h5 class="heading settled" data-level="4.2.1.1" id="idl-focusevent"><span class="secno">4.2.1.1. </span><span class="content">FocusEvent</span><a class="self-link" href="#idl-focusevent"></a></h5>
-<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="FocusEvent" data-dfn-type="constructor" data-export="" data-lt="FocusEvent(type, eventInitDict)|FocusEvent(type)" id="dom-focusevent-focusevent"><code>Constructor</code><a class="self-link" href="#dom-focusevent-focusevent"></a></dfn>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="FocusEvent/FocusEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-focusevent-focusevent-type-eventinitdict-type"><code>type</code><a class="self-link" href="#dom-focusevent-focusevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-focuseventinit" id="ref-for-dictdef-focuseventinit①">FocusEventInit</a> <dfn class="nv idl-code" data-dfn-for="FocusEvent/FocusEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-focusevent-focusevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code><a class="self-link" href="#dom-focusevent-focusevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①">Exposed</a>=<span class="n">Window</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="focusevent"><code>FocusEvent</code></dfn> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent①⑨">UIEvent</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget①">EventTarget</a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="FocusEvent" data-dfn-type="attribute" data-export="" data-readonly="" data-type="EventTarget?" id="dom-focusevent-relatedtarget"><code>relatedTarget</code></dfn>;
+<pre class="idl highlight def">[<dfn class="idl-code" data-dfn-for="FocusEvent" data-dfn-type="constructor" data-export data-lt="FocusEvent(type, eventInitDict)|FocusEvent(type)" id="dom-focusevent-focusevent"><code><c- g>Constructor</c-></code><a class="self-link" href="#dom-focusevent-focusevent"></a></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="FocusEvent/FocusEvent(type, eventInitDict)" data-dfn-type="argument" data-export id="dom-focusevent-focusevent-type-eventinitdict-type"><code><c- g>type</c-></code><a class="self-link" href="#dom-focusevent-focusevent-type-eventinitdict-type"></a></dfn>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-focuseventinit" id="ref-for-dictdef-focuseventinit①"><c- n>FocusEventInit</c-></a> <dfn class="idl-code" data-dfn-for="FocusEvent/FocusEvent(type, eventInitDict)" data-dfn-type="argument" data-export id="dom-focusevent-focusevent-type-eventinitdict-eventinitdict"><code><c- g>eventInitDict</c-></code><a class="self-link" href="#dom-focusevent-focusevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="focusevent"><code><c- g>FocusEvent</c-></code></dfn> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent①⑨"><c- n>UIEvent</c-></a> {
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget①"><c- n>EventTarget</c-></a>? <dfn class="dfn-paneled idl-code" data-dfn-for="FocusEvent" data-dfn-type="attribute" data-export data-readonly data-type="EventTarget?" id="dom-focusevent-relatedtarget"><code><c- g>relatedTarget</c-></code></dfn>;
 };
 </pre>
     <dl>
@@ -1216,8 +1216,8 @@ events.</p>
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value②">un-initialized value</a> of this attribute MUST be <code>null</code>.</p>
     </dl>
     <h5 class="heading settled" data-level="4.2.1.2" id="idl-focuseventinit"><span class="secno">4.2.1.2. </span><span class="content">FocusEventInit</span><a class="self-link" href="#idl-focuseventinit"></a></h5>
-<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-focuseventinit"><code>FocusEventInit</code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit③">UIEventInit</a> {
-  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget④">EventTarget</a>? <dfn class="nv dfn-paneled idl-code" data-default="null" data-dfn-for="FocusEventInit" data-dfn-type="dict-member" data-export="" data-type="EventTarget? " id="dom-focuseventinit-relatedtarget"><code>relatedTarget</code></dfn> = <span class="kt">null</span>;
+<pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-focuseventinit"><code><c- g>FocusEventInit</c-></code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit③"><c- n>UIEventInit</c-></a> {
+  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget④"><c- n>EventTarget</c-></a>? <dfn class="dfn-paneled idl-code" data-default="null" data-dfn-for="FocusEventInit" data-dfn-type="dict-member" data-export data-type="EventTarget? " id="dom-focuseventinit-relatedtarget"><code><c- g>relatedTarget</c-></code></dfn> = <c- b>null</c->;
 };
 </pre>
     <dl>
@@ -1277,17 +1277,17 @@ events.</p>
 		document <a data-link-type="dfn" href="#focus" id="ref-for-focus③">focus</a>. There are three distinct focus contexts that are
 		relevant to this discussion:</p>
     <ul>
-     <li data-md="">
+     <li data-md>
       <p>The <em>operating system focus context</em> which MAY be on one of
 many different applications currently running on the computer. One
 of these applications with focus can be a browser.</p>
-     <li data-md="">
+     <li data-md>
       <p>When the browser has focus, the user can switch (such as with the
 tab key) the <em>application focus context</em> among the different
 browser user interface fields (e.g., the Web site location bar, a
 search field, etc.). One of these user interface fields can be the
 document being shown in a tab.</p>
-     <li data-md="">
+     <li data-md>
       <p>When the document itself has focus, the <em>document focus
 context</em> can be set to any of the focusable elements in the
 document.</p>
@@ -1318,7 +1318,7 @@ document.</p>
 		elements to have the current focus.</p>
     <h4 class="heading settled" data-level="4.2.4" id="events-focus-types"><span class="secno">4.2.4. </span><span class="content">Focus Event Types</span><a class="self-link" href="#events-focus-types"></a></h4>
     <p>The Focus event types are listed below.</p>
-    <h5 class="heading settled" data-level="4.2.4.1" id="event-type-blur"><span class="secno">4.2.4.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="blur">blur</dfn></span><a class="self-link" href="#event-type-blur"></a></h5>
+    <h5 class="heading settled" data-level="4.2.4.1" id="event-type-blur"><span class="secno">4.2.4.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="blur">blur</dfn></span><a class="self-link" href="#event-type-blur"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -1360,7 +1360,7 @@ document.</p>
 			before the dispatch of this event type.  This event type is similar
 			to <a data-link-type="dfn" href="#focusout" id="ref-for-focusout②"><code>focusout</code></a>, but is dispatched after focus is shifted, and
 			does not bubble.</p>
-    <h5 class="heading settled" data-level="4.2.4.2" id="event-type-focus"><span class="secno">4.2.4.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="focus">focus</dfn></span><a class="self-link" href="#event-type-focus"></a></h5>
+    <h5 class="heading settled" data-level="4.2.4.2" id="event-type-focus"><span class="secno">4.2.4.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="focus">focus</dfn></span><a class="self-link" href="#event-type-focus"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -1402,7 +1402,7 @@ document.</p>
 			before the dispatch of this event type.  This event type is similar
 			to <a data-link-type="dfn" href="#focusin" id="ref-for-focusin③"><code>focusin</code></a>, but is dispatched after focus is shifted, and
 			does not bubble.</p>
-    <h5 class="heading settled" data-level="4.2.4.3" id="event-type-focusin"><span class="secno">4.2.4.3. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="focusin">focusin</dfn></span><a class="self-link" href="#event-type-focusin"></a></h5>
+    <h5 class="heading settled" data-level="4.2.4.3" id="event-type-focusin"><span class="secno">4.2.4.3. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="focusin">focusin</dfn></span><a class="self-link" href="#event-type-focusin"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -1451,7 +1451,7 @@ document.</p>
 			access to both the element losing focus and the element gaining
 			focus without the use of the <a data-link-type="dfn" href="#blur" id="ref-for-blur②"><code>blur</code></a> or <a data-link-type="dfn" href="#focusout" id="ref-for-focusout③"><code>focusout</code></a> event
 			types. </p>
-    <h5 class="heading settled" data-level="4.2.4.4" id="event-type-focusout"><span class="secno">4.2.4.4. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="focusout">focusout</dfn></span><a class="self-link" href="#event-type-focusout"></a></h5>
+    <h5 class="heading settled" data-level="4.2.4.4" id="event-type-focusout"><span class="secno">4.2.4.4. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="focusout">focusout</dfn></span><a class="self-link" href="#event-type-focusout"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -1512,83 +1512,83 @@ document.</p>
 		as target coordinates exposed by <a data-link-type="dfn" href="#dom-level-0" id="ref-for-dom-level-0">DOM Level 0</a> implementations or
 		other proprietary attributes, e.g., <code>pageX</code>). </p>
     <h5 class="heading settled" data-level="4.3.1.1" id="idl-mouseevent"><span class="secno">4.3.1.1. </span><span class="content">MouseEvent</span><a class="self-link" href="#idl-mouseevent"></a></h5>
-<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="MouseEvent" data-dfn-type="constructor" data-export="" data-lt="MouseEvent(type, eventInitDict)|MouseEvent(type)" id="dom-mouseevent-mouseevent"><code>Constructor</code><a class="self-link" href="#dom-mouseevent-mouseevent"></a></dfn>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="MouseEvent/MouseEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-mouseevent-mouseevent-type-eventinitdict-type"><code>type</code><a class="self-link" href="#dom-mouseevent-mouseevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-mouseeventinit" id="ref-for-dictdef-mouseeventinit①">MouseEventInit</a> <dfn class="nv idl-code" data-dfn-for="MouseEvent/MouseEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-mouseevent-mouseevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code><a class="self-link" href="#dom-mouseevent-mouseevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed②">Exposed</a>=<span class="n">Window</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="mouseevent"><code>MouseEvent</code></dfn> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent②⑧">UIEvent</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long②"><span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="#dom-mouseevent-screenx" id="ref-for-dom-mouseevent-screenx">screenX</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long③"><span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="#dom-mouseevent-screeny" id="ref-for-dom-mouseevent-screeny">screenY</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long④"><span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="#dom-mouseevent-clientx" id="ref-for-dom-mouseevent-clientx①">clientX</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long⑤"><span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="#dom-mouseevent-clienty" id="ref-for-dom-mouseevent-clienty①">clientY</a>;
+<pre class="idl highlight def">[<dfn class="idl-code" data-dfn-for="MouseEvent" data-dfn-type="constructor" data-export data-lt="MouseEvent(type, eventInitDict)|MouseEvent(type)" id="dom-mouseevent-mouseevent"><code><c- g>Constructor</c-></code><a class="self-link" href="#dom-mouseevent-mouseevent"></a></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="MouseEvent/MouseEvent(type, eventInitDict)" data-dfn-type="argument" data-export id="dom-mouseevent-mouseevent-type-eventinitdict-type"><code><c- g>type</c-></code><a class="self-link" href="#dom-mouseevent-mouseevent-type-eventinitdict-type"></a></dfn>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-mouseeventinit" id="ref-for-dictdef-mouseeventinit①"><c- n>MouseEventInit</c-></a> <dfn class="idl-code" data-dfn-for="MouseEvent/MouseEvent(type, eventInitDict)" data-dfn-type="argument" data-export id="dom-mouseevent-mouseevent-type-eventinitdict-eventinitdict"><code><c- g>eventInitDict</c-></code><a class="self-link" href="#dom-mouseevent-mouseevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed②"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="mouseevent"><code><c- g>MouseEvent</c-></code></dfn> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent②⑧"><c- n>UIEvent</c-></a> {
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long②"><c- b>long</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="long" href="#dom-mouseevent-screenx" id="ref-for-dom-mouseevent-screenx"><c- g>screenX</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long③"><c- b>long</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="long" href="#dom-mouseevent-screeny" id="ref-for-dom-mouseevent-screeny"><c- g>screenY</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long④"><c- b>long</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="long" href="#dom-mouseevent-clientx" id="ref-for-dom-mouseevent-clientx①"><c- g>clientX</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long⑤"><c- b>long</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="long" href="#dom-mouseevent-clienty" id="ref-for-dom-mouseevent-clienty①"><c- g>clientY</c-></a>;
 
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-mouseevent-ctrlkey" id="ref-for-dom-mouseevent-ctrlkey">ctrlKey</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-mouseevent-shiftkey" id="ref-for-dom-mouseevent-shiftkey">shiftKey</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-mouseevent-altkey" id="ref-for-dom-mouseevent-altkey">altKey</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-mouseevent-metakey" id="ref-for-dom-mouseevent-metakey">metaKey</a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="boolean" href="#dom-mouseevent-ctrlkey" id="ref-for-dom-mouseevent-ctrlkey"><c- g>ctrlKey</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="boolean" href="#dom-mouseevent-shiftkey" id="ref-for-dom-mouseevent-shiftkey"><c- g>shiftKey</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="boolean" href="#dom-mouseevent-altkey" id="ref-for-dom-mouseevent-altkey"><c- g>altKey</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="boolean" href="#dom-mouseevent-metakey" id="ref-for-dom-mouseevent-metakey"><c- g>metaKey</c-></a>;
 
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-short" id="ref-for-idl-short"><span class="kt">short</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="short" href="#dom-mouseevent-button" id="ref-for-dom-mouseevent-button">button</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short"><span class="kt">unsigned</span> <span class="kt">short</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned short" href="#dom-mouseevent-buttons" id="ref-for-dom-mouseevent-buttons">buttons</a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-short" id="ref-for-idl-short"><c- b>short</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="short" href="#dom-mouseevent-button" id="ref-for-dom-mouseevent-button"><c- g>button</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short"><c- b>unsigned</c-> <c- b>short</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="unsigned short" href="#dom-mouseevent-buttons" id="ref-for-dom-mouseevent-buttons"><c- g>buttons</c-></a>;
 
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget⑤">EventTarget</a>? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="EventTarget?" href="#dom-mouseevent-relatedtarget" id="ref-for-dom-mouseevent-relatedtarget">relatedTarget</a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget⑤"><c- n>EventTarget</c-></a>? <a class="idl-code" data-link-type="attribute" data-readonly data-type="EventTarget?" href="#dom-mouseevent-relatedtarget" id="ref-for-dom-mouseevent-relatedtarget"><c- g>relatedTarget</c-></a>;
 
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="method" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate①">getModifierState</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="MouseEvent/getModifierState(keyArg)" data-dfn-type="argument" data-export="" id="dom-mouseevent-getmodifierstate-keyarg-keyarg"><code>keyArg</code><a class="self-link" href="#dom-mouseevent-getmodifierstate-keyarg-keyarg"></a></dfn>);
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate①"><c- g>getModifierState</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="MouseEvent/getModifierState(keyArg)" data-dfn-type="argument" data-export id="dom-mouseevent-getmodifierstate-keyarg-keyarg"><code><c- g>keyArg</c-></code><a class="self-link" href="#dom-mouseevent-getmodifierstate-keyarg-keyarg"></a></dfn>);
 };
 </pre>
     <dl>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-screenx"><code>screenX</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long⑥">long</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export id="dom-mouseevent-screenx"><code>screenX</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long⑥">long</a>, readonly</span>
      <dd>
        The horizontal coordinate at which the event occurred relative
 					to the origin of the screen coordinate system. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value③">un-initialized value</a> of this attribute MUST be <code>0</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-screeny"><code>screenY</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long⑦">long</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export id="dom-mouseevent-screeny"><code>screenY</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long⑦">long</a>, readonly</span>
      <dd>
        The vertical coordinate at which the event occurred relative to
 					the origin of the screen coordinate system. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value④">un-initialized value</a> of this attribute MUST be <code>0</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-clientx"><code>clientX</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long⑧">long</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export id="dom-mouseevent-clientx"><code>clientX</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long⑧">long</a>, readonly</span>
      <dd>
        The horizontal coordinate at which the event occurred relative
 					to the viewport associated with the event. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value⑤">un-initialized value</a> of this attribute MUST be <code>0</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-clienty"><code>clientY</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long⑨">long</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export id="dom-mouseevent-clienty"><code>clientY</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long⑨">long</a>, readonly</span>
      <dd>
        The vertical coordinate at which the event occurred relative
 					to the viewport associated with the event. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value⑥">un-initialized value</a> of this attribute MUST be <code>0</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-ctrlkey"><code>ctrlKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑤">boolean</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export id="dom-mouseevent-ctrlkey"><code>ctrlKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑤">boolean</a>, readonly</span>
      <dd>
        Refer to the <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent⑦">KeyboardEvent</a></code>'s <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-ctrlkey" id="ref-for-dom-keyboardevent-ctrlkey">ctrlKey</a></code> attribute. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value⑦">un-initialized value</a> of this attribute MUST be <code>false</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-shiftkey"><code>shiftKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑥">boolean</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export id="dom-mouseevent-shiftkey"><code>shiftKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑥">boolean</a>, readonly</span>
      <dd>
        Refer to the <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent⑧">KeyboardEvent</a></code>'s <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-shiftkey" id="ref-for-dom-keyboardevent-shiftkey">shiftKey</a></code> attribute. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value⑧">un-initialized value</a> of this attribute MUST be <code>false</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-altkey"><code>altKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑦">boolean</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export id="dom-mouseevent-altkey"><code>altKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑦">boolean</a>, readonly</span>
      <dd>
        Refer to the <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent⑨">KeyboardEvent</a></code>'s <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-altkey" id="ref-for-dom-keyboardevent-altkey">altKey</a></code> attribute. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value⑨">un-initialized value</a> of this attribute MUST be <code>false</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-metakey"><code>metaKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑧">boolean</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export id="dom-mouseevent-metakey"><code>metaKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑧">boolean</a>, readonly</span>
      <dd>
        Refer to the <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent①⓪">KeyboardEvent</a></code>'s <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-metakey" id="ref-for-dom-keyboardevent-metakey">metaKey</a></code> attribute. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value①⓪">un-initialized value</a> of this attribute MUST be <code>false</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-button"><code>button</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-short" id="ref-for-idl-short①">short</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export id="dom-mouseevent-button"><code>button</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-short" id="ref-for-idl-short①">short</a>, readonly</span>
      <dd>
        During mouse events caused by the depression or release of a mouse button, <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-button" id="ref-for-dom-mouseevent-button①">button</a></code> MUST be used to indicate which pointer device button
 					changed state. 
       <p>The value of the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-button" id="ref-for-dom-mouseevent-button②">button</a></code> attribute MUST be as follows:</p>
       <ul>
-       <li data-md="">
+       <li data-md>
         <p><code>0</code> MUST indicate the primary button of the device
 (in general, the left button  or the only button on single-button devices,
 used to activate a user interface control or select text) or the
 un-initialized value.</p>
-       <li data-md="">
+       <li data-md>
         <p><code>1</code> MUST indicate the auxiliary button
 (in general, the middle button, often combined with a mouse wheel).</p>
-       <li data-md="">
+       <li data-md>
         <p><code>2</code> MUST indicate the secondary button
 (in general, the right button, often used to display a context menu).</p>
-       <li data-md="">
+       <li data-md>
         <p><code>3</code> MUST indicate the X1 (back) button.</p>
-       <li data-md="">
+       <li data-md>
         <p><code>4</code> MUST indicate the X2 (forward) button.</p>
       </ul>
       <p>Some pointing devices provide or simulate more button states, and values higher than <code>2</code> or lower than <code>0</code> MAY be used to represent such buttons.</p>
@@ -1600,7 +1600,7 @@ un-initialized value.</p>
 					to events such as <a data-link-type="dfn" href="#mousedown" id="ref-for-mousedown②"><code>mousedown</code></a> and <a data-link-type="dfn" href="#mouseup" id="ref-for-mouseup"><code>mouseup</code></a> depend on the specific mouse
 					button in use. </p>
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value①②">un-initialized value</a> of this attribute MUST be <code>0</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-buttons"><code>buttons</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short①">unsigned short</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export id="dom-mouseevent-buttons"><code>buttons</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short①">unsigned short</a>, readonly</span>
      <dd>
        During any mouse events, <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-buttons" id="ref-for-dom-mouseevent-buttons①">buttons</a></code> MUST be used to
 					indicate which combination of mouse buttons are currently being
@@ -1610,16 +1610,16 @@ un-initialized value.</p>
 					can represent the "no button currently active" state (0). </p>
       <p>The value of the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-buttons" id="ref-for-dom-mouseevent-buttons④">buttons</a></code> attribute MUST be as follows:</p>
       <ul>
-       <li data-md="">
+       <li data-md>
         <p><code>0</code> MUST indicate no button is currently active.</p>
-       <li data-md="">
+       <li data-md>
         <p><code>1</code> MUST indicate the primary button of the device
 (in general, the left button or the only button on single-button devices,
 used to activate a user interface control or select text).</p>
-       <li data-md="">
+       <li data-md>
         <p><code>2</code> MUST indicate the secondary button
 (in general, the right button, often used to display a context menu), if present.</p>
-       <li data-md="">
+       <li data-md>
         <p><code>4</code> MUST indicate the auxiliary button
 (in general, the middle button, often combined with a mouse wheel).</p>
       </ul>
@@ -1636,11 +1636,11 @@ used to activate a user interface control or select text).</p>
       <p class="note" role="note"> Some <a data-link-type="dfn" href="#default-action" id="ref-for-default-action①②">default actions</a> related to events such as <a data-link-type="dfn" href="#mousedown" id="ref-for-mousedown④"><code>mousedown</code></a> and <a data-link-type="dfn" href="#mouseup" id="ref-for-mouseup②"><code>mouseup</code></a> depend on the specific mouse
 					button in use. </p>
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value①③">un-initialized value</a> of this attribute MUST be <code>0</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export="" id="dom-mouseevent-relatedtarget"><code>relatedTarget</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget⑥">EventTarget</a>, readonly, nullable</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="attribute" data-export id="dom-mouseevent-relatedtarget"><code>relatedTarget</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget⑥">EventTarget</a>, readonly, nullable</span>
      <dd>
        Used to identify a secondary <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget⑦">EventTarget</a></code> related to a UI event, depending on the type of event. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value①④">un-initialized value</a> of this attribute MUST be <code>null</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="method" data-export="" id="dom-mouseevent-getmodifierstate"><code>getModifierState(keyArg)</code></dfn>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEvent" data-dfn-type="method" data-export id="dom-mouseevent-getmodifierstate"><code>getModifierState(keyArg)</code></dfn>
      <dd>
       <p class="intro-dom">Introduced in this specification</p>
       <p>Queries the state of a modifier using a key value.</p>
@@ -1652,43 +1652,43 @@ used to activate a user interface control or select text).</p>
       </dl>
     </dl>
     <h5 class="heading settled" data-level="4.3.1.2" id="idl-mouseeventinit"><span class="secno">4.3.1.2. </span><span class="content">MouseEventInit</span><a class="self-link" href="#idl-mouseeventinit"></a></h5>
-<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-mouseeventinit"><code>MouseEventInit</code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-eventmodifierinit" id="ref-for-dictdef-eventmodifierinit②">EventModifierInit</a> {
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①⓪"><span class="kt">long</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-screenx" id="ref-for-dom-mouseeventinit-screenx">screenX</a> = 0;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①①"><span class="kt">long</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-screeny" id="ref-for-dom-mouseeventinit-screeny">screenY</a> = 0;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①②"><span class="kt">long</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-clientx" id="ref-for-dom-mouseeventinit-clientx">clientX</a> = 0;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①③"><span class="kt">long</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-clienty" id="ref-for-dom-mouseeventinit-clienty">clientY</a> = 0;
+<pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-mouseeventinit"><code><c- g>MouseEventInit</c-></code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-eventmodifierinit" id="ref-for-dictdef-eventmodifierinit②"><c- n>EventModifierInit</c-></a> {
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①⓪"><c- b>long</c-></a> <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-screenx" id="ref-for-dom-mouseeventinit-screenx"><c- g>screenX</c-></a> = 0;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①①"><c- b>long</c-></a> <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-screeny" id="ref-for-dom-mouseeventinit-screeny"><c- g>screenY</c-></a> = 0;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①②"><c- b>long</c-></a> <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-clientx" id="ref-for-dom-mouseeventinit-clientx"><c- g>clientX</c-></a> = 0;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①③"><c- b>long</c-></a> <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-clienty" id="ref-for-dom-mouseeventinit-clienty"><c- g>clientY</c-></a> = 0;
 
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-short" id="ref-for-idl-short②"><span class="kt">short</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="short " href="#dom-mouseeventinit-button" id="ref-for-dom-mouseeventinit-button">button</a> = 0;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short②"><span class="kt">unsigned</span> <span class="kt">short</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned short " href="#dom-mouseeventinit-buttons" id="ref-for-dom-mouseeventinit-buttons">buttons</a> = 0;
-  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget⑧">EventTarget</a>? <a class="nv idl-code" data-default="null" data-link-type="dict-member" data-type="EventTarget? " href="#dom-mouseeventinit-relatedtarget" id="ref-for-dom-mouseeventinit-relatedtarget">relatedTarget</a> = <span class="kt">null</span>;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-short" id="ref-for-idl-short②"><c- b>short</c-></a> <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="short " href="#dom-mouseeventinit-button" id="ref-for-dom-mouseeventinit-button"><c- g>button</c-></a> = 0;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short②"><c- b>unsigned</c-> <c- b>short</c-></a> <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned short " href="#dom-mouseeventinit-buttons" id="ref-for-dom-mouseeventinit-buttons"><c- g>buttons</c-></a> = 0;
+  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget⑧"><c- n>EventTarget</c-></a>? <a class="idl-code" data-default="null" data-link-type="dict-member" data-type="EventTarget? " href="#dom-mouseeventinit-relatedtarget" id="ref-for-dom-mouseeventinit-relatedtarget"><c- g>relatedTarget</c-></a> = <c- b>null</c->;
 };
 </pre>
     <dl>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export="" id="dom-mouseeventinit-screenx"><code>screenX</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①④">long</a>, defaulting to <code>0</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export id="dom-mouseeventinit-screenx"><code>screenX</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①④">long</a>, defaulting to <code>0</code></span>
      <dd>
        Initializes the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-screenx" id="ref-for-dom-mouseevent-screenx①">screenX</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent⑨">MouseEvent</a></code> object to the desired horizontal relative position of the mouse
 					pointer on the user’s screen. 
       <p>Initializing the event object to the given mouse position must
 					not move the user’s mouse pointer to the initialized position.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export="" id="dom-mouseeventinit-screeny"><code>screenY</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①⑤">long</a>, defaulting to <code>0</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export id="dom-mouseeventinit-screeny"><code>screenY</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①⑤">long</a>, defaulting to <code>0</code></span>
      <dd>
        Initializes the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-screeny" id="ref-for-dom-mouseevent-screeny①">screenY</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent①⓪">MouseEvent</a></code> object to the desired vertical relative position of the mouse
 					pointer on the user’s screen. 
       <p>Initializing the event object to the given mouse position must
 					not move the user’s mouse pointer to the initialized position.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export="" id="dom-mouseeventinit-clientx"><code>clientX</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①⑥">long</a>, defaulting to <code>0</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export id="dom-mouseeventinit-clientx"><code>clientX</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①⑥">long</a>, defaulting to <code>0</code></span>
      <dd>
        Initializes the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-clientx" id="ref-for-dom-mouseevent-clientx②">clientX</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent①①">MouseEvent</a></code> object to the desired horizontal position of the mouse pointer
 					relative to the client window of the user’s browser. 
       <p>Initializing the event object to the given mouse position must
 					not move the user’s mouse pointer to the initialized position.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export="" id="dom-mouseeventinit-clienty"><code>clientY</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①⑦">long</a>, defaulting to <code>0</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export id="dom-mouseeventinit-clienty"><code>clientY</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①⑦">long</a>, defaulting to <code>0</code></span>
      <dd>
        Initializes the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-clienty" id="ref-for-dom-mouseevent-clienty②">clientY</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent①②">MouseEvent</a></code> object to the desired vertical position of the mouse pointer
 					relative to the client window of the user’s browser. 
       <p>Initializing the event object to the given mouse position must
 					not move the user’s mouse pointer to the initialized position.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export="" id="dom-mouseeventinit-button"><code>button</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-short" id="ref-for-idl-short③">short</a>, defaulting to <code>0</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export id="dom-mouseeventinit-button"><code>button</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-short" id="ref-for-idl-short③">short</a>, defaulting to <code>0</code></span>
      <dd>
        Initializes the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-button" id="ref-for-dom-mouseevent-button⑥">button</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent①③">MouseEvent</a></code> object to a number representing the desired state of the button(s)
 					of the mouse. 
@@ -1697,7 +1697,7 @@ used to activate a user interface control or select text).</p>
 					mouse button, and 2 to represent the right mouse button.
 					Numbers greater than 2 are also possible, but are not specified
 					in this document. </p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export="" id="dom-mouseeventinit-buttons"><code>buttons</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short③">unsigned short</a>, defaulting to <code>0</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export id="dom-mouseeventinit-buttons"><code>buttons</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short③">unsigned short</a>, defaulting to <code>0</code></span>
      <dd>
        Initializes the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-buttons" id="ref-for-dom-mouseevent-buttons⑤">buttons</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent①④">MouseEvent</a></code> object to a number representing one <em>or more</em> of the button(s) of the mouse
 					that are to be considered active. 
@@ -1709,7 +1709,7 @@ used to activate a user interface control or select text).</p>
       <p class="example" id="example-3c0b0458"><a class="self-link" href="#example-3c0b0458"></a> In JavaScript, to initialize the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-buttons" id="ref-for-dom-mouseevent-buttons⑦">buttons</a></code> attribute as if the right (2) and middle
 					button (4) were being pressed simultaneously, the buttons value
 					can be assigned as either:<br> <code>  { buttons: 2 | 4 }</code><br> or:<br> <code>  { buttons: 6 }</code> </p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export="" id="dom-mouseeventinit-relatedtarget"><code>relatedTarget</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget⑨">EventTarget</a>, nullable, defaulting to <code>null</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="MouseEventInit" data-dfn-type="dict-member" data-export id="dom-mouseeventinit-relatedtarget"><code>relatedTarget</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget⑨">EventTarget</a>, nullable, defaulting to <code>null</code></span>
      <dd> The <code>relatedTarget</code> should be initialized to the element
 					whose bounds the mouse pointer just left (in the case of a <em>mouseover</em> or <em>mouseenter</em> event) or the element
 					whose bounds the mouse pointer is entering (in the case of a <em>mouseout</em> or <em>mouseleave</em> or <em>focusout</em> event). For other events, this value need not
@@ -1727,76 +1727,76 @@ used to activate a user interface control or select text).</p>
 		initialize keyboard modifier attributes of the <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent①⑥">MouseEvent</a></code> and <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent①③">KeyboardEvent</a></code> interfaces, as well as the additional modifier states
 		queried via <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate②">getModifierState()</a></code>. The steps for
 		constructing events using this dictionary are defined in the <a href="#event-constructors">event constructors</a> section.</p>
-<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-eventmodifierinit"><code>EventModifierInit</code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit④">UIEventInit</a> {
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑨"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-ctrlkey" id="ref-for-dom-eventmodifierinit-ctrlkey">ctrlKey</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①⓪"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-shiftkey" id="ref-for-dom-eventmodifierinit-shiftkey">shiftKey</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-altkey" id="ref-for-dom-eventmodifierinit-altkey">altKey</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①②"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-metakey" id="ref-for-dom-eventmodifierinit-metakey">metaKey</a> = <span class="kt">false</span>;
+<pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-eventmodifierinit"><code><c- g>EventModifierInit</c-></code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit④"><c- n>UIEventInit</c-></a> {
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑨"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-ctrlkey" id="ref-for-dom-eventmodifierinit-ctrlkey"><c- g>ctrlKey</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①⓪"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-shiftkey" id="ref-for-dom-eventmodifierinit-shiftkey"><c- g>shiftKey</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①①"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-altkey" id="ref-for-dom-eventmodifierinit-altkey"><c- g>altKey</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①②"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-metakey" id="ref-for-dom-eventmodifierinit-metakey"><c- g>metaKey</c-></a> = <c- b>false</c->;
 
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①③"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifieraltgraph" id="ref-for-dom-eventmodifierinit-modifieraltgraph">modifierAltGraph</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①④"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiercapslock" id="ref-for-dom-eventmodifierinit-modifiercapslock">modifierCapsLock</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①⑤"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierfn" id="ref-for-dom-eventmodifierinit-modifierfn">modifierFn</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①⑥"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierfnlock" id="ref-for-dom-eventmodifierinit-modifierfnlock">modifierFnLock</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①⑦"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierhyper" id="ref-for-dom-eventmodifierinit-modifierhyper">modifierHyper</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①⑧"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiernumlock" id="ref-for-dom-eventmodifierinit-modifiernumlock">modifierNumLock</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①⑨"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierscrolllock" id="ref-for-dom-eventmodifierinit-modifierscrolllock">modifierScrollLock</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②⓪"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiersuper" id="ref-for-dom-eventmodifierinit-modifiersuper">modifierSuper</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiersymbol" id="ref-for-dom-eventmodifierinit-modifiersymbol">modifierSymbol</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②②"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiersymbollock" id="ref-for-dom-eventmodifierinit-modifiersymbollock">modifierSymbolLock</a> = <span class="kt">false</span>;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①③"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifieraltgraph" id="ref-for-dom-eventmodifierinit-modifieraltgraph"><c- g>modifierAltGraph</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①④"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiercapslock" id="ref-for-dom-eventmodifierinit-modifiercapslock"><c- g>modifierCapsLock</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①⑤"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierfn" id="ref-for-dom-eventmodifierinit-modifierfn"><c- g>modifierFn</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①⑥"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierfnlock" id="ref-for-dom-eventmodifierinit-modifierfnlock"><c- g>modifierFnLock</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①⑦"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierhyper" id="ref-for-dom-eventmodifierinit-modifierhyper"><c- g>modifierHyper</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①⑧"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiernumlock" id="ref-for-dom-eventmodifierinit-modifiernumlock"><c- g>modifierNumLock</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①⑨"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierscrolllock" id="ref-for-dom-eventmodifierinit-modifierscrolllock"><c- g>modifierScrollLock</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②⓪"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiersuper" id="ref-for-dom-eventmodifierinit-modifiersuper"><c- g>modifierSuper</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②①"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiersymbol" id="ref-for-dom-eventmodifierinit-modifiersymbol"><c- g>modifierSymbol</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②②"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiersymbollock" id="ref-for-dom-eventmodifierinit-modifiersymbollock"><c- g>modifierSymbolLock</c-></a> = <c- b>false</c->;
 };
 </pre>
     <dl>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-ctrlkey"><code>ctrlKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②③">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export id="dom-eventmodifierinit-ctrlkey"><code>ctrlKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②③">boolean</a>, defaulting to <code>false</code></span>
      <dd>
        Initializes the <code>ctrlKey</code> attribute of the <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent①⑦">MouseEvent</a></code> or <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent①④">KeyboardEvent</a></code> objects to <code>true</code> if the <code class="keycap">Control</code> key modifier is to be considered active, <code>false</code> otherwise. 
       <p>When <code>true</code>, implementations must also initialize the event object’s key modifier
 				state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate②">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate③">getModifierState()</a></code> when provided with the parameter <code class="keycap">Control</code> must return <code>true</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-shiftkey"><code>shiftKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②④">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export id="dom-eventmodifierinit-shiftkey"><code>shiftKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②④">boolean</a>, defaulting to <code>false</code></span>
      <dd>
        Initializes the <code>shiftKey</code> attribute of the <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent①⑧">MouseEvent</a></code> or <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent①⑤">KeyboardEvent</a></code> objects to <code>true</code> if the <code class="keycap">Shift</code> key modifier is to be considered active, <code>false</code> otherwise. 
       <p>When <code>true</code>, implementations must also initialize the event object’s key modifier
 				state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate③">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate④">getModifierState()</a></code> when provided with the parameter <code class="keycap">Shift</code> must
 				return <code>true</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-altkey"><code>altKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②⑤">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export id="dom-eventmodifierinit-altkey"><code>altKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②⑤">boolean</a>, defaulting to <code>false</code></span>
      <dd>
        Initializes the <code>altKey</code> attribute of the <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent①⑨">MouseEvent</a></code> or <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent①⑥">KeyboardEvent</a></code> objects to <code>true</code> if the <code class="keycap">Alt</code> (alternative) (or <code class="keycap">Option</code>) key modifier
 				is to be considered active, <code>false</code> otherwise. 
       <p>When <code>true</code>, implementations must also initialize the event object’s key modifier
 				state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate④">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate⑤">getModifierState()</a></code> when provided with the parameter <code class="keycap">Alt</code> must
 				return <code>true</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-metakey"><code>metaKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②⑥">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export id="dom-eventmodifierinit-metakey"><code>metaKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②⑥">boolean</a>, defaulting to <code>false</code></span>
      <dd>
        Initializes the <code>metaKey</code> attribute of the <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent②⓪">MouseEvent</a></code> or <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent①⑦">KeyboardEvent</a></code> objects to <code>true</code> if the <code class="keycap">Meta</code> key modifier is to be considered active, <code>false</code> otherwise. 
       <p>When <code>true</code>, implementations must also initialize the event object’s
 				key modifier state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate⑤">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate⑥">getModifierState()</a></code> when provided with either the parameter <code class="keycap">Meta</code> must return <code>true</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifieraltgraph"><code>modifierAltGraph</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②⑦">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export id="dom-eventmodifierinit-modifieraltgraph"><code>modifierAltGraph</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②⑦">boolean</a>, defaulting to <code>false</code></span>
      <dd> Initializes the event object’s key modifier state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate⑥">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate⑦">getModifierState()</a></code> when provided with the parameter <code class="keycap">AltGraph</code> must
 				return <code>true</code>. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifiercapslock"><code>modifierCapsLock</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②⑧">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export id="dom-eventmodifierinit-modifiercapslock"><code>modifierCapsLock</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②⑧">boolean</a>, defaulting to <code>false</code></span>
      <dd> Initializes the event object’s key modifier state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate⑦">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate⑧">getModifierState()</a></code> when provided with the parameter <code class="keycap">CapsLock</code> must
 				return <code>true</code>. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifierfn"><code>modifierFn</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②⑨">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export id="dom-eventmodifierinit-modifierfn"><code>modifierFn</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②⑨">boolean</a>, defaulting to <code>false</code></span>
      <dd> Initializes the event object’s key modifier state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate⑧">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate⑨">getModifierState()</a></code> when provided with the parameter <code class="keycap">Fn</code> must
 				return <code>true</code>. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifierfnlock"><code>modifierFnLock</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③⓪">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export id="dom-eventmodifierinit-modifierfnlock"><code>modifierFnLock</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③⓪">boolean</a>, defaulting to <code>false</code></span>
      <dd> Initializes the event object’s key modifier state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate⑨">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate①⓪">getModifierState()</a></code> when provided with the parameter <code class="keycap">FnLock</code> must
 				return <code>true</code>. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifierhyper"><code>modifierHyper</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③①">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export id="dom-eventmodifierinit-modifierhyper"><code>modifierHyper</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③①">boolean</a>, defaulting to <code>false</code></span>
      <dd> Initializes the event object’s key modifier state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate①⓪">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate①①">getModifierState()</a></code> when provided with the parameter <code class="keycap">Hyper</code> must
 				return <code>true</code>. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifiernumlock"><code>modifierNumLock</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③②">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export id="dom-eventmodifierinit-modifiernumlock"><code>modifierNumLock</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③②">boolean</a>, defaulting to <code>false</code></span>
      <dd> Initializes the event object’s key modifier state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate①①">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate①②">getModifierState()</a></code> when provided with the parameter <code class="keycap">NumLock</code> must
 				return <code>true</code>. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifierscrolllock"><code>modifierScrollLock</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③③">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export id="dom-eventmodifierinit-modifierscrolllock"><code>modifierScrollLock</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③③">boolean</a>, defaulting to <code>false</code></span>
      <dd> Initializes the event object’s key modifier state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate①②">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate①③">getModifierState()</a></code> when provided with the parameter <code class="keycap">ScrollLock</code> must
 				return <code>true</code>. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifiersuper"><code>modifierSuper</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③④">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export id="dom-eventmodifierinit-modifiersuper"><code>modifierSuper</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③④">boolean</a>, defaulting to <code>false</code></span>
      <dd> Initializes the event object’s key modifier state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate①③">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate①④">getModifierState()</a></code> when provided with the parameter <code class="keycap">Super</code> must
 				return <code>true</code>. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifiersymbol"><code>modifierSymbol</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③⑤">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export id="dom-eventmodifierinit-modifiersymbol"><code>modifierSymbol</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③⑤">boolean</a>, defaulting to <code>false</code></span>
      <dd> Initializes the event object’s key modifier state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate①④">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate①⑤">getModifierState()</a></code> when provided with the parameter <code class="keycap">Symbol</code> must
 				return <code>true</code>. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export="" id="dom-eventmodifierinit-modifiersymbollock"><code>modifierSymbolLock</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③⑥">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="EventModifierInit" data-dfn-type="dict-member" data-export id="dom-eventmodifierinit-modifiersymbollock"><code>modifierSymbolLock</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③⑥">boolean</a>, defaulting to <code>false</code></span>
      <dd> Initializes the event object’s key modifier state such that calls to the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate①⑤">getModifierState()</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate①⑥">getModifierState()</a></code> when provided with the parameter <code class="keycap">SymbolLock</code> must
 				return <code>true</code>. 
     </dl>
@@ -2112,7 +2112,7 @@ used to activate a user interface control or select text).</p>
 		mouse event types are always targeted at the most deeply nested element.
 		Ancestors of the targeted element MAY use bubbling to obtain
 		notification of mouse events which occur within its descendent elements.</p>
-    <h5 class="heading settled" data-level="4.3.4.1" id="event-type-auxclick"><span class="secno">4.3.4.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="auxclick">auxclick</dfn></span><a class="self-link" href="#event-type-auxclick"></a></h5>
+    <h5 class="heading settled" data-level="4.3.4.1" id="event-type-auxclick"><span class="secno">4.3.4.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="auxclick">auxclick</dfn></span><a class="self-link" href="#event-type-auxclick"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -2179,10 +2179,10 @@ used to activate a user interface control or select text).</p>
     <p>The <a data-link-type="dfn" href="#default-action" id="ref-for-default-action①③">default action</a> of the <a data-link-type="dfn" href="#auxclick" id="ref-for-auxclick⑤"><code>auxclick</code></a> event type varies
 			based on the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target②①">event target</a> of the event and the value of the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-button" id="ref-for-dom-mouseevent-button⑨">button</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-buttons" id="ref-for-dom-mouseevent-buttons①⓪">buttons</a></code> attributes. Typical <a data-link-type="dfn" href="#default-action" id="ref-for-default-action①④">default actions</a> of the <a data-link-type="dfn" href="#auxclick" id="ref-for-auxclick⑥"><code>auxclick</code></a> event type are as follows:</p>
     <ul>
-     <li data-md="">
+     <li data-md>
       <p>If the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target②②">event target</a> has associated activation behavior,
 the <a data-link-type="dfn" href="#default-action" id="ref-for-default-action①⑤">default action</a> MUST be to execute that activation
-behavior (see <a href="#event-flow-activation">§3.5 Activation triggers and behavior</a>).</p>
+behavior (see <a href="#event-flow-activation">§ 3.5 Activation triggers and behavior</a>).</p>
     </ul>
     <p class="example" id="example-214090d6"><a class="self-link" href="#example-214090d6"></a> Receiving and handling auxclick for the middle button.<br> <code class="pre">myLink.addEventListener("auxclick", function(e) {
   if (e.button === 1) {
@@ -2211,7 +2211,7 @@ myDiv.addEventListener("auxclick", function(e) {
     // customized context menu inside the app.
   }
 }); </code> </p>
-    <h5 class="heading settled" data-level="4.3.4.2" id="event-type-click"><span class="secno">4.3.4.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="click">click</dfn></span><a class="self-link" href="#event-type-click"></a></h5>
+    <h5 class="heading settled" data-level="4.3.4.2" id="event-type-click"><span class="secno">4.3.4.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="click">click</dfn></span><a class="self-link" href="#event-type-click"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -2285,7 +2285,7 @@ myDiv.addEventListener("auxclick", function(e) {
 			within the scope of the same element. Note that user-agent-generated
 			mouse events are not dispatched on text nodes. </p>
     <p>In addition to being associated with pointer devices, the <a data-link-type="dfn" href="#click" id="ref-for-click②①"><code>click</code></a> event type MUST be dispatched as part of an element
-			activation, as described in <a href="#event-flow-activation">§3.5 Activation triggers and behavior</a>.</p>
+			activation, as described in <a href="#event-flow-activation">§ 3.5 Activation triggers and behavior</a>.</p>
     <p class="note" role="note"> For maximum accessibility, content authors are encouraged to use the <a data-link-type="dfn" href="#click" id="ref-for-click②②"><code>click</code></a> event type when defining activation behavior for custom
 			controls, rather than other pointing-device event types such as <a data-link-type="dfn" href="#mousedown" id="ref-for-mousedown①④"><code>mousedown</code></a> or <a data-link-type="dfn" href="#mouseup" id="ref-for-mouseup①④"><code>mouseup</code></a>, which are more device-specific.
 			Though the <a data-link-type="dfn" href="#click" id="ref-for-click②③"><code>click</code></a> event type has its origins in pointer
@@ -2295,15 +2295,15 @@ myDiv.addEventListener("auxclick", function(e) {
     <p>The <a data-link-type="dfn" href="#default-action" id="ref-for-default-action①⑥">default action</a> of the <a data-link-type="dfn" href="#click" id="ref-for-click②④"><code>click</code></a> event type varies
 			based on the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target②③">event target</a> of the event and the value of the <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-button" id="ref-for-dom-mouseevent-button①②">button</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-buttons" id="ref-for-dom-mouseevent-buttons①③">buttons</a></code> attributes. Typical <a data-link-type="dfn" href="#default-action" id="ref-for-default-action①⑦">default actions</a> of the <a data-link-type="dfn" href="#click" id="ref-for-click②⑤"><code>click</code></a> event type are as follows:</p>
     <ul>
-     <li data-md="">
+     <li data-md>
       <p>If the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target②④">event target</a> has associated activation behavior,
 the <a data-link-type="dfn" href="#default-action" id="ref-for-default-action①⑧">default action</a> MUST be to execute that activation
-behavior (see <a href="#event-flow-activation">§3.5 Activation triggers and behavior</a>).</p>
-     <li data-md="">
+behavior (see <a href="#event-flow-activation">§ 3.5 Activation triggers and behavior</a>).</p>
+     <li data-md>
       <p>If the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target②⑤">event target</a> is focusable, the <a data-link-type="dfn" href="#default-action" id="ref-for-default-action①⑨">default
 action</a> MUST be to give that element document focus.</p>
     </ul>
-    <h5 class="heading settled" data-level="4.3.4.3" id="event-type-dblclick"><span class="secno">4.3.4.3. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dblclick">dblclick</dfn></span><a class="self-link" href="#event-type-dblclick"></a></h5>
+    <h5 class="heading settled" data-level="4.3.4.3" id="event-type-dblclick"><span class="secno">4.3.4.3. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="dblclick">dblclick</dfn></span><a class="self-link" href="#event-type-dblclick"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -2366,13 +2366,13 @@ action</a> MUST be to give that element document focus.</p>
 			of the <a data-link-type="dfn" href="#click" id="ref-for-click③⓪"><code>click</code></a> event type, with the following additional
 			behavior:</p>
     <ul>
-     <li data-md="">
+     <li data-md>
       <p>If the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target②⑦">event target</a> is selectable, the <a data-link-type="dfn" href="#default-action" id="ref-for-default-action②②">default
 action</a> MUST be to select part or all of the selectable
 content. Subsequent clicks MAY select additional selectable
 portions of that content.</p>
     </ul>
-    <h5 class="heading settled" data-level="4.3.4.4" id="event-type-mousedown"><span class="secno">4.3.4.4. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="mousedown">mousedown</dfn></span><a class="self-link" href="#event-type-mousedown"></a></h5>
+    <h5 class="heading settled" data-level="4.3.4.4" id="event-type-mousedown"><span class="secno">4.3.4.4. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="mousedown">mousedown</dfn></span><a class="self-link" href="#event-type-mousedown"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -2429,7 +2429,7 @@ portions of that content.</p>
 			Additionally, some implementations provide a mouse-driven panning
 			feature that is activated when the middle mouse button is pressed at
 			the time the <a data-link-type="dfn" href="#mousedown" id="ref-for-mousedown①⑧"><code>mousedown</code></a> event is dispatched. </p>
-    <h5 class="heading settled" data-level="4.3.4.5" id="event-type-mouseenter"><span class="secno">4.3.4.5. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="mouseenter">mouseenter</dfn></span><a class="self-link" href="#event-type-mouseenter"></a></h5>
+    <h5 class="heading settled" data-level="4.3.4.5" id="event-type-mouseenter"><span class="secno">4.3.4.5. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="mouseenter">mouseenter</dfn></span><a class="self-link" href="#event-type-mouseenter"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -2486,7 +2486,7 @@ portions of that content.</p>
 			of its descendent elements.</p>
     <p class="note" role="note"> There are similarities between this event type and the CSS <a href="http://www.w3.org/TR/CSS2/selector.html#dynamic-pseudo-classes" title="Selectors"><code>:hover</code> pseudo-class</a> <a data-link-type="biblio" href="#biblio-css2">[CSS2]</a>.
 			See also the <a data-link-type="dfn" href="#mouseleave" id="ref-for-mouseleave⑧"><code>mouseleave</code></a> event type. </p>
-    <h5 class="heading settled" data-level="4.3.4.6" id="event-type-mouseleave"><span class="secno">4.3.4.6. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="mouseleave">mouseleave</dfn></span><a class="self-link" href="#event-type-mouseleave"></a></h5>
+    <h5 class="heading settled" data-level="4.3.4.6" id="event-type-mouseleave"><span class="secno">4.3.4.6. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="mouseleave">mouseleave</dfn></span><a class="self-link" href="#event-type-mouseleave"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -2543,7 +2543,7 @@ portions of that content.</p>
 			element and the boundaries of all of its children.</p>
     <p class="note" role="note"> There are similarities between this event type and the CSS <a href="http://www.w3.org/TR/CSS2/selector.html#dynamic-pseudo-classes" title="Selectors"><code>:hover</code> pseudo-class</a> <a data-link-type="biblio" href="#biblio-css2">[CSS2]</a>.
 			See also the <a data-link-type="dfn" href="#mouseenter" id="ref-for-mouseenter⑦"><code>mouseenter</code></a> event type. </p>
-    <h5 class="heading settled" data-level="4.3.4.7" id="event-type-mousemove"><span class="secno">4.3.4.7. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="mousemove">mousemove</dfn></span><a class="self-link" href="#event-type-mousemove"></a></h5>
+    <h5 class="heading settled" data-level="4.3.4.7" id="event-type-mousemove"><span class="secno">4.3.4.7. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="mousemove">mousemove</dfn></span><a class="self-link" href="#event-type-mousemove"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -2604,7 +2604,7 @@ portions of that content.</p>
     <p class="note" id="mousemove-now-cancelable" role="note"><a class="self-link" href="#mousemove-now-cancelable"></a> This event was formerly specified to be non-cancelable in DOM Level
 			2 Events <a data-link-type="biblio" href="#biblio-dom-level-2-events">[DOM-Level-2-Events]</a>, but was changed to reflect existing
 			interoperability between user agents. </p>
-    <h5 class="heading settled" data-level="4.3.4.8" id="event-type-mouseout"><span class="secno">4.3.4.8. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="mouseout">mouseout</dfn></span><a class="self-link" href="#event-type-mouseout"></a></h5>
+    <h5 class="heading settled" data-level="4.3.4.8" id="event-type-mouseout"><span class="secno">4.3.4.8. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="mouseout">mouseout</dfn></span><a class="self-link" href="#event-type-mouseout"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -2658,7 +2658,7 @@ portions of that content.</p>
 			does bubble, and that it MUST be dispatched when the pointer device
 			moves from an element onto the boundaries of one of its descendent elements.</p>
     <p class="note" role="note"> See also the <a data-link-type="dfn" href="#mouseover" id="ref-for-mouseover⑨"><code>mouseover</code></a> event type. </p>
-    <h5 class="heading settled" data-level="4.3.4.9" id="event-type-mouseover"><span class="secno">4.3.4.9. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="mouseover">mouseover</dfn></span><a class="self-link" href="#event-type-mouseover"></a></h5>
+    <h5 class="heading settled" data-level="4.3.4.9" id="event-type-mouseover"><span class="secno">4.3.4.9. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="mouseover">mouseover</dfn></span><a class="self-link" href="#event-type-mouseover"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -2713,7 +2713,7 @@ portions of that content.</p>
 			boundaries of an element whose ancestor element is the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target③②">event
 			target</a> for the same event listener instance.</p>
     <p class="note" role="note"> See also the <a data-link-type="dfn" href="#mouseout" id="ref-for-mouseout①⓪"><code>mouseout</code></a> event type. </p>
-    <h5 class="heading settled" data-level="4.3.4.10" id="event-type-mouseup"><span class="secno">4.3.4.10. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="mouseup">mouseup</dfn></span><a class="self-link" href="#event-type-mouseup"></a></h5>
+    <h5 class="heading settled" data-level="4.3.4.10" id="event-type-mouseup"><span class="secno">4.3.4.10. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="mouseup">mouseup</dfn></span><a class="self-link" href="#event-type-mouseup"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -2809,31 +2809,31 @@ portions of that content.</p>
     <p>To create an instance of the <code class="idl"><a data-link-type="idl" href="#wheelevent" id="ref-for-wheelevent②">WheelEvent</a></code> interface, use the <code class="idl"><a data-link-type="idl" href="#wheelevent" id="ref-for-wheelevent③">WheelEvent</a></code> constructor,
 		passing an optional <code class="idl"><a data-link-type="idl" href="#dictdef-wheeleventinit" id="ref-for-dictdef-wheeleventinit">WheelEventInit</a></code> dictionary.</p>
     <h5 class="heading settled" data-level="4.4.1.1" id="idl-wheelevent"><span class="secno">4.4.1.1. </span><span class="content">WheelEvent</span><a class="self-link" href="#idl-wheelevent"></a></h5>
-<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="WheelEvent" data-dfn-type="constructor" data-export="" data-lt="WheelEvent(type, eventInitDict)|WheelEvent(type)" id="dom-wheelevent-wheelevent"><code>Constructor</code><a class="self-link" href="#dom-wheelevent-wheelevent"></a></dfn>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString④"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="WheelEvent/WheelEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-wheelevent-wheelevent-type-eventinitdict-type"><code>type</code><a class="self-link" href="#dom-wheelevent-wheelevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-wheeleventinit" id="ref-for-dictdef-wheeleventinit①">WheelEventInit</a> <dfn class="nv idl-code" data-dfn-for="WheelEvent/WheelEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-wheelevent-wheelevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code><a class="self-link" href="#dom-wheelevent-wheelevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed③">Exposed</a>=<span class="n">Window</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="wheelevent"><code>WheelEvent</code></dfn> : <a class="n" data-link-type="idl-name" href="#mouseevent" id="ref-for-mouseevent①④①">MouseEvent</a> {
+<pre class="idl highlight def">[<dfn class="idl-code" data-dfn-for="WheelEvent" data-dfn-type="constructor" data-export data-lt="WheelEvent(type, eventInitDict)|WheelEvent(type)" id="dom-wheelevent-wheelevent"><code><c- g>Constructor</c-></code><a class="self-link" href="#dom-wheelevent-wheelevent"></a></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString④"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="WheelEvent/WheelEvent(type, eventInitDict)" data-dfn-type="argument" data-export id="dom-wheelevent-wheelevent-type-eventinitdict-type"><code><c- g>type</c-></code><a class="self-link" href="#dom-wheelevent-wheelevent-type-eventinitdict-type"></a></dfn>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-wheeleventinit" id="ref-for-dictdef-wheeleventinit①"><c- n>WheelEventInit</c-></a> <dfn class="idl-code" data-dfn-for="WheelEvent/WheelEvent(type, eventInitDict)" data-dfn-type="argument" data-export id="dom-wheelevent-wheelevent-type-eventinitdict-eventinitdict"><code><c- g>eventInitDict</c-></code><a class="self-link" href="#dom-wheelevent-wheelevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed③"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="wheelevent"><code><c- g>WheelEvent</c-></code></dfn> : <a class="n" data-link-type="idl-name" href="#mouseevent" id="ref-for-mouseevent①④①"><c- n>MouseEvent</c-></a> {
   // DeltaModeCode
-  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-wheelevent-dom_delta_pixel" id="ref-for-dom-wheelevent-dom_delta_pixel">DOM_DELTA_PIXEL</a> = 0x00;
-  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-wheelevent-dom_delta_line" id="ref-for-dom-wheelevent-dom_delta_line">DOM_DELTA_LINE</a>  = 0x01;
-  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-wheelevent-dom_delta_page" id="ref-for-dom-wheelevent-dom_delta_page">DOM_DELTA_PAGE</a>  = 0x02;
+  <c- b>const</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="const" href="#dom-wheelevent-dom_delta_pixel" id="ref-for-dom-wheelevent-dom_delta_pixel"><c- g>DOM_DELTA_PIXEL</c-></a> = 0x00;
+  <c- b>const</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="const" href="#dom-wheelevent-dom_delta_line" id="ref-for-dom-wheelevent-dom_delta_line"><c- g>DOM_DELTA_LINE</c-></a>  = 0x01;
+  <c- b>const</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="const" href="#dom-wheelevent-dom_delta_page" id="ref-for-dom-wheelevent-dom_delta_page"><c- g>DOM_DELTA_PAGE</c-></a>  = 0x02;
 
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="double" href="#dom-wheelevent-deltax" id="ref-for-dom-wheelevent-deltax">deltaX</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="double" href="#dom-wheelevent-deltay" id="ref-for-dom-wheelevent-deltay">deltaY</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="double" href="#dom-wheelevent-deltaz" id="ref-for-dom-wheelevent-deltaz">deltaZ</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long③"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-wheelevent-deltamode" id="ref-for-dom-wheelevent-deltamode">deltaMode</a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double"><c- b>double</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="double" href="#dom-wheelevent-deltax" id="ref-for-dom-wheelevent-deltax"><c- g>deltaX</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①"><c- b>double</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="double" href="#dom-wheelevent-deltay" id="ref-for-dom-wheelevent-deltay"><c- g>deltaY</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②"><c- b>double</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="double" href="#dom-wheelevent-deltaz" id="ref-for-dom-wheelevent-deltaz"><c- g>deltaZ</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long③"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="unsigned long" href="#dom-wheelevent-deltamode" id="ref-for-dom-wheelevent-deltamode"><c- g>deltaMode</c-></a>;
 };
 </pre>
     <dl>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="const" data-export="" id="dom-wheelevent-dom_delta_pixel"><code>DOM_DELTA_PIXEL</code></dfn>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="const" data-export id="dom-wheelevent-dom_delta_pixel"><code>DOM_DELTA_PIXEL</code></dfn>
      <dd> The units of measurement for the <a data-link-type="dfn" href="#delta" id="ref-for-delta③">delta</a> MUST be pixels.
 					This is the most typical case in most operating system and
 					implementation configurations. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="const" data-export="" id="dom-wheelevent-dom_delta_line"><code>DOM_DELTA_LINE</code></dfn>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="const" data-export id="dom-wheelevent-dom_delta_line"><code>DOM_DELTA_LINE</code></dfn>
      <dd> The units of measurement for the <a data-link-type="dfn" href="#delta" id="ref-for-delta④">delta</a> MUST be individual
 					lines of text.  This is the case for many form controls. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="const" data-export="" id="dom-wheelevent-dom_delta_page"><code>DOM_DELTA_PAGE</code></dfn>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="const" data-export id="dom-wheelevent-dom_delta_page"><code>DOM_DELTA_PAGE</code></dfn>
      <dd> The units of measurement for the <a data-link-type="dfn" href="#delta" id="ref-for-delta⑤">delta</a> MUST be pages,
 					either defined as a single screen or as a demarcated page. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="attribute" data-export="" id="dom-wheelevent-deltax"><code>deltaX</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double③">double</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="attribute" data-export id="dom-wheelevent-deltax"><code>deltaX</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double③">double</a>, readonly</span>
      <dd>
        In user agents where the default action of the <a data-link-type="dfn" href="#wheel" id="ref-for-wheel③"><code>wheel</code></a> event is to scroll, the value MUST be the measurement along the
 					x-axis (in pixels, lines, or pages) to be scrolled in the case
@@ -2841,7 +2841,7 @@ portions of that content.</p>
 					implementation-specific measurement (in pixels, lines, or pages)
 					of the movement of a wheel device around the x-axis. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value①⑤">un-initialized value</a> of this attribute MUST be <code>0.0</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="attribute" data-export="" id="dom-wheelevent-deltay"><code>deltaY</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double④">double</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="attribute" data-export id="dom-wheelevent-deltay"><code>deltaY</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double④">double</a>, readonly</span>
      <dd>
        In user agents where the default action of the <a data-link-type="dfn" href="#wheel" id="ref-for-wheel④"><code>wheel</code></a> event is to scroll, the value MUST be the measurement along the
 					y-axis (in pixels, lines, or pages) to be scrolled in the case
@@ -2849,7 +2849,7 @@ portions of that content.</p>
 					implementation-specific measurement (in pixels, lines, or pages)
 					of the movement of a wheel device around the y-axis. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value①⑥">un-initialized value</a> of this attribute MUST be <code>0.0</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="attribute" data-export="" id="dom-wheelevent-deltaz"><code>deltaZ</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑤">double</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="attribute" data-export id="dom-wheelevent-deltaz"><code>deltaZ</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑤">double</a>, readonly</span>
      <dd>
        In user agents where the default action of the <a data-link-type="dfn" href="#wheel" id="ref-for-wheel⑤"><code>wheel</code></a> event is to scroll, the value MUST be the measurement along the
 					z-axis (in pixels, lines, or pages) to be scrolled in the case
@@ -2857,7 +2857,7 @@ portions of that content.</p>
 					implementation-specific measurement (in pixels, lines, or pages)
 					of the movement of a wheel device around the z-axis. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value①⑦">un-initialized value</a> of this attribute MUST be <code>0.0</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="attribute" data-export="" id="dom-wheelevent-deltamode"><code>deltaMode</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long④">unsigned long</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEvent" data-dfn-type="attribute" data-export id="dom-wheelevent-deltamode"><code>deltaMode</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long④">unsigned long</a>, readonly</span>
      <dd>
        The <code>deltaMode</code> attribute contains an indication of
 					the units of measurement for the <a data-link-type="dfn" href="#delta" id="ref-for-delta⑥">delta</a> values. The
@@ -2869,19 +2869,19 @@ portions of that content.</p>
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value①⑧">un-initialized value</a> of this attribute MUST be <code>0</code>.</p>
     </dl>
     <h5 class="heading settled" data-level="4.4.1.2" id="idl-wheeleventinit"><span class="secno">4.4.1.2. </span><span class="content">WheelEventInit</span><a class="self-link" href="#idl-wheeleventinit"></a></h5>
-<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-wheeleventinit"><code>WheelEventInit</code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-mouseeventinit" id="ref-for-dictdef-mouseeventinit②">MouseEventInit</a> {
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑥"><span class="kt">double</span></a> <a class="nv idl-code" data-default="0.0" data-link-type="dict-member" data-type="double " href="#dom-wheeleventinit-deltax" id="ref-for-dom-wheeleventinit-deltax">deltaX</a> = 0.0;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑦"><span class="kt">double</span></a> <a class="nv idl-code" data-default="0.0" data-link-type="dict-member" data-type="double " href="#dom-wheeleventinit-deltay" id="ref-for-dom-wheeleventinit-deltay">deltaY</a> = 0.0;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑧"><span class="kt">double</span></a> <a class="nv idl-code" data-default="0.0" data-link-type="dict-member" data-type="double " href="#dom-wheeleventinit-deltaz" id="ref-for-dom-wheeleventinit-deltaz">deltaZ</a> = 0.0;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑤"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned long " href="#dom-wheeleventinit-deltamode" id="ref-for-dom-wheeleventinit-deltamode">deltaMode</a> = 0;
+<pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-wheeleventinit"><code><c- g>WheelEventInit</c-></code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-mouseeventinit" id="ref-for-dictdef-mouseeventinit②"><c- n>MouseEventInit</c-></a> {
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑥"><c- b>double</c-></a> <a class="idl-code" data-default="0.0" data-link-type="dict-member" data-type="double " href="#dom-wheeleventinit-deltax" id="ref-for-dom-wheeleventinit-deltax"><c- g>deltaX</c-></a> = 0.0;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑦"><c- b>double</c-></a> <a class="idl-code" data-default="0.0" data-link-type="dict-member" data-type="double " href="#dom-wheeleventinit-deltay" id="ref-for-dom-wheeleventinit-deltay"><c- g>deltaY</c-></a> = 0.0;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑧"><c- b>double</c-></a> <a class="idl-code" data-default="0.0" data-link-type="dict-member" data-type="double " href="#dom-wheeleventinit-deltaz" id="ref-for-dom-wheeleventinit-deltaz"><c- g>deltaZ</c-></a> = 0.0;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑤"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned long " href="#dom-wheeleventinit-deltamode" id="ref-for-dom-wheeleventinit-deltamode"><c- g>deltaMode</c-></a> = 0;
 };
 </pre>
     <dl>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEventInit" data-dfn-type="dict-member" data-export="" id="dom-wheeleventinit-deltax"><code>deltaX</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑨">double</a>, defaulting to <code>0.0</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEventInit" data-dfn-type="dict-member" data-export id="dom-wheeleventinit-deltax"><code>deltaX</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑨">double</a>, defaulting to <code>0.0</code></span>
      <dd>See <code>deltaZ</code> attribute.
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEventInit" data-dfn-type="dict-member" data-export="" id="dom-wheeleventinit-deltay"><code>deltaY</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①⓪">double</a>, defaulting to <code>0.0</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEventInit" data-dfn-type="dict-member" data-export id="dom-wheeleventinit-deltay"><code>deltaY</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①⓪">double</a>, defaulting to <code>0.0</code></span>
      <dd>See <code>deltaZ</code> attribute.
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEventInit" data-dfn-type="dict-member" data-export="" id="dom-wheeleventinit-deltaz"><code>deltaZ</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①①">double</a>, defaulting to <code>0.0</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEventInit" data-dfn-type="dict-member" data-export id="dom-wheeleventinit-deltaz"><code>deltaZ</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①①">double</a>, defaulting to <code>0.0</code></span>
      <dd> Initializes the <code class="idl"><a data-link-type="idl" href="#dom-wheelevent-deltaz" id="ref-for-dom-wheelevent-deltaz①">deltaZ</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#wheelevent" id="ref-for-wheelevent④">WheelEvent</a></code> object. Relative positive values for this attribute (as well as
 					the <code class="idl"><a data-link-type="idl" href="#dom-wheelevent-deltax" id="ref-for-dom-wheelevent-deltax①">deltaX</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-wheelevent-deltay" id="ref-for-dom-wheelevent-deltay①">deltaY</a></code> attributes) are
 					given by a right-hand coordinate system where the X, Y, and Z
@@ -2889,7 +2889,7 @@ portions of that content.</p>
 					and farthest depth (away from the user) of the document,
 					respectively. Negative relative values are in the respective
 					opposite directions. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEventInit" data-dfn-type="dict-member" data-export="" id="dom-wheeleventinit-deltamode"><code>deltaMode</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑥">unsigned long</a>, defaulting to <code>0</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="WheelEventInit" data-dfn-type="dict-member" data-export id="dom-wheeleventinit-deltamode"><code>deltaMode</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑥">unsigned long</a>, defaulting to <code>0</code></span>
      <dd> Initializes the <code class="idl"><a data-link-type="idl" href="#dom-wheelevent-deltamode" id="ref-for-dom-wheelevent-deltamode①">deltaMode</a></code> attribute on the <code class="idl"><a data-link-type="idl" href="#wheelevent" id="ref-for-wheelevent⑤">WheelEvent</a></code> object to the enumerated values 0, 1, or 2, which
 					represent the amount of pixels scrolled
 					(<code class="idl"><a data-link-type="idl" href="#dom-wheelevent-dom_delta_pixel" id="ref-for-dom-wheelevent-dom_delta_pixel②">DOM_DELTA_PIXEL</a></code>), lines scrolled
@@ -2898,7 +2898,7 @@ portions of that content.</p>
 					wheel would have resulted in scrolling. 
     </dl>
     <h4 class="heading settled" data-level="4.4.2" id="events-wheel-types"><span class="secno">4.4.2. </span><span class="content">Wheel Event Types</span><a class="self-link" href="#events-wheel-types"></a></h4>
-    <h5 class="heading settled" data-level="4.4.2.1" id="event-type-wheel"><span class="secno">4.4.2.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="wheel">wheel</dfn></span><a class="self-link" href="#event-type-wheel"></a></h5>
+    <h5 class="heading settled" data-level="4.4.2.1" id="event-type-wheel"><span class="secno">4.4.2.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="wheel">wheel</dfn></span><a class="self-link" href="#event-type-wheel"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -2978,15 +2978,15 @@ portions of that content.</p>
     <h4 class="heading settled" data-level="4.5.1" id="interface-inputevent"><span class="secno">4.5.1. </span><span class="content">Interface InputEvent</span><a class="self-link" href="#interface-inputevent"></a></h4>
     <h5 class="heading settled" data-level="4.5.1.1" id="idl-inputevent"><span class="secno">4.5.1.1. </span><span class="content">InputEvent</span><a class="self-link" href="#idl-inputevent"></a></h5>
     <p class="intro-dom">Introduced in DOM Level 3</p>
-<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="InputEvent" data-dfn-type="constructor" data-export="" data-lt="InputEvent(type, eventInitDict)|InputEvent(type)" id="dom-inputevent-inputevent"><code>Constructor</code><a class="self-link" href="#dom-inputevent-inputevent"></a></dfn>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑤"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="InputEvent/InputEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-inputevent-inputevent-type-eventinitdict-type"><code>type</code><a class="self-link" href="#dom-inputevent-inputevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-inputeventinit" id="ref-for-dictdef-inputeventinit">InputEventInit</a> <dfn class="nv idl-code" data-dfn-for="InputEvent/InputEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-inputevent-inputevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code><a class="self-link" href="#dom-inputevent-inputevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed④">Exposed</a>=<span class="n">Window</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="inputevent"><code>InputEvent</code></dfn> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent⑤①">UIEvent</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑥"><span class="kt">DOMString</span></a>? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString?" href="#dom-inputevent-data" id="ref-for-dom-inputevent-data">data</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③⑦"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-inputevent-iscomposing" id="ref-for-dom-inputevent-iscomposing">isComposing</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑦"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-inputevent-inputtype" id="ref-for-dom-inputevent-inputtype">inputType</a>;
+<pre class="idl highlight def">[<dfn class="idl-code" data-dfn-for="InputEvent" data-dfn-type="constructor" data-export data-lt="InputEvent(type, eventInitDict)|InputEvent(type)" id="dom-inputevent-inputevent"><code><c- g>Constructor</c-></code><a class="self-link" href="#dom-inputevent-inputevent"></a></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑤"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="InputEvent/InputEvent(type, eventInitDict)" data-dfn-type="argument" data-export id="dom-inputevent-inputevent-type-eventinitdict-type"><code><c- g>type</c-></code><a class="self-link" href="#dom-inputevent-inputevent-type-eventinitdict-type"></a></dfn>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-inputeventinit" id="ref-for-dictdef-inputeventinit"><c- n>InputEventInit</c-></a> <dfn class="idl-code" data-dfn-for="InputEvent/InputEvent(type, eventInitDict)" data-dfn-type="argument" data-export id="dom-inputevent-inputevent-type-eventinitdict-eventinitdict"><code><c- g>eventInitDict</c-></code><a class="self-link" href="#dom-inputevent-inputevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed④"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="inputevent"><code><c- g>InputEvent</c-></code></dfn> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent⑤①"><c- n>UIEvent</c-></a> {
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑥"><c- b>DOMString</c-></a>? <a class="idl-code" data-link-type="attribute" data-readonly data-type="DOMString?" href="#dom-inputevent-data" id="ref-for-dom-inputevent-data"><c- g>data</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③⑦"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="boolean" href="#dom-inputevent-iscomposing" id="ref-for-dom-inputevent-iscomposing"><c- g>isComposing</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑦"><c- b>DOMString</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="DOMString" href="#dom-inputevent-inputtype" id="ref-for-dom-inputevent-inputtype"><c- g>inputType</c-></a>;
 };
 </pre>
     <dl>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="InputEvent" data-dfn-type="attribute" data-export="" id="dom-inputevent-data"><code>data</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑧">DOMString</a>, readonly, nullable</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="InputEvent" data-dfn-type="attribute" data-export id="dom-inputevent-data"><code>data</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑧">DOMString</a>, readonly, nullable</span>
      <dd>
        <code>data</code> holds the value of the characters generated by
 					an input method. This MAY be a single Unicode character or a
@@ -2995,13 +2995,13 @@ portions of that content.</p>
 					form <em>NFC</em>, defined in <a data-link-type="biblio" href="#biblio-uax15">[UAX15]</a>.
 					This attribute MAY contain the <a data-link-type="dfn" href="#empty-string" id="ref-for-empty-string">empty string</a>. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value①⑨">un-initialized value</a> of this attribute MUST be <code>null</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="InputEvent" data-dfn-type="attribute" data-export="" id="dom-inputevent-iscomposing"><code>isComposing</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③⑧">boolean</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="InputEvent" data-dfn-type="attribute" data-export id="dom-inputevent-iscomposing"><code>isComposing</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③⑧">boolean</a>, readonly</span>
      <dd>
        <code>true</code> if the input event occurs as part of a
 					composition session, i.e., after a <a data-link-type="dfn" href="#compositionstart" id="ref-for-compositionstart"><code>compositionstart</code></a> event
 					and before the corresponding <a data-link-type="dfn" href="#compositionend" id="ref-for-compositionend"><code>compositionend</code></a> event. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value②⓪">un-initialized value</a> of this attribute MUST be <code>false</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="InputEvent" data-dfn-type="attribute" data-export="" id="dom-inputevent-inputtype"><code>inputType</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑨">DOMString</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="InputEvent" data-dfn-type="attribute" data-export id="dom-inputevent-inputtype"><code>inputType</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑨">DOMString</a>, readonly</span>
      <dd>
        <code>inputType</code> contains a string that identifies the type
 					of input associated with the event. 
@@ -3010,18 +3010,18 @@ portions of that content.</p>
 					the empty string <code>""</code>.</p>
     </dl>
     <h5 class="heading settled" data-level="4.5.1.2" id="idl-inputeventinit"><span class="secno">4.5.1.2. </span><span class="content">InputEventInit</span><a class="self-link" href="#idl-inputeventinit"></a></h5>
-<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-inputeventinit"><code>InputEventInit</code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit⑤">UIEventInit</a> {
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⓪"><span class="kt">DOMString</span></a>? <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString? " href="#dom-inputeventinit-data" id="ref-for-dom-inputeventinit-data">data</a> = "";
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③⑨"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-inputeventinit-iscomposing" id="ref-for-dom-inputeventinit-iscomposing">isComposing</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①①"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-inputeventinit-inputtype" id="ref-for-dom-inputeventinit-inputtype">inputType</a> = "";
+<pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-inputeventinit"><code><c- g>InputEventInit</c-></code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit⑤"><c- n>UIEventInit</c-></a> {
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⓪"><c- b>DOMString</c-></a>? <a class="idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString? " href="#dom-inputeventinit-data" id="ref-for-dom-inputeventinit-data"><c- g>data</c-></a> = "";
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③⑨"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-inputeventinit-iscomposing" id="ref-for-dom-inputeventinit-iscomposing"><c- g>isComposing</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①①"><c- b>DOMString</c-></a> <a class="idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-inputeventinit-inputtype" id="ref-for-dom-inputeventinit-inputtype"><c- g>inputType</c-></a> = "";
 };
 </pre>
     <dl>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="InputEventInit" data-dfn-type="dict-member" data-export="" id="dom-inputeventinit-data"><code>data</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①②">DOMString</a>, nullable, defaulting to <code>""</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="InputEventInit" data-dfn-type="dict-member" data-export id="dom-inputeventinit-data"><code>data</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①②">DOMString</a>, nullable, defaulting to <code>""</code></span>
      <dd> Initializes the <code>data</code> attribute of the InputEvent object. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="InputEventInit" data-dfn-type="dict-member" data-export="" id="dom-inputeventinit-iscomposing"><code>isComposing</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④⓪">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="InputEventInit" data-dfn-type="dict-member" data-export id="dom-inputeventinit-iscomposing"><code>isComposing</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④⓪">boolean</a>, defaulting to <code>false</code></span>
      <dd> Initializes the <code>isComposing</code> attribute of the InputEvent object. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="InputEventInit" data-dfn-type="dict-member" data-export="" id="dom-inputeventinit-inputtype"><code>inputType</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①③">DOMString</a>, defaulting to <code>""</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="InputEventInit" data-dfn-type="dict-member" data-export id="dom-inputeventinit-inputtype"><code>inputType</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①③">DOMString</a>, defaulting to <code>""</code></span>
      <dd> Initializes the <code>inputType</code> attribute of the InputEvent object. 
     </dl>
     <h4 class="heading settled" data-level="4.5.2" id="events-inputevent-event-order"><span class="secno">4.5.2. </span><span class="content">Input Event Order</span><a class="self-link" href="#events-inputevent-event-order"></a></h4>
@@ -3047,7 +3047,7 @@ portions of that content.</p>
        <td>
     </table>
     <h4 class="heading settled" data-level="4.5.3" id="events-input-types"><span class="secno">4.5.3. </span><span class="content">Input Event Types</span><a class="self-link" href="#events-input-types"></a></h4>
-    <h5 class="heading settled" data-level="4.5.3.1" id="event-type-beforeinput"><span class="secno">4.5.3.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="beforeinput">beforeinput</dfn></span><a class="self-link" href="#event-type-beforeinput"></a></h5>
+    <h5 class="heading settled" data-level="4.5.3.1" id="event-type-beforeinput"><span class="secno">4.5.3.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="beforeinput">beforeinput</dfn></span><a class="self-link" href="#event-type-beforeinput"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -3087,7 +3087,7 @@ portions of that content.</p>
     </table>
     <p>A <a data-link-type="dfn" href="#user-agent" id="ref-for-user-agent②⑨">user agent</a> MUST dispatch this event when the DOM is about
 			to be updated.</p>
-    <h5 class="heading settled" data-level="4.5.3.2" id="event-type-input"><span class="secno">4.5.3.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="input">input</dfn></span><a class="self-link" href="#event-type-input"></a></h5>
+    <h5 class="heading settled" data-level="4.5.3.2" id="event-type-input"><span class="secno">4.5.3.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="input">input</dfn></span><a class="self-link" href="#event-type-input"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -3147,31 +3147,31 @@ portions of that content.</p>
 		method <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate①⑦">getModifierState()</a></code> with <code class="keycap">Control</code>, <code class="keycap">Shift</code>, <code class="keycap">Alt</code>, or <code class="keycap">Meta</code> respectively.</p>
     <p>To create an instance of the <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent②⓪">KeyboardEvent</a></code> interface, use the <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent②①">KeyboardEvent</a></code> constructor, passing an optional <code class="idl"><a data-link-type="idl" href="#dictdef-keyboardeventinit" id="ref-for-dictdef-keyboardeventinit">KeyboardEventInit</a></code> dictionary.</p>
     <h5 class="heading settled" data-level="4.6.1.1" id="idl-keyboardevent"><span class="secno">4.6.1.1. </span><span class="content">KeyboardEvent</span><a class="self-link" href="#idl-keyboardevent"></a></h5>
-<pre class="idl highlight def" data-highlight="webidl">[<dfn class="nv idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="constructor" data-export="" data-lt="KeyboardEvent(type, eventInitDict)|KeyboardEvent(type)" id="dom-keyboardevent-keyboardevent"><code>Constructor</code><a class="self-link" href="#dom-keyboardevent-keyboardevent"></a></dfn>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①④"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="KeyboardEvent/KeyboardEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-keyboardevent-keyboardevent-type-eventinitdict-type"><code>type</code><a class="self-link" href="#dom-keyboardevent-keyboardevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-keyboardeventinit" id="ref-for-dictdef-keyboardeventinit①">KeyboardEventInit</a> <dfn class="nv idl-code" data-dfn-for="KeyboardEvent/KeyboardEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-keyboardevent-keyboardevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code><a class="self-link" href="#dom-keyboardevent-keyboardevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑤">Exposed</a>=<span class="n">Window</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="keyboardevent"><code>KeyboardEvent</code></dfn> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent⑤⑥">UIEvent</a> {
+<pre class="idl highlight def" data-highlight="webidl">[<dfn class="idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="constructor" data-export data-lt="KeyboardEvent(type, eventInitDict)|KeyboardEvent(type)" id="dom-keyboardevent-keyboardevent"><code><c- g>Constructor</c-></code><a class="self-link" href="#dom-keyboardevent-keyboardevent"></a></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①④"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="KeyboardEvent/KeyboardEvent(type, eventInitDict)" data-dfn-type="argument" data-export id="dom-keyboardevent-keyboardevent-type-eventinitdict-type"><code><c- g>type</c-></code><a class="self-link" href="#dom-keyboardevent-keyboardevent-type-eventinitdict-type"></a></dfn>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-keyboardeventinit" id="ref-for-dictdef-keyboardeventinit①"><c- n>KeyboardEventInit</c-></a> <dfn class="idl-code" data-dfn-for="KeyboardEvent/KeyboardEvent(type, eventInitDict)" data-dfn-type="argument" data-export id="dom-keyboardevent-keyboardevent-type-eventinitdict-eventinitdict"><code><c- g>eventInitDict</c-></code><a class="self-link" href="#dom-keyboardevent-keyboardevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑤"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="keyboardevent"><code><c- g>KeyboardEvent</c-></code></dfn> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent⑤⑥"><c- n>UIEvent</c-></a> {
   // KeyLocationCode
-  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑦"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_standard" id="ref-for-dom-keyboardevent-dom_key_location_standard">DOM_KEY_LOCATION_STANDARD</a> = 0x00;
-  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑧"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_left" id="ref-for-dom-keyboardevent-dom_key_location_left">DOM_KEY_LOCATION_LEFT</a> = 0x01;
-  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑨"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_right" id="ref-for-dom-keyboardevent-dom_key_location_right">DOM_KEY_LOCATION_RIGHT</a> = 0x02;
-  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①⓪"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_numpad" id="ref-for-dom-keyboardevent-dom_key_location_numpad">DOM_KEY_LOCATION_NUMPAD</a> = 0x03;
+  <c- b>const</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑦"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_standard" id="ref-for-dom-keyboardevent-dom_key_location_standard"><c- g>DOM_KEY_LOCATION_STANDARD</c-></a> = 0x00;
+  <c- b>const</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑧"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_left" id="ref-for-dom-keyboardevent-dom_key_location_left"><c- g>DOM_KEY_LOCATION_LEFT</c-></a> = 0x01;
+  <c- b>const</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑨"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_right" id="ref-for-dom-keyboardevent-dom_key_location_right"><c- g>DOM_KEY_LOCATION_RIGHT</c-></a> = 0x02;
+  <c- b>const</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①⓪"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_numpad" id="ref-for-dom-keyboardevent-dom_key_location_numpad"><c- g>DOM_KEY_LOCATION_NUMPAD</c-></a> = 0x03;
 
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑤"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-keyboardevent-key" id="ref-for-dom-keyboardevent-key③">key</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑥"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-keyboardevent-code" id="ref-for-dom-keyboardevent-code②">code</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①①"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-keyboardevent-location" id="ref-for-dom-keyboardevent-location">location</a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑤"><c- b>DOMString</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="DOMString" href="#dom-keyboardevent-key" id="ref-for-dom-keyboardevent-key③"><c- g>key</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑥"><c- b>DOMString</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="DOMString" href="#dom-keyboardevent-code" id="ref-for-dom-keyboardevent-code②"><c- g>code</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="unsigned long" href="#dom-keyboardevent-location" id="ref-for-dom-keyboardevent-location"><c- g>location</c-></a>;
 
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-ctrlkey" id="ref-for-dom-keyboardevent-ctrlkey②">ctrlKey</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④②"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-shiftkey" id="ref-for-dom-keyboardevent-shiftkey②">shiftKey</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④③"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-altkey" id="ref-for-dom-keyboardevent-altkey②">altKey</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④④"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-metakey" id="ref-for-dom-keyboardevent-metakey②">metaKey</a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④①"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="boolean" href="#dom-keyboardevent-ctrlkey" id="ref-for-dom-keyboardevent-ctrlkey②"><c- g>ctrlKey</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④②"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="boolean" href="#dom-keyboardevent-shiftkey" id="ref-for-dom-keyboardevent-shiftkey②"><c- g>shiftKey</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④③"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="boolean" href="#dom-keyboardevent-altkey" id="ref-for-dom-keyboardevent-altkey②"><c- g>altKey</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④④"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="boolean" href="#dom-keyboardevent-metakey" id="ref-for-dom-keyboardevent-metakey②"><c- g>metaKey</c-></a>;
 
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④⑤"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-repeat" id="ref-for-dom-keyboardevent-repeat">repeat</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④⑥"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-iscomposing" id="ref-for-dom-keyboardevent-iscomposing">isComposing</a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④⑤"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="boolean" href="#dom-keyboardevent-repeat" id="ref-for-dom-keyboardevent-repeat"><c- g>repeat</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④⑥"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="boolean" href="#dom-keyboardevent-iscomposing" id="ref-for-dom-keyboardevent-iscomposing"><c- g>isComposing</c-></a>;
 
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④⑦"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="method" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate①⑧">getModifierState</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑦"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="KeyboardEvent/getModifierState(keyArg)" data-dfn-type="argument" data-export="" id="dom-keyboardevent-getmodifierstate-keyarg-keyarg"><code>keyArg</code><a class="self-link" href="#dom-keyboardevent-getmodifierstate-keyarg-keyarg"></a></dfn>);
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④⑦"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate①⑧"><c- g>getModifierState</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑦"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="KeyboardEvent/getModifierState(keyArg)" data-dfn-type="argument" data-export id="dom-keyboardevent-getmodifierstate-keyarg-keyarg"><code><c- g>keyArg</c-></code><a class="self-link" href="#dom-keyboardevent-getmodifierstate-keyarg-keyarg"></a></dfn>);
 };
 </pre>
     <dl>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="const" data-export="" id="dom-keyboardevent-dom_key_location_standard"><code>DOM_KEY_LOCATION_STANDARD</code></dfn>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="const" data-export id="dom-keyboardevent-dom_key_location_standard"><code>DOM_KEY_LOCATION_STANDARD</code></dfn>
      <dd>
        The key activation MUST NOT be distinguished as the left or
 					right version of the key, and (other than the <code class="keycap">NumLock</code> key) did not originate from the numeric keypad (or did not
@@ -3179,38 +3179,38 @@ portions of that content.</p>
 					keypad). 
       <p class="example" id="example-911fe244"><a class="self-link" href="#example-911fe244"></a> The <code class="keycap">Q</code> key on a PC 101 Key US keyboard.<br> The <code class="keycap">NumLock</code> key on a PC 101 Key US keyboard.<br> The <code class="keycap">1</code> key on a PC 101 Key US keyboard located in the
 					main section of the keyboard. </p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="const" data-export="" id="dom-keyboardevent-dom_key_location_left"><code>DOM_KEY_LOCATION_LEFT</code></dfn>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="const" data-export id="dom-keyboardevent-dom_key_location_left"><code>DOM_KEY_LOCATION_LEFT</code></dfn>
      <dd>
        The key activated originated from the left key location (when
 					there is more than one possible location for this key). 
       <p class="example" id="example-93f18483"><a class="self-link" href="#example-93f18483"></a> The left <code class="keycap">Control</code> key on a PC 101 Key US keyboard. </p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="const" data-export="" id="dom-keyboardevent-dom_key_location_right"><code>DOM_KEY_LOCATION_RIGHT</code></dfn>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="const" data-export id="dom-keyboardevent-dom_key_location_right"><code>DOM_KEY_LOCATION_RIGHT</code></dfn>
      <dd>
        The key activation originated from the right key location (when
 					there is more than one possible location for this key). 
       <p class="example" id="example-39e05464"><a class="self-link" href="#example-39e05464"></a> The right <code class="keycap">Shift</code> key on a PC 101 Key US keyboard. </p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="const" data-export="" id="dom-keyboardevent-dom_key_location_numpad"><code>DOM_KEY_LOCATION_NUMPAD</code></dfn>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="const" data-export id="dom-keyboardevent-dom_key_location_numpad"><code>DOM_KEY_LOCATION_NUMPAD</code></dfn>
      <dd>
        The key activation originated on the numeric keypad or with a
 					virtual key corresponding to the numeric keypad (when there is
 					more than one possible location for this key). Note that the <code class="keycap">NumLock</code> key should always be encoded with a <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-location" id="ref-for-dom-keyboardevent-location①">location</a></code> of <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-dom_key_location_standard" id="ref-for-dom-keyboardevent-dom_key_location_standard①">DOM_KEY_LOCATION_STANDARD</a></code>. 
       <p class="example" id="example-cd3aecaf"><a class="self-link" href="#example-cd3aecaf"></a> The <code class="keycap">1</code> key on a PC 101 Key US keyboard located on the
 					numeric pad. </p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-key"><code>key</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑧">DOMString</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export id="dom-keyboardevent-key"><code>key</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑧">DOMString</a>, readonly</span>
      <dd>
-       <code>key</code> holds a <a data-link-type="dfn" href="http://www.w3.org/TR/uievents/#">key attribute value</a> corresponding to
+       <code>key</code> holds a <a data-link-type="dfn" href="http://www.w3.org/TR/uievents/#" id="termref-for-">key attribute value</a> corresponding to
 					the key pressed. 
       <p class="note" role="note"> The <code>key</code> attribute is not related to the legacy <code>keyCode</code> attribute and does not have the same set of
 					values. </p>
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value②②">un-initialized value</a> of this attribute MUST be <code>""</code> (the empty string).</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-code"><code>code</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑨">DOMString</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export id="dom-keyboardevent-code"><code>code</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑨">DOMString</a>, readonly</span>
      <dd>
        <code>code</code> holds a string that identifies the physical
 					key being pressed. The value is not affected by the current
 					keyboard layout or modifier state, so a particular key will
 					always return the same value. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value②③">un-initialized value</a> of this attribute MUST be <code>""</code> (the empty string).</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-location"><code>location</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①②">unsigned long</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export id="dom-keyboardevent-location"><code>location</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①②">unsigned long</a>, readonly</span>
      <dd>
        The <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-location" id="ref-for-dom-keyboardevent-location②">location</a></code> attribute contains an indication
 					of the logical location of the key on the device. 
@@ -3223,28 +3223,28 @@ portions of that content.</p>
 					then the <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-location" id="ref-for-dom-keyboardevent-location⑤">location</a></code> attribute MUST be set to
 					either <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-dom_key_location_left" id="ref-for-dom-keyboardevent-dom_key_location_left①">DOM_KEY_LOCATION_LEFT</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-dom_key_location_right" id="ref-for-dom-keyboardevent-dom_key_location_right①">DOM_KEY_LOCATION_RIGHT</a></code>.</p>
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value②④">un-initialized value</a> of this attribute MUST be <code>0</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-ctrlkey"><code>ctrlKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④⑧">boolean</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export id="dom-keyboardevent-ctrlkey"><code>ctrlKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④⑧">boolean</a>, readonly</span>
      <dd>
        <code>true</code> if the <code class="keycap">Control</code> (control) key modifier
 					was active. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value②⑤">un-initialized value</a> of this attribute MUST be <code>false</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-shiftkey"><code>shiftKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④⑨">boolean</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export id="dom-keyboardevent-shiftkey"><code>shiftKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④⑨">boolean</a>, readonly</span>
      <dd>
        <code>true</code> if the shift (<code class="keycap">Shift</code>) key modifier was
 					active. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value②⑥">un-initialized value</a> of this attribute MUST be <code>false</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-altkey"><code>altKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑤⓪">boolean</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export id="dom-keyboardevent-altkey"><code>altKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑤⓪">boolean</a>, readonly</span>
      <dd>
        <code>true</code> if the <code class="keycap">Alt</code> (alternative) (or <code class="glyph">"Option"</code>) key modifier was active. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value②⑦">un-initialized value</a> of this attribute MUST be <code>false</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-metakey"><code>metaKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑤①">boolean</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export id="dom-keyboardevent-metakey"><code>metaKey</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑤①">boolean</a>, readonly</span>
      <dd>
        <code>true</code> if the meta (<code class="keycap">Meta</code>) key modifier was
 					active. 
       <p class="note" role="note"> The <code class="glyph">"Command"</code> (<code class="glyph">"⌘"</code>) key modifier on Macintosh
 					systems is represented using this key modifier. </p>
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value②⑧">un-initialized value</a> of this attribute MUST be <code>false</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-repeat"><code>repeat</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑤②">boolean</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export id="dom-keyboardevent-repeat"><code>repeat</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑤②">boolean</a>, readonly</span>
      <dd>
        <code>true</code> if the key has been pressed in a sustained
 					manner.  Holding down a key MUST result in the repeating the
@@ -3255,13 +3255,13 @@ portions of that content.</p>
 					of <code>true</code> MUST serve as an indication of a <em>long-key-press</em>. The length of time that the key MUST be
 					pressed in order to begin repeating is configuration-dependent. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value②⑨">un-initialized value</a> of this attribute MUST be <code>false</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-iscomposing"><code>isComposing</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑤③">boolean</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export id="dom-keyboardevent-iscomposing"><code>isComposing</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑤③">boolean</a>, readonly</span>
      <dd>
        <code>true</code> if the key event occurs as part of a
 					composition session, i.e., after a <a data-link-type="dfn" href="#compositionstart" id="ref-for-compositionstart①"><code>compositionstart</code></a> event
 					and before the corresponding <a data-link-type="dfn" href="#compositionend" id="ref-for-compositionend①"><code>compositionend</code></a> event. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value③⓪">un-initialized value</a> of this attribute MUST be <code>false</code>.</p>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="method" data-export="" id="dom-keyboardevent-getmodifierstate"><code>getModifierState(keyArg)</code></dfn>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="method" data-export id="dom-keyboardevent-getmodifierstate"><code>getModifierState(keyArg)</code></dfn>
      <dd>
        Queries the state of a modifier using a key value. 
       <p>Returns <code>true</code> if it is a modifier key and
@@ -3277,53 +3277,53 @@ portions of that content.</p>
       </dl>
     </dl>
     <h5 class="heading settled" data-level="4.6.1.2" id="idl-keyboardeventinit"><span class="secno">4.6.1.2. </span><span class="content">KeyboardEventInit</span><a class="self-link" href="#idl-keyboardeventinit"></a></h5>
-<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-keyboardeventinit"><code>KeyboardEventInit</code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-eventmodifierinit" id="ref-for-dictdef-eventmodifierinit③">EventModifierInit</a> {
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⓪"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-keyboardeventinit-key" id="ref-for-dom-keyboardeventinit-key">key</a> = "";
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②①"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-keyboardeventinit-code" id="ref-for-dom-keyboardeventinit-code">code</a> = "";
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①③"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned long " href="#dom-keyboardeventinit-location" id="ref-for-dom-keyboardeventinit-location">location</a> = 0;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑤④"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-keyboardeventinit-repeat" id="ref-for-dom-keyboardeventinit-repeat">repeat</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑤⑤"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-keyboardeventinit-iscomposing" id="ref-for-dom-keyboardeventinit-iscomposing">isComposing</a> = <span class="kt">false</span>;
+<pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-keyboardeventinit"><code><c- g>KeyboardEventInit</c-></code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-eventmodifierinit" id="ref-for-dictdef-eventmodifierinit③"><c- n>EventModifierInit</c-></a> {
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⓪"><c- b>DOMString</c-></a> <a class="idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-keyboardeventinit-key" id="ref-for-dom-keyboardeventinit-key"><c- g>key</c-></a> = "";
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②①"><c- b>DOMString</c-></a> <a class="idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-keyboardeventinit-code" id="ref-for-dom-keyboardeventinit-code"><c- g>code</c-></a> = "";
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①③"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned long " href="#dom-keyboardeventinit-location" id="ref-for-dom-keyboardeventinit-location"><c- g>location</c-></a> = 0;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑤④"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-keyboardeventinit-repeat" id="ref-for-dom-keyboardeventinit-repeat"><c- g>repeat</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑤⑤"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-keyboardeventinit-iscomposing" id="ref-for-dom-keyboardeventinit-iscomposing"><c- g>isComposing</c-></a> = <c- b>false</c->;
 };
 </pre>
     <dl>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export="" id="dom-keyboardeventinit-key"><code>key</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②②">DOMString</a>, defaulting to <code>""</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export id="dom-keyboardeventinit-key"><code>key</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②②">DOMString</a>, defaulting to <code>""</code></span>
      <dd> Initializes the <code>key</code> attribute of the KeyboardEvent
 					object to the unicode character string representing the meaning
 					of a key after taking into account all keyboard modifiers
 					(such as shift-state). This value is the final effective value
 					of the key. If the key is not a printable character, then it
 					should be one of the key values defined in <a data-link-type="biblio" href="#biblio-uievents-key">[UIEvents-Key]</a>. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export="" id="dom-keyboardeventinit-code"><code>code</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②③">DOMString</a>, defaulting to <code>""</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export id="dom-keyboardeventinit-code"><code>code</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②③">DOMString</a>, defaulting to <code>""</code></span>
      <dd> Initializes the <code>code</code> attribute of the KeyboardEvent
 					object to the unicode character string representing the key that
 					was pressed, ignoring any keyboard modifications such as
 					keyboard layout. This value should be one of the code values
 					defined in [UIEvents-Code]]. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export="" id="dom-keyboardeventinit-location"><code>location</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①④">unsigned long</a>, defaulting to <code>0</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export id="dom-keyboardeventinit-location"><code>location</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①④">unsigned long</a>, defaulting to <code>0</code></span>
      <dd>
        Initializes the <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-location" id="ref-for-dom-keyboardevent-location⑦">location</a></code> attribute of the
 					KeyboardEvent object to one of the following location numerical
 					constants: 
       <ul>
-       <li data-md="">
+       <li data-md>
         <p><code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-dom_key_location_standard" id="ref-for-dom-keyboardevent-dom_key_location_standard③">DOM_KEY_LOCATION_STANDARD</a></code> (numerical value 0)</p>
        <p></p>
-       <li data-md="">
+       <li data-md>
         <p><code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-dom_key_location_left" id="ref-for-dom-keyboardevent-dom_key_location_left②">DOM_KEY_LOCATION_LEFT</a></code> (numerical value 1)</p>
        <p></p>
-       <li data-md="">
+       <li data-md>
         <p><code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-dom_key_location_right" id="ref-for-dom-keyboardevent-dom_key_location_right②">DOM_KEY_LOCATION_RIGHT</a></code> (numerical value 2)</p>
        <p></p>
-       <li data-md="">
+       <li data-md>
         <p><code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-dom_key_location_numpad" id="ref-for-dom-keyboardevent-dom_key_location_numpad①">DOM_KEY_LOCATION_NUMPAD</a></code> (numerical value 3)</p>
        <p></p>
       </ul>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export="" id="dom-keyboardeventinit-repeat"><code>repeat</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑤⑥">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export id="dom-keyboardeventinit-repeat"><code>repeat</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑤⑥">boolean</a>, defaulting to <code>false</code></span>
      <dd> Initializes the <code>repeat</code> attribute of the
 					KeyboardEvent object. This attribute should be set to <code>true</code> if the the current KeyboardEvent is considered
 					part of a repeating sequence of similar events caused by the
 					long depression of any single key, <code>false</code> otherwise. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export="" id="dom-keyboardeventinit-iscomposing"><code>isComposing</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑤⑦">boolean</a>, defaulting to <code>false</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEventInit" data-dfn-type="dict-member" data-export id="dom-keyboardeventinit-iscomposing"><code>isComposing</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑤⑦">boolean</a>, defaulting to <code>false</code></span>
      <dd> Initializes the <code>isComposing</code> attribute of the
 					KeyboardEvent object. This attribute should be set to <code>true</code> if the event being constructed occurs as part
 					of a composition sequence, <code>false</code> otherwise. 
@@ -3450,7 +3450,7 @@ portions of that content.</p>
 		a different <a data-link-type="dfn" href="#event-target" id="ref-for-event-target③⑧">event target</a> than the <a data-link-type="dfn" href="#keyup" id="ref-for-keyup③"><code>keyup</code></a> event on the same
 		keystroke. </p>
     <h4 class="heading settled" data-level="4.6.4" id="events-keyboard-types"><span class="secno">4.6.4. </span><span class="content">Keyboard Event Types</span><a class="self-link" href="#events-keyboard-types"></a></h4>
-    <h5 class="heading settled" data-level="4.6.4.1" id="event-type-keydown"><span class="secno">4.6.4.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="keydown">keydown</dfn></span><a class="self-link" href="#event-type-keydown"></a></h5>
+    <h5 class="heading settled" data-level="4.6.4.1" id="event-type-keydown"><span class="secno">4.6.4.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="keydown">keydown</dfn></span><a class="self-link" href="#event-type-keydown"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -3502,31 +3502,31 @@ portions of that content.</p>
 			with the same key.</p>
     <p>The default action of the <a data-link-type="dfn" href="#keydown" id="ref-for-keydown⑥"><code>keydown</code></a> event depends upon the key:</p>
     <ul>
-     <li data-md="">
+     <li data-md>
       <p>If the key is associated with a character, the default action
 MUST be to dispatch a <a data-link-type="dfn" href="#beforeinput" id="ref-for-beforeinput⑥"><code>beforeinput</code></a> event followed by an <a data-link-type="dfn" href="#input" id="ref-for-input⑥"><code>input</code></a> event. In the case where the key which is
 associated with multiple characters (such as with a macro or
 certain sequences of dead keys), the default action MUST be to
 dispatch one set of <a data-link-type="dfn" href="#beforeinput" id="ref-for-beforeinput⑦"><code>beforeinput</code></a> / <a data-link-type="dfn" href="#input" id="ref-for-input⑦"><code>input</code></a> events for
 each character</p>
-     <li data-md="">
+     <li data-md>
       <p>If the key is associated with a <a data-link-type="dfn" href="#text-composition-system" id="ref-for-text-composition-system①">text composition system</a>,
 the default action MUST be to launch that system</p>
-     <li data-md="">
+     <li data-md>
       <p>If the key is the <code class="keycap">Tab</code> key, the default action MUST be
 to shift the document focus from the currently focused element
 (if any) to the new focused element, as described in <a href="#events-focusevent">Focus Event Types</a></p>
-     <li data-md="">
+     <li data-md>
       <p>If the key is the <code class="keycap">Enter</code> or <code class="keycap"> </code> key and the
 current focus is on a state-changing element, the default action
-MUST be to dispatch a <a data-link-type="dfn" href="#click" id="ref-for-click③①"><code>click</code></a> event, and a <a data-link-type="dfn" href="#domactivate" id="ref-for-domactivate"><code>DOMActivate</code></a> event if that event type is supported by the <a data-link-type="dfn" href="#user-agent" id="ref-for-user-agent③③">user agent</a> (refer to <a href="#event-flow-activation">§3.5 Activation triggers and behavior</a> for more
+MUST be to dispatch a <a data-link-type="dfn" href="#click" id="ref-for-click③①"><code>click</code></a> event, and a <a data-link-type="dfn" href="#domactivate" id="ref-for-domactivate"><code>DOMActivate</code></a> event if that event type is supported by the <a data-link-type="dfn" href="#user-agent" id="ref-for-user-agent③③">user agent</a> (refer to <a href="#event-flow-activation">§ 3.5 Activation triggers and behavior</a> for more
 details)</p>
     </ul>
     <p>If this event is canceled, the associated event types MUST NOT be
 			dispatched, and the associated actions MUST NOT be performed.</p>
     <p class="note" role="note"> The <a data-link-type="dfn" href="#keydown" id="ref-for-keydown⑦"><code>keydown</code></a> and <a data-link-type="dfn" href="#keyup" id="ref-for-keyup⑤"><code>keyup</code></a> events are traditionally
 			associated with detecting any key, not just those which produce a <a data-link-type="dfn" href="#character-value" id="ref-for-character-value③">character value</a>. </p>
-    <h5 class="heading settled" data-level="4.6.4.2" id="event-type-keyup"><span class="secno">4.6.4.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="keyup">keyup</dfn></span><a class="self-link" href="#event-type-keyup"></a></h5>
+    <h5 class="heading settled" data-level="4.6.4.2" id="event-type-keyup"><span class="secno">4.6.4.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="keyup">keyup</dfn></span><a class="self-link" href="#event-type-keyup"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -3587,7 +3587,7 @@ details)</p>
 	absence from standard US keyboards, to build up logograms of many Asian
 	languages from their base components or categories, to select word choices
 	from a combination of key presses on a mobile device keyboard, or to convert
-	voice commands into text using a speech recognition processor. Refer to <a href="#keys">§5 Keyboard events and key values</a> for examples on how Composition Events are used in combination
+	voice commands into text using a speech recognition processor. Refer to <a href="#keys">§ 5 Keyboard events and key values</a> for examples on how Composition Events are used in combination
 	with keyboard events.</p>
     <p>Conceptually, a composition session consists of one <a data-link-type="dfn" href="#compositionstart" id="ref-for-compositionstart②"><code>compositionstart</code></a> event, one or more <a data-link-type="dfn" href="#compositionupdate" id="ref-for-compositionupdate"><code>compositionupdate</code></a> events, and one <a data-link-type="dfn" href="#compositionend" id="ref-for-compositionend②"><code>compositionend</code></a> event, with the value of the <code class="idl"><a data-link-type="idl" href="#dom-compositionevent-data" id="ref-for-dom-compositionevent-data">data</a></code> attribute persisting between each <q>stage</q> of this event chain during
 	each session.</p>
@@ -3605,13 +3605,13 @@ details)</p>
     <p>To create an instance of the <code class="idl"><a data-link-type="idl" href="#compositionevent" id="ref-for-compositionevent①">CompositionEvent</a></code> interface,
 		use the <code class="idl"><a data-link-type="idl" href="#compositionevent" id="ref-for-compositionevent②">CompositionEvent</a></code> constructor, passing an optional <code class="idl"><a data-link-type="idl" href="#dictdef-compositioneventinit" id="ref-for-dictdef-compositioneventinit">CompositionEventInit</a></code> dictionary.</p>
     <h5 class="heading settled" data-level="4.7.1.1" id="idl-compositionevent"><span class="secno">4.7.1.1. </span><span class="content">CompositionEvent</span><a class="self-link" href="#idl-compositionevent"></a></h5>
-<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="CompositionEvent" data-dfn-type="constructor" data-export="" data-lt="CompositionEvent(type, eventInitDict)|CompositionEvent(type)" id="dom-compositionevent-compositionevent"><code>Constructor</code><a class="self-link" href="#dom-compositionevent-compositionevent"></a></dfn>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②④"><span class="kt">DOMString</span></a> <dfn class="nv idl-code" data-dfn-for="CompositionEvent/CompositionEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-compositionevent-compositionevent-type-eventinitdict-type"><code>type</code><a class="self-link" href="#dom-compositionevent-compositionevent-type-eventinitdict-type"></a></dfn>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-compositioneventinit" id="ref-for-dictdef-compositioneventinit①">CompositionEventInit</a> <dfn class="nv idl-code" data-dfn-for="CompositionEvent/CompositionEvent(type, eventInitDict)" data-dfn-type="argument" data-export="" id="dom-compositionevent-compositionevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code><a class="self-link" href="#dom-compositionevent-compositionevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑥">Exposed</a>=<span class="n">Window</span>]
-<span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="compositionevent"><code>CompositionEvent</code></dfn> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent⑥①">UIEvent</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑤"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-compositionevent-data" id="ref-for-dom-compositionevent-data①">data</a>;
+<pre class="idl highlight def">[<dfn class="idl-code" data-dfn-for="CompositionEvent" data-dfn-type="constructor" data-export data-lt="CompositionEvent(type, eventInitDict)|CompositionEvent(type)" id="dom-compositionevent-compositionevent"><code><c- g>Constructor</c-></code><a class="self-link" href="#dom-compositionevent-compositionevent"></a></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②④"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="CompositionEvent/CompositionEvent(type, eventInitDict)" data-dfn-type="argument" data-export id="dom-compositionevent-compositionevent-type-eventinitdict-type"><code><c- g>type</c-></code><a class="self-link" href="#dom-compositionevent-compositionevent-type-eventinitdict-type"></a></dfn>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-compositioneventinit" id="ref-for-dictdef-compositioneventinit①"><c- n>CompositionEventInit</c-></a> <dfn class="idl-code" data-dfn-for="CompositionEvent/CompositionEvent(type, eventInitDict)" data-dfn-type="argument" data-export id="dom-compositionevent-compositionevent-type-eventinitdict-eventinitdict"><code><c- g>eventInitDict</c-></code><a class="self-link" href="#dom-compositionevent-compositionevent-type-eventinitdict-eventinitdict"></a></dfn>), <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑥"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="compositionevent"><code><c- g>CompositionEvent</c-></code></dfn> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent⑥①"><c- n>UIEvent</c-></a> {
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑤"><c- b>DOMString</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="DOMString" href="#dom-compositionevent-data" id="ref-for-dom-compositionevent-data①"><c- g>data</c-></a>;
 };
 </pre>
     <dl>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="CompositionEvent" data-dfn-type="attribute" data-export="" id="dom-compositionevent-data"><code>data</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑥">DOMString</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="CompositionEvent" data-dfn-type="attribute" data-export id="dom-compositionevent-data"><code>data</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑥">DOMString</a>, readonly</span>
      <dd>
        <code>data</code> holds the value of the characters generated by
 					an input method. This MAY be a single Unicode character or a
@@ -3622,12 +3622,12 @@ details)</p>
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value③①">un-initialized value</a> of this attribute MUST be <code>""</code> (the empty string).</p>
     </dl>
     <h5 class="heading settled" data-level="4.7.1.2" id="idl-compositioneventinit"><span class="secno">4.7.1.2. </span><span class="content">CompositionEventInit</span><a class="self-link" href="#idl-compositioneventinit"></a></h5>
-<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-compositioneventinit"><code>CompositionEventInit</code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit⑥">UIEventInit</a> {
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑦"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-compositioneventinit-data" id="ref-for-dom-compositioneventinit-data">data</a> = "";
+<pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-compositioneventinit"><code><c- g>CompositionEventInit</c-></code></dfn> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit⑥"><c- n>UIEventInit</c-></a> {
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑦"><c- b>DOMString</c-></a> <a class="idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-compositioneventinit-data" id="ref-for-dom-compositioneventinit-data"><c- g>data</c-></a> = "";
 };
 </pre>
     <dl>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="CompositionEventInit" data-dfn-type="dict-member" data-export="" id="dom-compositioneventinit-data"><code>data</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑧">DOMString</a>, defaulting to <code>""</code></span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="CompositionEventInit" data-dfn-type="dict-member" data-export id="dom-compositioneventinit-data"><code>data</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑧">DOMString</a>, defaulting to <code>""</code></span>
      <dd> Initializes the <code>data</code> attribute of the
 					CompositionEvent object to the characters generated by the IME
 					composition. 
@@ -3858,7 +3858,7 @@ details)</p>
        <td>
     </table>
     <h4 class="heading settled" data-level="4.7.7" id="events-composition-types"><span class="secno">4.7.7. </span><span class="content">Composition Event Types</span><a class="self-link" href="#events-composition-types"></a></h4>
-    <h5 class="heading settled" data-level="4.7.7.1" id="event-type-compositionstart"><span class="secno">4.7.7.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="compositionstart">compositionstart</dfn></span><a class="self-link" href="#event-type-compositionstart"></a></h5>
+    <h5 class="heading settled" data-level="4.7.7.1" id="event-type-compositionstart"><span class="secno">4.7.7.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="compositionstart">compositionstart</dfn></span><a class="self-link" href="#event-type-compositionstart"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -3919,7 +3919,7 @@ details)</p>
 			session (e.g., such as GTK which doesn’t presently have such an
 			API). In these cases, calling <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-preventdefault" id="ref-for-dom-event-preventdefault⑤">preventDefault()</a></code> will not
 			stop this event’s default action. </p>
-    <h5 class="heading settled" data-level="4.7.7.2" id="event-type-compositionupdate"><span class="secno">4.7.7.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="compositionupdate">compositionupdate</dfn></span><a class="self-link" href="#event-type-compositionupdate"></a></h5>
+    <h5 class="heading settled" data-level="4.7.7.2" id="event-type-compositionupdate"><span class="secno">4.7.7.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="compositionupdate">compositionupdate</dfn></span><a class="self-link" href="#event-type-compositionupdate"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -3969,7 +3969,7 @@ details)</p>
     <p>If the composition session is canceled, this event will be fired
 			immediately before the <a data-link-type="dfn" href="#compositionend" id="ref-for-compositionend①⓪"><code>compositionend</code></a> event, and the <code class="idl"><a data-link-type="idl" href="#dom-compositionevent-data" id="ref-for-dom-compositionevent-data⑧">data</a></code> attribute will be set to the <a data-link-type="dfn" href="#empty-string" id="ref-for-empty-string⑦">empty
 			string</a>.</p>
-    <h5 class="heading settled" data-level="4.7.7.3" id="event-type-compositionend"><span class="secno">4.7.7.3. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="compositionend">compositionend</dfn></span><a class="self-link" href="#event-type-compositionend"></a></h5>
+    <h5 class="heading settled" data-level="4.7.7.3" id="event-type-compositionend"><span class="secno">4.7.7.3. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="compositionend">compositionend</dfn></span><a class="self-link" href="#event-type-compositionend"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -4018,13 +4018,13 @@ details)</p>
     <h2 class="heading settled" data-level="5" id="keys"><span class="secno">5. </span><span class="content">Keyboard events and key values</span><a class="self-link" href="#keys"></a></h2>
     <p>This section contains necessary information regarding keyboard events:</p>
     <ul>
-     <li data-md="">
+     <li data-md>
       <p>Explanation of keyboard layout, mapping, and key values.</p>
-     <li data-md="">
+     <li data-md>
       <p>Relations between keys, such as <a data-link-type="dfn" href="#dead-key" id="ref-for-dead-key">dead keys</a> or modifiers keys.</p>
-     <li data-md="">
+     <li data-md>
       <p>Relations between keyboard events and their default actions.</p>
-     <li data-md="">
+     <li data-md>
       <p>The set of <code>key</code> values, and guidelines on how to extend this set.</p>
     </ul>
     <p class="note" role="note"> This section uses Serbian and Kanji characters which could be misrepresented or
@@ -4035,13 +4035,13 @@ unavailable in the PDF version or printed version of this specification. </p>
 	aspects, each of which vary among different models and configurations of
 	keyboards, particularly for locale-specific reasons:</p>
     <ul>
-     <li data-md="">
+     <li data-md>
       <p><strong>Mechanical layout:</strong> the dimensions, size, and placement
 of the physical keys on the keyboard</p>
-     <li data-md="">
+     <li data-md>
       <p><strong>Visual markings:</strong> the labels (or <em>legends</em>) that
 mark each key</p>
-     <li data-md="">
+     <li data-md>
       <p><strong>Functional mapping:</strong> the abstract key-value association
 of each key.</p>
     </ul>
@@ -5396,13 +5396,13 @@ described in this Appendix.</p>
     <p>This section documents legacy initializer methods that were introduced
 	in earlier versions of this specification.</p>
     <h4 class="heading settled" data-level="6.1.1" id="idl-interface-UIEvent-initializers"><span class="secno">6.1.1. </span><span class="content">Initializers for interface UIEvent</span><a class="self-link" href="#idl-interface-UIEvent-initializers"></a></h4>
-<pre class="idl-ignore" data-highlight="webidl" data-no-idl="">partial interface UIEvent {
+<pre class="idl-ignore" data-highlight="webidl" data-no-idl>partial interface UIEvent {
   // Deprecated in this specification
   void initUIEvent();
 };
 </pre>
     <dl>
-     <dt><dfn class="idl-code" data-dfn-for="UIEvent" data-dfn-type="method" data-export="" id="dom-uievent-inituievent"><code>initUIEvent()</code><a class="self-link" href="#dom-uievent-inituievent"></a></dfn>
+     <dt><dfn class="idl-code" data-dfn-for="UIEvent" data-dfn-type="method" data-export id="dom-uievent-inituievent"><code>initUIEvent()</code><a class="self-link" href="#dom-uievent-inituievent"></a></dfn>
      <dd>
        Initializes attributes of an <code class="idl"><a data-link-type="idl" href="#uievent" id="ref-for-uievent⑥⑧">UIEvent</a></code> object.
 				This method has the same behavior as <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-initevent" id="ref-for-dom-event-initevent①">initEvent()</a></code>. 
@@ -5423,13 +5423,13 @@ described in this Appendix.</p>
       </dl>
     </dl>
     <h4 class="heading settled" data-level="6.1.2" id="idl-interface-MouseEvent-initializers"><span class="secno">6.1.2. </span><span class="content">Initializers for interface MouseEvent</span><a class="self-link" href="#idl-interface-MouseEvent-initializers"></a></h4>
-<pre class="idl-ignore" data-highlight="webidl" data-no-idl="">partial interface MouseEvent {
+<pre class="idl-ignore" data-highlight="webidl" data-no-idl>partial interface MouseEvent {
   // Deprecated in this specification
   void initMouseEvent();
 };
 </pre>
     <dl>
-     <dt><dfn class="idl-code" data-dfn-for="MouseEvent" data-dfn-type="method" data-export="" id="dom-mouseevent-initmouseevent"><code>initMouseEvent()</code><a class="self-link" href="#dom-mouseevent-initmouseevent"></a></dfn>
+     <dt><dfn class="idl-code" data-dfn-for="MouseEvent" data-dfn-type="method" data-export id="dom-mouseevent-initmouseevent"><code>initMouseEvent()</code><a class="self-link" href="#dom-mouseevent-initmouseevent"></a></dfn>
      <dd>
        Initializes attributes of a <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent①⑤③">MouseEvent</a></code> object. This
 				method has the same behavior as <code>UIEvent.initUIEvent()</code>. 
@@ -5471,13 +5471,13 @@ described in this Appendix.</p>
       </dl>
     </dl>
     <h4 class="heading settled" data-level="6.1.3" id="idl-interface-WheelEvent-initializers"><span class="secno">6.1.3. </span><span class="content">Initializers for interface WheelEvent</span><a class="self-link" href="#idl-interface-WheelEvent-initializers"></a></h4>
-<pre class="idl-ignore" data-highlight="webidl" data-no-idl="">partial interface WheelEvent {
+<pre class="idl-ignore" data-highlight="webidl" data-no-idl>partial interface WheelEvent {
   // Originally introduced (and deprecated) in this specification
   void initWheelEvent();
 };
 </pre>
     <dl>
-     <dt><dfn class="idl-code" data-dfn-for="WheelEvent" data-dfn-type="method" data-export="" id="dom-wheelevent-initwheelevent"><code>initWheelEvent()</code><a class="self-link" href="#dom-wheelevent-initwheelevent"></a></dfn>
+     <dt><dfn class="idl-code" data-dfn-for="WheelEvent" data-dfn-type="method" data-export id="dom-wheelevent-initwheelevent"><code>initWheelEvent()</code><a class="self-link" href="#dom-wheelevent-initwheelevent"></a></dfn>
      <dd>
        Initializes attributes of a <code>WheelEvent</code> object. This
 				method has the same behavior as <code>MouseEvent.initMouseEvent()</code>. 
@@ -5523,10 +5523,10 @@ described in this Appendix.</p>
     <h4 class="heading settled" data-level="6.1.4" id="idl-interface-KeyboardEvent-initializers"><span class="secno">6.1.4. </span><span class="content">Initializers for interface KeyboardEvent</span><a class="self-link" href="#idl-interface-KeyboardEvent-initializers"></a></h4>
     <p class="note" role="note"> The argument list to this legacy KeyboardEvent initializer does not
 		include the <code>detailArg</code> (present in other initializers) and
-		adds the <code>locale</code> argument (see <a href="#changes-drafts">§11.2 Changes between different drafts of UI Events</a>); it is
+		adds the <code>locale</code> argument (see <a href="#changes-drafts">§ 11.2 Changes between different drafts of UI Events</a>); it is
 		necessary to preserve this inconsistency for compatibility with existing
 		implementations. </p>
-<pre class="idl-ignore" data-highlight="webidl" data-no-idl="">partial interface KeyboardEvent {
+<pre class="idl-ignore" data-highlight="webidl" data-no-idl>partial interface KeyboardEvent {
   // Originally introduced (and deprecated) in this specification
   void initKeyboardEvent(DOMString typeArg,
                          optional boolean bubblesArg = false,
@@ -5541,7 +5541,7 @@ described in this Appendix.</p>
 };
 </pre>
     <dl>
-     <dt><dfn class="idl-code" data-dfn-for="KeyboardEveng" data-dfn-type="method" data-export="" id="dom-keyboardeveng-initkeyboardevent"><code>initKeyboardEvent()</code><a class="self-link" href="#dom-keyboardeveng-initkeyboardevent"></a></dfn>
+     <dt><dfn class="idl-code" data-dfn-for="KeyboardEveng" data-dfn-type="method" data-export id="dom-keyboardeveng-initkeyboardevent"><code>initKeyboardEvent()</code><a class="self-link" href="#dom-keyboardeveng-initkeyboardevent"></a></dfn>
      <dd>
        Initializes attributes of a <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent⑦①">KeyboardEvent</a></code> object. This
 				method has the same behavior as <code>UIEvent.initUIEvent()</code>.
@@ -5573,16 +5573,16 @@ described in this Appendix.</p>
     <h4 class="heading settled" data-level="6.1.5" id="idl-interface-CompositionEvent-initializers"><span class="secno">6.1.5. </span><span class="content">Initializers for interface CompositionEvent</span><a class="self-link" href="#idl-interface-CompositionEvent-initializers"></a></h4>
     <p class="note" role="note"> The argument list to this legacy CompositionEvent initializer does not
 		include the <code>detailArg</code> (present in other initializers) and
-		adds the <code>locale</code> argument (see <a href="#changes-drafts">§11.2 Changes between different drafts of UI Events</a>); it is
+		adds the <code>locale</code> argument (see <a href="#changes-drafts">§ 11.2 Changes between different drafts of UI Events</a>); it is
 		necessary to preserve this inconsistency for compatibility with existing
 		implementations. </p>
-<pre class="idl-ignore" data-highlight="webidl" data-no-idl="">partial interface CompositionEvent {
+<pre class="idl-ignore" data-highlight="webidl" data-no-idl>partial interface CompositionEvent {
   // Originally introduced (and deprecated) in this specification
   void initCompositionEvent();
 };
 </pre>
     <dl>
-     <dt><dfn class="idl-code" data-dfn-for="CompositionEvent" data-dfn-type="method" data-export="" id="dom-compositionevent-initcompositionevent"><code>initCompositionEvent()</code><a class="self-link" href="#dom-compositionevent-initcompositionevent"></a></dfn>
+     <dt><dfn class="idl-code" data-dfn-for="CompositionEvent" data-dfn-type="method" data-export id="dom-compositionevent-initcompositionevent"><code>initCompositionEvent()</code><a class="self-link" href="#dom-compositionevent-initcompositionevent"></a></dfn>
      <dd>
        Initializes attributes of a <code>CompositionEvent</code> object. This method has the same behavior as <code>UIEvent.initUIEvent()</code>. The value of <code class="idl"><a data-link-type="idl" href="#dom-uievent-detail" id="ref-for-dom-uievent-detail③②">detail</a></code> remains undefined. 
       <p class="warning"> The <code>initCompositionEvent</code> method is deprecated. </p>
@@ -5630,13 +5630,13 @@ used.</p>
 	directly on <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent⑦③">KeyboardEvent</a></code> and <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent①⑤⑤">MouseEvent</a></code> rather than having a shared <code class="idl"><a data-link-type="idl" href="#dom-uievent-which" id="ref-for-dom-uievent-which②">which</a></code> attribute defined on <code class="idl"><a data-link-type="idl" href="#uievent" id="ref-for-uievent⑦⓪">UIEvent</a></code>. </p>
     <h4 class="heading settled" data-level="7.1.1" id="legacy-interface-UIEvent"><span class="secno">7.1.1. </span><span class="content">Interface UIEvent (supplemental)</span><a class="self-link" href="#legacy-interface-UIEvent"></a></h4>
     <p>The partial <code class="idl"><a data-link-type="idl" href="#uievent" id="ref-for-uievent⑦①">UIEvent</a></code> interface is an informative extension of the <code class="idl"><a data-link-type="idl" href="#uievent" id="ref-for-uievent⑦②">UIEvent</a></code> interface, which adds the <code class="idl"><a data-link-type="idl" href="#dom-uievent-which" id="ref-for-dom-uievent-which③">which</a></code> attribute.</p>
-<pre class="idl highlight def"><span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="#uievent" id="ref-for-uievent⑦③">UIEvent</a> {
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#uievent" id="ref-for-uievent⑦③"><c- g>UIEvent</c-></a> {
   // The following support legacy user agents
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①⑤"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-uievent-which" id="ref-for-dom-uievent-which④">which</a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①⑤"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="unsigned long" href="#dom-uievent-which" id="ref-for-dom-uievent-which④"><c- g>which</c-></a>;
 };
 </pre>
     <dl>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="UIEvent" data-dfn-type="attribute" data-export="" id="dom-uievent-which"><code>which</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①⑥">unsigned long</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="UIEvent" data-dfn-type="attribute" data-export id="dom-uievent-which"><code>which</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①⑥">unsigned long</a>, readonly</span>
      <dd> For <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent①⑤⑥">MouseEvent</a></code>s, this contains a value equal to the value stored in <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-button" id="ref-for-dom-mouseevent-button②⑤">button</a></code>+1.
 				For <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent⑦④">KeyboardEvent</a></code>s, this holds a system- and implementation-dependent
 				numerical code signifying the unmodified identifier associated
@@ -5646,12 +5646,12 @@ used.</p>
     <p>Browsers that include support for <code class="idl"><a data-link-type="idl" href="#dom-uievent-which" id="ref-for-dom-uievent-which⑤">which</a></code> in <code class="idl"><a data-link-type="idl" href="#uievent" id="ref-for-uievent⑦④">UIEvent</a></code> should also add the following members to the <code class="idl"><a data-link-type="idl" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit⑦">UIEventInit</a></code> dictionary.</p>
     <p>The partial <code class="idl"><a data-link-type="idl" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit⑧">UIEventInit</a></code> dictionary is an informative extension
 		of the <code class="idl"><a data-link-type="idl" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit⑨">UIEventInit</a></code> dictionary, which adds the <code class="idl"><a data-link-type="idl" href="#dom-uievent-which" id="ref-for-dom-uievent-which⑥">which</a></code> member to initialize the corresponding <code class="idl"><a data-link-type="idl" href="#uievent" id="ref-for-uievent⑦⑤">UIEvent</a></code> attributes.</p>
-<pre class="idl-ignore" data-highlight="webidl" data-no-idl="">partial dictionary UIEventInit {
+<pre class="idl-ignore" data-highlight="webidl" data-no-idl>partial dictionary UIEventInit {
   unsigned long which = 0;
 };
 </pre>
     <dl>
-     <dt><dfn data-dfn-for="UIEventInit" data-dfn-type="dfn" data-noexport="" id="uieventinit-which" unknown="">which<a class="self-link" href="#uieventinit-which"></a></dfn>
+     <dt><dfn data-dfn-for="UIEventInit" data-dfn-type="dfn" data-noexport id="uieventinit-which" unknown>which<a class="self-link" href="#uieventinit-which"></a></dfn>
      <dd> Initializes the <code class="idl"><a data-link-type="idl" href="#dom-uievent-which" id="ref-for-dom-uievent-which⑦">which</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#uievent" id="ref-for-uievent⑦⑥">UIEvent</a></code>. 
     </dl>
     <h3 class="heading settled" data-level="7.2" id="legacy-KeyboardEvent"><span class="secno">7.2. </span><span class="content">Legacy <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent⑦⑤">KeyboardEvent</a></code> supplemental interface</span><a class="self-link" href="#legacy-KeyboardEvent"></a></h3>
@@ -5668,19 +5668,19 @@ used.</p>
 		the <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent⑦⑦">KeyboardEvent</a></code> interface, which adds the <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-charcode" id="ref-for-dom-keyboardevent-charcode③">charCode</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-keycode" id="ref-for-dom-keyboardevent-keycode④">keyCode</a></code> attributes.</p>
     <p>The partial <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent⑦⑧">KeyboardEvent</a></code> interface can be obtained by using the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-document-createevent" id="ref-for-dom-document-createevent①">createEvent()</a></code> method call in
 		implementations that support this extension.</p>
-<pre class="idl highlight def"><span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="#keyboardevent" id="ref-for-keyboardevent⑦⑨">KeyboardEvent</a> {
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#keyboardevent" id="ref-for-keyboardevent⑦⑨"><c- g>KeyboardEvent</c-></a> {
   // The following support legacy user agents
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①⑦"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-keyboardevent-charcode" id="ref-for-dom-keyboardevent-charcode④">charCode</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①⑧"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-keyboardevent-keycode" id="ref-for-dom-keyboardevent-keycode⑤">keyCode</a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①⑦"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="unsigned long" href="#dom-keyboardevent-charcode" id="ref-for-dom-keyboardevent-charcode④"><c- g>charCode</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①⑧"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="unsigned long" href="#dom-keyboardevent-keycode" id="ref-for-dom-keyboardevent-keycode⑤"><c- g>keyCode</c-></a>;
 };
 </pre>
     <dl>
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-charcode"><code>charCode</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①⑨">unsigned long</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export id="dom-keyboardevent-charcode"><code>charCode</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①⑨">unsigned long</a>, readonly</span>
      <dd> <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-charcode" id="ref-for-dom-keyboardevent-charcode⑤">charCode</a></code> holds a character value, for <a data-link-type="dfn" href="#keypress" id="ref-for-keypress⑤"><code>keypress</code></a> events which generate character input. The value
 				is the Unicode reference number (code point) of that character
 				(e.g. <code>event.charCode = event.key.charCodeAt(0)</code> for
 				printable characters). For <a data-link-type="dfn" href="#keydown" id="ref-for-keydown⑤⑨"><code>keydown</code></a> or <a data-link-type="dfn" href="#keyup" id="ref-for-keyup⑤③"><code>keyup</code></a> events, the value of <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-charcode" id="ref-for-dom-keyboardevent-charcode⑥">charCode</a></code> is <code>0</code>. 
-     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export="" id="dom-keyboardevent-keycode"><code>keyCode</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②⓪">unsigned long</a>, readonly</span>
+     <dt><dfn class="dfn-paneled idl-code" data-dfn-for="KeyboardEvent" data-dfn-type="attribute" data-export id="dom-keyboardevent-keycode"><code>keyCode</code></dfn>, <span> of type <a data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②⓪">unsigned long</a>, readonly</span>
      <dd>
        <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-keycode" id="ref-for-dom-keyboardevent-keycode⑥">keyCode</a></code> holds a system- and
 				implementation-dependent numerical code signifying the
@@ -5692,24 +5692,24 @@ used.</p>
 				1252 <a data-link-type="biblio" href="#biblio-win1252">[WIN1252]</a>, but MAY be drawn from a different appropriate
 				character set. Implementations that are unable to identify a key
 				use the key value <code class="keycap">0</code>. 
-      <p>See <a href="#legacy-key-models">§7.3 Legacy key models</a> for more details on how to determine
+      <p>See <a href="#legacy-key-models">§ 7.3 Legacy key models</a> for more details on how to determine
 				the values for <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-keycode" id="ref-for-dom-keyboardevent-keycode⑧">keyCode</a></code>.</p>
     </dl>
     <h4 class="heading settled" data-level="7.2.2" id="legacy-dictionary-KeyboardEventInit"><span class="secno">7.2.2. </span><span class="content">Interface KeyboardEventInit (supplemental)</span><a class="self-link" href="#legacy-dictionary-KeyboardEventInit"></a></h4>
-    <p>Browsers that include support for <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-keycode" id="ref-for-dom-keyboardevent-keycode⑨">keyCode</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-charcode" id="ref-for-dom-keyboardevent-charcode⑦">charCode</a></code>, and <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/uievents/#dom-keyboardevent-which" id="ref-for-dom-keyboardevent-which">which</a></code> in <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent⑧⓪">KeyboardEvent</a></code> should also add the following members to the <code class="idl"><a data-link-type="idl" href="#dictdef-keyboardeventinit" id="ref-for-dictdef-keyboardeventinit②">KeyboardEventInit</a></code> dictionary.</p>
+    <p>Browsers that include support for <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-keycode" id="ref-for-dom-keyboardevent-keycode⑨">keyCode</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-charcode" id="ref-for-dom-keyboardevent-charcode⑦">charCode</a></code>, and <code class="idl"><a data-link-type="idl">which</a></code> in <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent⑧⓪">KeyboardEvent</a></code> should also add the following members to the <code class="idl"><a data-link-type="idl" href="#dictdef-keyboardeventinit" id="ref-for-dictdef-keyboardeventinit②">KeyboardEventInit</a></code> dictionary.</p>
     <p>The partial <code class="idl"><a data-link-type="idl" href="#dictdef-keyboardeventinit" id="ref-for-dictdef-keyboardeventinit③">KeyboardEventInit</a></code> dictionary is an informative extension
-		of the <code class="idl"><a data-link-type="idl" href="#dictdef-keyboardeventinit" id="ref-for-dictdef-keyboardeventinit④">KeyboardEventInit</a></code> dictionary, which adds <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-charcode" id="ref-for-dom-keyboardevent-charcode⑧">charCode</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-keycode" id="ref-for-dom-keyboardevent-keycode①⓪">keyCode</a></code>, and <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/uievents/#dom-keyboardevent-which" id="ref-for-dom-keyboardevent-which①">which</a></code> members to initialize the corresponding <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent⑧①">KeyboardEvent</a></code> attributes.</p>
-<pre class="idl-ignore" data-highlight="webidl" data-no-idl="">partial dictionary KeyboardEventInit {
+		of the <code class="idl"><a data-link-type="idl" href="#dictdef-keyboardeventinit" id="ref-for-dictdef-keyboardeventinit④">KeyboardEventInit</a></code> dictionary, which adds <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-charcode" id="ref-for-dom-keyboardevent-charcode⑧">charCode</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-keycode" id="ref-for-dom-keyboardevent-keycode①⓪">keyCode</a></code>, and <code class="idl"><a data-link-type="idl">which</a></code> members to initialize the corresponding <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent⑧①">KeyboardEvent</a></code> attributes.</p>
+<pre class="idl-ignore" data-highlight="webidl" data-no-idl>partial dictionary KeyboardEventInit {
   // The following support legacy user agents
   unsigned long charCode = 0;
   unsigned long keyCode = 0;
 };
 </pre>
     <dl>
-     <dt><dfn data-dfn-for="KeyboardEventInit" data-dfn-type="dfn" data-noexport="" id="keyboardeventinit-charcode" unknown="">charCode<a class="self-link" href="#keyboardeventinit-charcode"></a></dfn>
+     <dt><dfn data-dfn-for="KeyboardEventInit" data-dfn-type="dfn" data-noexport id="keyboardeventinit-charcode" unknown>charCode<a class="self-link" href="#keyboardeventinit-charcode"></a></dfn>
      <dd> Initializes the <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-charcode" id="ref-for-dom-keyboardevent-charcode⑨">charCode</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent⑧②">KeyboardEvent</a></code> to the Unicode code point for the event’s
 				character. 
-     <dt><dfn data-dfn-for="KeyboardEventInit" data-dfn-type="dfn" data-noexport="" id="keyboardeventinit-keycode" unknown="">keyCode<a class="self-link" href="#keyboardeventinit-keycode"></a></dfn>
+     <dt><dfn data-dfn-for="KeyboardEventInit" data-dfn-type="dfn" data-noexport id="keyboardeventinit-keycode" unknown>keyCode<a class="self-link" href="#keyboardeventinit-keycode"></a></dfn>
      <dd> Initializes the <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-keycode" id="ref-for-dom-keyboardevent-keycode①①">keyCode</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent⑧③">KeyboardEvent</a></code> to the system- and implementation-dependent
 				numerical code signifying the unmodified identifier associated
 				with the key pressed. 
@@ -5724,40 +5724,40 @@ used.</p>
     <p>The <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-keycode" id="ref-for-dom-keyboardevent-keycode①⑤">keyCode</a></code> for <a data-link-type="dfn" href="#keydown" id="ref-for-keydown⑥①"><code>keydown</code></a> or <a data-link-type="dfn" href="#keyup" id="ref-for-keyup⑤⑤"><code>keyup</code></a> events
 		is calculated as follows:</p>
     <ul>
-     <li data-md="">
+     <li data-md>
       <p>Read the virtual key code from the operating system’s event
 information, if such information is available.</p>
-     <li data-md="">
+     <li data-md>
       <p>If an Input Method Editor is processing key input and the event is <a data-link-type="dfn" href="#keydown" id="ref-for-keydown⑥②"><code>keydown</code></a>, return 229.</p>
-     <li data-md="">
+     <li data-md>
       <p>If input key when pressed without modifiers would insert a numerical
 character (0-9), return the ASCII code of that numerical character.</p>
-     <li data-md="">
+     <li data-md>
       <p>If input key when pressed without modifiers would insert a lower
 case character in the a-z alphabetical range, return the ASCII code
 of the upper case equivalent.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the implementation supports a key code conversion table for the
 operating system and platform, look up the value. If the conversion
 table specifies an alternate virtual key value for the given input,
 return the specified value.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the key’s function, as determined in an implementation-specific
-way, corresponds to one of the keys in the <a href="#fixed-virtual-key-codes">§7.3.3 Fixed virtual key codes</a> table, return the corresponding key
+way, corresponds to one of the keys in the <a href="#fixed-virtual-key-codes">§ 7.3.3 Fixed virtual key codes</a> table, return the corresponding key
 code.</p>
-     <li data-md="">
+     <li data-md>
       <p>Return the virtual key code from the operating system.</p>
-     <li data-md="">
+     <li data-md>
       <p>If no key code was found, return 0.</p>
     </ul>
     <h4 class="heading settled" data-level="7.3.2" id="determine-keypress-keyCode"><span class="secno">7.3.2. </span><span class="content">How to determine <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-keycode" id="ref-for-dom-keyboardevent-keycode①⑥">keyCode</a></code> for <a data-link-type="dfn" href="#keypress" id="ref-for-keypress⑥"><code>keypress</code></a> events</span><a class="self-link" href="#determine-keypress-keyCode"></a></h4>
     <p>The <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-keycode" id="ref-for-dom-keyboardevent-keycode①⑦">keyCode</a></code> for <a data-link-type="dfn" href="#keypress" id="ref-for-keypress⑦"><code>keypress</code></a> events is calculated
 		as follows:</p>
     <ul>
-     <li data-md="">
+     <li data-md>
       <p>If the implementation supports a <em>conflated model</em>, set <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-keycode" id="ref-for-dom-keyboardevent-keycode①⑧">keyCode</a></code> to the Unicode code point of the character
 being entered.</p>
-     <li data-md="">
+     <li data-md>
       <p>If the implementation supports a <em>split model</em>, set <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-keycode" id="ref-for-dom-keyboardevent-keycode①⑨">keyCode</a></code> to 0.</p>
     </ul>
     <h4 class="heading settled" data-level="7.3.3" id="fixed-virtual-key-codes"><span class="secno">7.3.3. </span><span class="content">Fixed virtual key codes</span><a class="self-link" href="#fixed-virtual-key-codes"></a></h4>
@@ -6067,7 +6067,7 @@ completeness.</p>
     </table>
     <h3 class="heading settled" data-level="8.1" id="legacy-uievent-events"><span class="secno">8.1. </span><span class="content">Legacy <code class="idl"><a data-link-type="idl" href="#uievent" id="ref-for-uievent⑦⑨">UIEvent</a></code> events</span><a class="self-link" href="#legacy-uievent-events"></a></h3>
     <h4 class="heading settled" data-level="8.1.1" id="legacy-uievent-event-types"><span class="secno">8.1.1. </span><span class="content">Legacy <code class="idl"><a data-link-type="idl" href="#uievent" id="ref-for-uievent⑧⓪">UIEvent</a></code> event types</span><a class="self-link" href="#legacy-uievent-event-types"></a></h4>
-    <h5 class="heading settled" data-level="8.1.1.1" id="event-type-DOMActivate"><span class="secno">8.1.1.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domactivate">DOMActivate</dfn></span><a class="self-link" href="#event-type-DOMActivate"></a></h5>
+    <h5 class="heading settled" data-level="8.1.1.1" id="event-type-DOMActivate"><span class="secno">8.1.1.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="domactivate">DOMActivate</dfn></span><a class="self-link" href="#event-type-DOMActivate"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -6105,7 +6105,7 @@ completeness.</p>
         </ul>
     </table>
     <p>A <a data-link-type="dfn" href="#user-agent" id="ref-for-user-agent④⑥">user agent</a> MUST dispatch this event when a button, link, or
-			other state-changing element is activated.  Refer to <a href="#event-flow-activation">§3.5 Activation triggers and behavior</a> for more details.</p>
+			other state-changing element is activated.  Refer to <a href="#event-flow-activation">§ 3.5 Activation triggers and behavior</a> for more details.</p>
     <p class="warning" id="DOMActivate-deprecated"> The <a data-link-type="dfn" href="#domactivate" id="ref-for-domactivate③"><code>DOMActivate</code></a> <a data-link-type="dfn" href="#event-type" id="ref-for-event-type①③">event type</a> is defined in this
 			specification for reference and completeness, but this specification <a data-link-type="dfn" href="#deprecates" id="ref-for-deprecates⑤">deprecates</a> the use of this event type in favor of the related <a data-link-type="dfn" href="#event-type" id="ref-for-event-type①④">event type</a> <a data-link-type="dfn" href="#click" id="ref-for-click③②"><code>click</code></a>.  Other specifications MAY define and
 			maintain their own <a data-link-type="dfn" href="#domactivate" id="ref-for-domactivate④"><code>DOMActivate</code></a> <a data-link-type="dfn" href="#event-type" id="ref-for-event-type①⑤">event type</a> for backwards
@@ -6188,7 +6188,7 @@ completeness.</p>
     </table>
     <h3 class="heading settled" data-level="8.2" id="legacy-focusevent-events"><span class="secno">8.2. </span><span class="content">Legacy <code class="idl"><a data-link-type="idl" href="#focusevent" id="ref-for-focusevent①②">FocusEvent</a></code> events</span><a class="self-link" href="#legacy-focusevent-events"></a></h3>
     <h4 class="heading settled" data-level="8.2.1" id="legacy-focusevent-event-types"><span class="secno">8.2.1. </span><span class="content">Legacy <code class="idl"><a data-link-type="idl" href="#focusevent" id="ref-for-focusevent①③">FocusEvent</a></code> event types</span><a class="self-link" href="#legacy-focusevent-event-types"></a></h4>
-    <h5 class="heading settled" data-level="8.2.1.1" id="event-type-DOMFocusIn"><span class="secno">8.2.1.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domfocusin">DOMFocusIn</dfn></span><a class="self-link" href="#event-type-DOMFocusIn"></a></h5>
+    <h5 class="heading settled" data-level="8.2.1.1" id="event-type-DOMFocusIn"><span class="secno">8.2.1.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="domfocusin">DOMFocusIn</dfn></span><a class="self-link" href="#event-type-DOMFocusIn"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -6233,7 +6233,7 @@ completeness.</p>
 			specification for reference and completeness, but this
 			specification <a data-link-type="dfn" href="#deprecates" id="ref-for-deprecates⑥">deprecates</a> the use of this event type in
 			favor of the related event types <a data-link-type="dfn" href="#focus" id="ref-for-focus⑧"><code>focus</code></a> and <a data-link-type="dfn" href="#focusin" id="ref-for-focusin④"><code>focusin</code></a>. </p>
-    <h5 class="heading settled" data-level="8.2.1.2" id="event-type-DOMFocusOut"><span class="secno">8.2.1.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domfocusout">DOMFocusOut</dfn></span><a class="self-link" href="#event-type-DOMFocusOut"></a></h5>
+    <h5 class="heading settled" data-level="8.2.1.2" id="event-type-DOMFocusOut"><span class="secno">8.2.1.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="domfocusout">DOMFocusOut</dfn></span><a class="self-link" href="#event-type-DOMFocusOut"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -6337,13 +6337,13 @@ completeness.</p>
     <p>The <a data-link-type="dfn" href="#keypress" id="ref-for-keypress⑨"><code>keypress</code></a> event is the traditional method for capturing key events
 	and processing them before the DOM is updated with the effects of the key
 	press. Code that makes use of the <a data-link-type="dfn" href="#keypress" id="ref-for-keypress①⓪"><code>keypress</code></a> event typically relies on
-	the legacy <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-charcode" id="ref-for-dom-keyboardevent-charcode①①">charCode</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-keycode" id="ref-for-dom-keyboardevent-keycode②⓪">keyCode</a></code>, and <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/uievents/#dom-keyboardevent-which" id="ref-for-dom-keyboardevent-which②">which</a></code> attributes.</p>
+	the legacy <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-charcode" id="ref-for-dom-keyboardevent-charcode①①">charCode</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-keycode" id="ref-for-dom-keyboardevent-keycode②⓪">keyCode</a></code>, and <code class="idl"><a data-link-type="idl">which</a></code> attributes.</p>
     <p>Note that the <a data-link-type="dfn" href="#keypress" id="ref-for-keypress①①"><code>keypress</code></a> event is specific to key events, and has been
 	replaced by the more general event sequence of <a data-link-type="dfn" href="#beforeinput" id="ref-for-beforeinput②⑧"><code>beforeinput</code></a> and <a data-link-type="dfn" href="#input" id="ref-for-input②⑨"><code>input</code></a> events. These new <code>input</code> events are not specific to
 	keyboard actions and can be used to capture user input regardless of the
 	original source.</p>
     <h4 class="heading settled" data-level="8.3.1" id="legacy-keyboardevent-event-types"><span class="secno">8.3.1. </span><span class="content">Legacy <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent⑧⑥">KeyboardEvent</a></code> event types</span><a class="self-link" href="#legacy-keyboardevent-event-types"></a></h4>
-    <h5 class="heading settled" data-level="8.3.1.1" id="event-type-keypress"><span class="secno">8.3.1.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="keypress">keypress</dfn></span><a class="self-link" href="#event-type-keypress"></a></h5>
+    <h5 class="heading settled" data-level="8.3.1.1" id="event-type-keypress"><span class="secno">8.3.1.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="keypress">keypress</dfn></span><a class="self-link" href="#event-type-keypress"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -6384,7 +6384,7 @@ completeness.</p>
 								legacy character value for this event
          <li><code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent⑧⑨">KeyboardEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-keycode" id="ref-for-dom-keyboardevent-keycode②①">keyCode</a></code> :
 								legacy numerical code for this key
-         <li><code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent⑨⓪">KeyboardEvent</a></code>.<code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/uievents/#dom-keyboardevent-which" id="ref-for-dom-keyboardevent-which③">which</a></code> :
+         <li><code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent⑨⓪">KeyboardEvent</a></code>.<code class="idl"><a data-link-type="idl">which</a></code> :
 								legacy numerical code for this key
          <li><code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent⑨①">KeyboardEvent</a></code>.<code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-key" id="ref-for-dom-keyboardevent-key④⑥">key</a></code> :
 								the key value of the key pressed.
@@ -6502,7 +6502,7 @@ completeness.</p>
 		information associated with Mutation events.</p>
     <p>To create an instance of the <code>MutationEvent</code> interface, use
 		the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-document-createevent" id="ref-for-dom-document-createevent②">createEvent()</a></code> method call.</p>
-<pre class="idl-ignore" data-highlight="webidl" data-no-idl="">interface MutationEvent : Event {
+<pre class="idl-ignore" data-highlight="webidl" data-no-idl>interface MutationEvent : Event {
   // attrChangeType
   const unsigned short MODIFICATION = 1;
   const unsigned short ADDITION = 2;
@@ -6518,13 +6518,13 @@ completeness.</p>
 };
 </pre>
     <dl>
-     <dt><dfn class="idl-code" data-dfn-for="MutationEvent" data-dfn-type="const" data-export="" id="dom-mutationevent-modification"><code>MODIFICATION</code><a class="self-link" href="#dom-mutationevent-modification"></a></dfn>
+     <dt><dfn class="idl-code" data-dfn-for="MutationEvent" data-dfn-type="const" data-export id="dom-mutationevent-modification"><code>MODIFICATION</code><a class="self-link" href="#dom-mutationevent-modification"></a></dfn>
      <dd> The <code>Attr</code> was modified in place. 
-     <dt><dfn class="idl-code" data-dfn-for="MutationEvent" data-dfn-type="const" data-export="" id="dom-mutationevent-addition"><code>ADDITION</code><a class="self-link" href="#dom-mutationevent-addition"></a></dfn>
+     <dt><dfn class="idl-code" data-dfn-for="MutationEvent" data-dfn-type="const" data-export id="dom-mutationevent-addition"><code>ADDITION</code><a class="self-link" href="#dom-mutationevent-addition"></a></dfn>
      <dd> The <code>Attr</code> was just added. 
-     <dt><dfn class="idl-code" data-dfn-for="MutationEvent" data-dfn-type="const" data-export="" id="dom-mutationevent-removal"><code>REMOVAL</code><a class="self-link" href="#dom-mutationevent-removal"></a></dfn>
+     <dt><dfn class="idl-code" data-dfn-for="MutationEvent" data-dfn-type="const" data-export id="dom-mutationevent-removal"><code>REMOVAL</code><a class="self-link" href="#dom-mutationevent-removal"></a></dfn>
      <dd> The <code>Attr</code> was just removed. 
-     <dt><dfn data-dfn-for="MutationEvent" data-dfn-type="dfn" data-noexport="" id="mutationevent-relatednode" unknown="">relatedNode<a class="self-link" href="#mutationevent-relatednode"></a></dfn>
+     <dt><dfn data-dfn-for="MutationEvent" data-dfn-type="dfn" data-noexport id="mutationevent-relatednode" unknown>relatedNode<a class="self-link" href="#mutationevent-relatednode"></a></dfn>
      <dd>
        <code>relatedNode</code> MUST be used to identify a secondary
 				node related to a mutation event. For example, if a mutation
@@ -6534,28 +6534,28 @@ completeness.</p>
 				indicating a node was changed within it, the <code>relatedNode</code> MUST be the changed node. In the case
 				of the <a data-link-type="dfn" href="#domattrmodified" id="ref-for-domattrmodified①"><code>DOMAttrModified</code></a> event, it indicates the <code>Attr</code> node which was modified, added, or removed. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value③②">un-initialized value</a> of this attribute MUST be <code>null</code>.</p>
-     <dt><dfn data-dfn-for="MutationEvent" data-dfn-type="dfn" data-noexport="" id="mutationevent-prevvalue" unknown="">prevValue<a class="self-link" href="#mutationevent-prevvalue"></a></dfn>
+     <dt><dfn data-dfn-for="MutationEvent" data-dfn-type="dfn" data-noexport id="mutationevent-prevvalue" unknown>prevValue<a class="self-link" href="#mutationevent-prevvalue"></a></dfn>
      <dd>
        <code>prevValue</code> indicates the previous value of the <code>Attr</code> node in <a data-link-type="dfn" href="#domattrmodified" id="ref-for-domattrmodified②"><code>DOMAttrModified</code></a> events, and of
 				the <code>CharacterData</code> node in <a data-link-type="dfn" href="#domcharacterdatamodified" id="ref-for-domcharacterdatamodified①"><code>DOMCharacterDataModified</code></a> events. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value③③">un-initialized value</a> of this attribute MUST be <code>""</code> (the empty string).</p>
-     <dt><dfn data-dfn-for="MutationEvent" data-dfn-type="dfn" data-noexport="" id="mutationevent-newvalue" unknown="">newValue<a class="self-link" href="#mutationevent-newvalue"></a></dfn>
+     <dt><dfn data-dfn-for="MutationEvent" data-dfn-type="dfn" data-noexport id="mutationevent-newvalue" unknown>newValue<a class="self-link" href="#mutationevent-newvalue"></a></dfn>
      <dd>
        <code>newValue</code> indicates the new value of the <code>Attr</code> node in <a data-link-type="dfn" href="#domattrmodified" id="ref-for-domattrmodified③"><code>DOMAttrModified</code></a> events, and of
 				the <code>CharacterData</code> node in <a data-link-type="dfn" href="#domcharacterdatamodified" id="ref-for-domcharacterdatamodified②"><code>DOMCharacterDataModified</code></a> events. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value③④">un-initialized value</a> of this attribute MUST be <code>""</code> (the empty string).</p>
-     <dt><dfn data-dfn-for="MutationEvent" data-dfn-type="dfn" data-noexport="" id="mutationevent-attrname" unknown="">attrName<a class="self-link" href="#mutationevent-attrname"></a></dfn>
+     <dt><dfn data-dfn-for="MutationEvent" data-dfn-type="dfn" data-noexport id="mutationevent-attrname" unknown>attrName<a class="self-link" href="#mutationevent-attrname"></a></dfn>
      <dd>
        <code>attrName</code> indicates the name of the changed <code>Attr</code> node in a <a data-link-type="dfn" href="#domattrmodified" id="ref-for-domattrmodified④"><code>DOMAttrModified</code></a> event. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value③⑤">un-initialized value</a> of this attribute MUST be <code>""</code> (the empty string).</p>
-     <dt><dfn data-dfn-for="MutationEvent" data-dfn-type="dfn" data-noexport="" id="mutationevent-attrchange" unknown="">attrChange<a class="self-link" href="#mutationevent-attrchange"></a></dfn>
+     <dt><dfn data-dfn-for="MutationEvent" data-dfn-type="dfn" data-noexport id="mutationevent-attrchange" unknown>attrChange<a class="self-link" href="#mutationevent-attrchange"></a></dfn>
      <dd>
        <code>attrChange</code> indicates the type of change which
 				triggered the <a data-link-type="dfn" href="#domattrmodified" id="ref-for-domattrmodified⑤"><code>DOMAttrModified</code></a> event. The values can be <code>MODIFICATION</code>, <code>ADDITION</code>, or <code>REMOVAL</code>. 
       <p>The <a data-link-type="dfn" href="#un-initialized-value" id="ref-for-un-initialized-value③⑥">un-initialized value</a> of this attribute MUST be <code>0</code>.</p>
       <p class="note" role="note"> There is no defined constant for the attrChange value of 0 (the
 				un-initialized value). </p>
-     <dt><dfn class="idl-code" data-dfn-for="MutationEvent" data-dfn-type="method" data-export="" id="dom-mutationevent-initmutationevent"><code>initMutationEvent()</code><a class="self-link" href="#dom-mutationevent-initmutationevent"></a></dfn>
+     <dt><dfn class="idl-code" data-dfn-for="MutationEvent" data-dfn-type="method" data-export id="dom-mutationevent-initmutationevent"><code>initMutationEvent()</code><a class="self-link" href="#dom-mutationevent-initmutationevent"></a></dfn>
      <dd>
        Initializes attributes of a <code>MutationEvent</code> object.
 				This method has the same behavior as <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-initevent" id="ref-for-dom-event-initevent①⑦">initEvent()</a></code>. 
@@ -6583,7 +6583,7 @@ completeness.</p>
     </dl>
     <h4 class="heading settled" data-level="8.4.2" id="legacy-mutationevent-event-types"><span class="secno">8.4.2. </span><span class="content">Legacy <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#mutationevent" id="ref-for-mutationevent①⑥">MutationEvent</a></code> event types</span><a class="self-link" href="#legacy-mutationevent-event-types"></a></h4>
     <p>The mutation event types are listed below.</p>
-    <h5 class="heading settled" data-level="8.4.2.1" id="event-type-DOMAttrModified"><span class="secno">8.4.2.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domattrmodified">DOMAttrModified</dfn></span><a class="self-link" href="#event-type-DOMAttrModified"></a></h5>
+    <h5 class="heading settled" data-level="8.4.2.1" id="event-type-DOMAttrModified"><span class="secno">8.4.2.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="domattrmodified">DOMAttrModified</dfn></span><a class="self-link" href="#event-type-DOMAttrModified"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -6635,7 +6635,7 @@ completeness.</p>
 			not affect the value of <code>Attr.value</code>.</p>
     <p class="warning"> The <a data-link-type="dfn" href="#domattrmodified" id="ref-for-domattrmodified⑥"><code>DOMAttrModified</code></a> event type is defined in this
 			specification for reference and completeness, but this specification <a data-link-type="dfn" href="#deprecates" id="ref-for-deprecates①⓪">deprecates</a> the use of this event type. </p>
-    <h5 class="heading settled" data-level="8.4.2.2" id="event-type-DOMCharacterDataModified"><span class="secno">8.4.2.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domcharacterdatamodified">DOMCharacterDataModified</dfn></span><a class="self-link" href="#event-type-DOMCharacterDataModified"></a></h5>
+    <h5 class="heading settled" data-level="8.4.2.2" id="event-type-DOMCharacterDataModified"><span class="secno">8.4.2.2. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="domcharacterdatamodified">DOMCharacterDataModified</dfn></span><a class="self-link" href="#event-type-DOMCharacterDataModified"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -6685,7 +6685,7 @@ completeness.</p>
 			or the <code>ProcessingInstruction</code> node.</p>
     <p class="warning"> The <a data-link-type="dfn" href="#domcharacterdatamodified" id="ref-for-domcharacterdatamodified③"><code>DOMCharacterDataModified</code></a> event type is defined in this
 			specification for reference and completeness, but this specification <a data-link-type="dfn" href="#deprecates" id="ref-for-deprecates①①">deprecates</a> the use of this event type. </p>
-    <h5 class="heading settled" data-level="8.4.2.3" id="event-type-DOMNodeInserted"><span class="secno">8.4.2.3. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domnodeinserted">DOMNodeInserted</dfn></span><a class="self-link" href="#event-type-DOMNodeInserted"></a></h5>
+    <h5 class="heading settled" data-level="8.4.2.3" id="event-type-DOMNodeInserted"><span class="secno">8.4.2.3. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="domnodeinserted">DOMNodeInserted</dfn></span><a class="self-link" href="#event-type-DOMNodeInserted"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -6736,7 +6736,7 @@ completeness.</p>
     <p class="note" id="DOMNodeInserted-attr" role="note"><a class="self-link" href="#DOMNodeInserted-attr"></a> For detecting attribute insertion, use the <a data-link-type="dfn" href="#domattrmodified" id="ref-for-domattrmodified⑦"><code>DOMAttrModified</code></a> event type instead. </p>
     <p class="warning"> The <a data-link-type="dfn" href="#domnodeinserted" id="ref-for-domnodeinserted①"><code>DOMNodeInserted</code></a> event type is defined in this
 			specification for reference and completeness, but this specification <a data-link-type="dfn" href="#deprecates" id="ref-for-deprecates①②">deprecates</a> the use of this event type. </p>
-    <h5 class="heading settled" data-level="8.4.2.4" id="event-type-DOMNodeInsertedIntoDocument"><span class="secno">8.4.2.4. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domnodeinsertedintodocument">DOMNodeInsertedIntoDocument</dfn></span><a class="self-link" href="#event-type-DOMNodeInsertedIntoDocument"></a></h5>
+    <h5 class="heading settled" data-level="8.4.2.4" id="event-type-DOMNodeInsertedIntoDocument"><span class="secno">8.4.2.4. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="domnodeinsertedintodocument">DOMNodeInsertedIntoDocument</dfn></span><a class="self-link" href="#event-type-DOMNodeInsertedIntoDocument"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -6790,7 +6790,7 @@ completeness.</p>
 			this event type.</p>
     <p class="warning"> The <a data-link-type="dfn" href="#domnodeinsertedintodocument" id="ref-for-domnodeinsertedintodocument①"><code>DOMNodeInsertedIntoDocument</code></a> event type is defined in this
 			specification for reference and completeness, but this specification <a data-link-type="dfn" href="#deprecates" id="ref-for-deprecates①③">deprecates</a> the use of this event type. </p>
-    <h5 class="heading settled" data-level="8.4.2.5" id="event-type-DOMNodeRemoved"><span class="secno">8.4.2.5. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domnoderemoved">DOMNodeRemoved</dfn></span><a class="self-link" href="#event-type-DOMNodeRemoved"></a></h5>
+    <h5 class="heading settled" data-level="8.4.2.5" id="event-type-DOMNodeRemoved"><span class="secno">8.4.2.5. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="domnoderemoved">DOMNodeRemoved</dfn></span><a class="self-link" href="#event-type-DOMNodeRemoved"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -6840,7 +6840,7 @@ completeness.</p>
     <p class="note" id="DOMNodeRemoved-attr" role="note"><a class="self-link" href="#DOMNodeRemoved-attr"></a> For reliably detecting attribute removal, use the <a data-link-type="dfn" href="#domattrmodified" id="ref-for-domattrmodified⑧"><code>DOMAttrModified</code></a> event type instead. </p>
     <p class="warning"> The <a data-link-type="dfn" href="#domnoderemoved" id="ref-for-domnoderemoved①"><code>DOMNodeRemoved</code></a> event type is defined in this
 			specification for reference and completeness, but this specification <a data-link-type="dfn" href="#deprecates" id="ref-for-deprecates①④">deprecates</a> the use of this event type. </p>
-    <h5 class="heading settled" data-level="8.4.2.6" id="event-type-DOMNodeRemovedFromDocument"><span class="secno">8.4.2.6. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domnoderemovedfromdocument">DOMNodeRemovedFromDocument</dfn></span><a class="self-link" href="#event-type-DOMNodeRemovedFromDocument"></a></h5>
+    <h5 class="heading settled" data-level="8.4.2.6" id="event-type-DOMNodeRemovedFromDocument"><span class="secno">8.4.2.6. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="domnoderemovedfromdocument">DOMNodeRemovedFromDocument</dfn></span><a class="self-link" href="#event-type-DOMNodeRemovedFromDocument"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -6895,7 +6895,7 @@ completeness.</p>
     <p class="note" role="note"> For reliably detecting attribute removal, use the <a data-link-type="dfn" href="#domattrmodified" id="ref-for-domattrmodified⑨"><code>DOMAttrModified</code></a> event type instead. </p>
     <p class="warning"> The <a data-link-type="dfn" href="#domnoderemovedfromdocument" id="ref-for-domnoderemovedfromdocument①"><code>DOMNodeRemovedFromDocument</code></a> event type is defined in this
 			specification for reference and completeness, but this specification <a data-link-type="dfn" href="#deprecates" id="ref-for-deprecates①⑤">deprecates</a> the use of this event type. </p>
-    <h5 class="heading settled" data-level="8.4.2.7" id="event-type-DOMSubtreeModified"><span class="secno">8.4.2.7. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="domsubtreemodified">DOMSubtreeModified</dfn></span><a class="self-link" href="#event-type-DOMSubtreeModified"></a></h5>
+    <h5 class="heading settled" data-level="8.4.2.7" id="event-type-DOMSubtreeModified"><span class="secno">8.4.2.7. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="domsubtreemodified">DOMSubtreeModified</dfn></span><a class="self-link" href="#event-type-DOMSubtreeModified"></a></h5>
     <table class="event-definition">
      <tbody>
       <tr>
@@ -7090,10 +7090,10 @@ attempt to embed resources on the local network.</p>
     <p>This new specification introduced the following new concepts in the
         event flow:</p>
     <ul>
-     <li data-md="">
+     <li data-md>
       <p>Event listeners are now ordered. In DOM Level 2, the event ordering
 was unspecified.</p>
-     <li data-md="">
+     <li data-md>
       <p>The event flow now includes the <a data-link-type="dfn" href="#window" id="ref-for-window⑤⓪"><code>Window</code></a>, to
 reflect existing implementations.</p>
     </ul>
@@ -7112,32 +7112,32 @@ reflect existing implementations.</p>
      <dt>Interface <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#event" id="ref-for-event⑤④">Event</a></code>
      <dd>
       <ul>
-       <li data-md="">
+       <li data-md>
         <p>The <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#event" id="ref-for-event⑤⑤">Event</a></code> interface has one new attribute, <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-defaultprevented" id="ref-for-dom-event-defaultprevented①">defaultPrevented</a></code>, and one new method, <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-stopimmediatepropagation" id="ref-for-dom-event-stopimmediatepropagation">stopImmediatePropagation()</a></code>.</p>
-       <li data-md="">
+       <li data-md>
         <p><code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-timestamp" id="ref-for-dom-event-timestamp">timeStamp</a></code> is now a <code>Number</code> in the
 ECMAScript binding. A proposed correction to make the same
 change in <a data-link-type="biblio" href="#biblio-dom-level-3-core">[DOM-Level-3-Core]</a> is forthcoming.</p>
-       <li data-md="">
+       <li data-md>
         <p>This specification considers the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-type" id="ref-for-dom-event-type">type</a></code> attribute
 to be case-sensitive, while DOM Level 2 Events considers <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-type" id="ref-for-dom-event-type①">type</a></code> to be case-insensitive.</p>
       </ul>
      <dt>Interface <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget①⓪">EventTarget</a></code>
      <dd>
       <ul>
-       <li data-md="">
+       <li data-md>
         <p>The method <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-eventtarget-dispatchevent" id="ref-for-dom-eventtarget-dispatchevent③">dispatchEvent()</a></code> was modified.</p>
       </ul>
      <dt>Interface <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent①⑤⑧">MouseEvent</a></code>
      <dd>
       <ul>
-       <li data-md="">
+       <li data-md>
         <p>The <code class="idl"><a data-link-type="idl" href="#mouseevent" id="ref-for-mouseevent①⑤⑨">MouseEvent</a></code> interface has one new method <code class="idl"><a data-link-type="idl" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate①⑥">getModifierState()</a></code>.</p>
       </ul>
      <dt>Exception <code>EventException</code>
      <dd>
       <ul>
-       <li data-md="">
+       <li data-md>
         <p>The exception <code>EventException</code> is removed in this
 specification. The prior <code>DISPATCH_REQUEST_ERR</code> code is re-mapped to a <code>DOMException</code> of type <code>InvalidStateError</code>.</p>
       </ul>
@@ -7161,33 +7161,33 @@ specification. The prior <code>DISPATCH_REQUEST_ERR</code> code is re-mapped to 
 	hierarchies and events flows more clearly. Here are some of the more
 	important changes between drafts:</p>
     <ul>
-     <li data-md="">
+     <li data-md>
       <p>The <q>key identifier</q> feature has been renamed <q>key value</q> to
 disambiguate them from unique identifiers for keys.</p>
-     <li data-md="">
+     <li data-md>
       <p>The <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent①⓪②">KeyboardEvent</a></code> interface was briefly (from 2003-2010) defined to
 have <code>keyIdentifier</code> and <code>keyLocation</code> attributes,
 but these were removed in favor of the current <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-key" id="ref-for-dom-keyboardevent-key④⑧">key</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-keyboardevent-location" id="ref-for-dom-keyboardevent-location①⑨">location</a></code> attributes. These attributes were not widely
 implemented.</p>
-     <li data-md="">
+     <li data-md>
       <p>The <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent①⓪③">KeyboardEvent</a></code> and <code class="idl"><a data-link-type="idl" href="#compositionevent" id="ref-for-compositionevent①⑦">CompositionEvent</a></code> interfaces defined a <code>locale</code> attribute. This attribute was underspecified and
 moved into a technical note until it can be specified adequately.
 Refer to this <a href="https://www.w3.org/TR/2014/WD-uievents-20140612/">old version of UI Events</a> (before the DOM3Events spec was renamed "UI Events") for details.</p>
-     <li data-md="">
+     <li data-md>
       <p>The <code class="idl"><a data-link-type="idl" href="#keyboardevent" id="ref-for-keyboardevent①⓪④">KeyboardEvent</a></code> also had a <code>char</code> attribute that
 was only used by the <a data-link-type="dfn" href="#keypress" id="ref-for-keypress②①"><code>keypress</code></a> event. Since the keypress event has
 been deprecated, this attribute was no longer useful and was removed.</p>
-     <li data-md="">
+     <li data-md>
       <p>The <code>change</code>, <code>submit</code>, and <code>reset</code> events were removed, since they were specific to HTML forms, and are
 specified in <a data-link-type="biblio" href="#biblio-html5">[HTML5]</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>The <code>textInput</code> event, originally proposed as a replacement
 for <a data-link-type="dfn" href="#keypress" id="ref-for-keypress②②"><code>keypress</code></a>, was removed in favor of the current <a data-link-type="dfn" href="#beforeinput" id="ref-for-beforeinput③③"><code>beforeinput</code></a> and <a data-link-type="dfn" href="#input" id="ref-for-input③③"><code>input</code></a> events.</p>
-     <li data-md="">
+     <li data-md>
       <p>Namespaced events have been removed.</p>
-     <li data-md="">
+     <li data-md>
       <p>Updated to use <a data-link-type="biblio" href="#biblio-webidl">[WebIDL]</a>.</p>
-     <li data-md="">
+     <li data-md>
       <p>EventException has been removed.</p>
     </ul>
    </section>
@@ -7353,8 +7353,8 @@ William Edney and
 similar definitions in other W3C or standards documents. See the links within
 the definitions for more information.</p>
     <dl>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="activation-behavior">activation behavior</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="activation-behavior">activation behavior</dfn>
+     <dd data-md>
       <p>The action taken when an <a data-link-type="dfn" href="#event" id="ref-for-event⑤⑥">event</a>, typically initiated by users through
 an input device, causes an element to fulfill a defined task.  The task MAY
 be defined for that element by the <a data-link-type="dfn" href="#host-language" id="ref-for-host-language①①">host language</a>, or by
@@ -7365,38 +7365,38 @@ cause the <a data-link-type="dfn" href="#user-agent" id="ref-for-user-agent⑥�
 specifying the browsing context for the traversal (such as the current
 window or tab, a named window, or a new window). The activation behavior of
 an HTML <code>&lt;input></code> element with the <code>type</code> attribute value <code>submit</code> is be to send the values of the form
-elements to an author-defined IRI by the author-defined HTTP method.  See <a href="#event-flow-activation">§3.5 Activation triggers and behavior</a> for more details.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="activation-trigger">activation trigger</dfn>
-     <dd data-md="">
+elements to an author-defined IRI by the author-defined HTTP method.  See <a href="#event-flow-activation">§ 3.5 Activation triggers and behavior</a> for more details.</p>
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="activation-trigger">activation trigger</dfn>
+     <dd data-md>
       <p>An event which is defined to initiate an <a data-link-type="dfn" href="#activation-behavior" id="ref-for-activation-behavior⑤">activation behavior</a>.  Refer
-to <a href="#event-flow-activation">§3.5 Activation triggers and behavior</a> for more details.</p>
-     <dt data-md=""><dfn data-dfn-type="dfn" data-noexport="" id="author">author<a class="self-link" href="#author"></a></dfn>
-     <dd data-md="">
+to <a href="#event-flow-activation">§ 3.5 Activation triggers and behavior</a> for more details.</p>
+     <dt data-md><dfn data-dfn-type="dfn" data-noexport id="author">author<a class="self-link" href="#author"></a></dfn>
+     <dd data-md>
       <p>In the context of this specification, an <em>author</em>, <em>content
 author</em>, or <em>script author</em> is a person who writes script or
 other executable content that uses the interfaces, events, and event flow
-defined in this specification. See <a href="#conf-authors">§1.2.3 Content authors and content</a> conformance category
+defined in this specification. See <a href="#conf-authors">§ 1.2.3 Content authors and content</a> conformance category
 for more details.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="body-element">body element</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="body-element">body element</dfn>
+     <dd data-md>
       <p>In HTML or XHTML documents, the body element represents the contents of the
 document. In a well-formed HTML document, the body element is a first
 descendant of the <a data-link-type="dfn" href="#root-element" id="ref-for-root-element⑥">root element</a>.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="bubble phase|bubbling phase" data-noexport="" id="bubble-phase">bubbling phase</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="bubble phase|bubbling phase" data-noexport id="bubble-phase">bubbling phase</dfn>
+     <dd data-md>
       <p>The process by which an <a data-link-type="dfn" href="#event" id="ref-for-event⑤⑦">event</a> can be handled by one of the target’s
 ancestors <em>after</em> being handled by the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target⑤⓪">event target</a>. See the
 description of the <a data-link-type="dfn" href="#bubble-phase" id="ref-for-bubble-phase①">bubble phase</a> in the context of event flow for more
 details.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="capture-phase">capture phase</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="capture-phase">capture phase</dfn>
+     <dd data-md>
       <p>The process by which an <a data-link-type="dfn" href="#event" id="ref-for-event⑤⑧">event</a> can be handled by one of the target’s
 ancestors <em>before</em> being handled by the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target⑤①">event target</a>. See the
 description of the <a href="#capture-phase" id="ref-for-capture-phase②">capture phase</a> in the context
 of event flow for more details.</p>
-     <dt data-md=""><dfn data-dfn-type="dfn" data-noexport="" id="candidate-event-handlers">candidate event handlers<a class="self-link" href="#candidate-event-handlers"></a></dfn>
-     <dt data-md=""><dfn data-dfn-type="dfn" data-noexport="" id="candidate-event-listeners">candidate event listeners<a class="self-link" href="#candidate-event-listeners"></a></dfn>
-     <dd data-md="">
+     <dt data-md><dfn data-dfn-type="dfn" data-noexport id="candidate-event-handlers">candidate event handlers<a class="self-link" href="#candidate-event-handlers"></a></dfn>
+     <dt data-md><dfn data-dfn-type="dfn" data-noexport id="candidate-event-listeners">candidate event listeners<a class="self-link" href="#candidate-event-listeners"></a></dfn>
+     <dd data-md>
       <p>The list of all <a data-link-type="dfn" href="#event-listener" id="ref-for-event-listener">event listeners</a> that have been registered on the
 target object in their order of registration. When an event is about to be
 dispatched to a target object, the list of current listeners is captured
@@ -7407,8 +7407,8 @@ dispatch begins will be removed.</p>
       <p class="note" role="note"> Initially capturing the candidate event handlers and not allowing new
 listeners to be added prevents infinite loops of event listener dispatch on
 a given target object. </p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="character-value">character value</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="character-value">character value</dfn>
+     <dd data-md>
       <p>In the context of key values, a character value is a string representing one
 or more Unicode characters, such as a letter or symbol, or a set of letters.
 In this specification, character values are denoted as a unicode string
@@ -7416,28 +7416,28 @@ In this specification, character values are denoted as a unicode string
       <p class="note" role="note"> In source code, some key values, such as non-graphic characters, can be
 represented using the character escape syntax of the programming language in
 use. </p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="current-event-target">current event target</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="current-event-target">current event target</dfn>
+     <dd data-md>
       <p>In an event flow, the current event target is the object associated with the <a data-link-type="dfn" href="#event-handler" id="ref-for-event-handler">event handler</a> that is currently being dispatched. This object MAY be
 the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target⑤②">event target</a> itself or one of its ancestors. The current event
 target changes as the <a data-link-type="dfn" href="#event" id="ref-for-event⑤⑨">event</a> propagates from object to object through
 the various <a data-link-type="dfn" href="#phase" id="ref-for-phase">phases</a> of the event flow. The current event target is the
 value of the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-currenttarget" id="ref-for-dom-event-currenttarget">currentTarget</a></code> attribute.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dead-key">dead key</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="dead-key">dead key</dfn>
+     <dd data-md>
       <p>A dead key is a key or combination of keys which produces no character by
 itself, but which in combination or sequence with another key produces a
 modified character, such as a character with diacritical marks (e.g., <code class="glyph">"ö"</code>, <code class="glyph">"é"</code>, <code class="glyph">"â"</code>).</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="default-action">default action</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="default-action">default action</dfn>
+     <dd data-md>
       <p>A <a data-link-type="dfn" href="#default-action" id="ref-for-default-action④④">default action</a> is an OPTIONAL supplementary behavior that an
 implementation MUST perform in combination with the dispatch of the event
 object.  Each event type definition, and each specification, defines the <a data-link-type="dfn" href="#default-action" id="ref-for-default-action④⑤">default action</a> for that event type, if it has one.  An instance of an
 event MAY have more than one <a data-link-type="dfn" href="#default-action" id="ref-for-default-action④⑥">default action</a> under some circumstances,
 such as when associated with an <a data-link-type="dfn" href="#activation-trigger" id="ref-for-activation-trigger⑧">activation trigger</a>.  A <a data-link-type="dfn" href="#default-action" id="ref-for-default-action④⑦">default
-action</a> MAY be cancelled through the invocation of the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-preventdefault" id="ref-for-dom-event-preventdefault⑨">preventDefault()</a></code> method. For more details, see <a href="#event-flow-default-cancel">§3.2 Default actions and cancelable events</a>.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="delta">delta</dfn>
-     <dd data-md="">
+action</a> MAY be cancelled through the invocation of the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-preventdefault" id="ref-for-dom-event-preventdefault⑨">preventDefault()</a></code> method. For more details, see <a href="#event-flow-default-cancel">§ 3.2 Default actions and cancelable events</a>.</p>
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="delta">delta</dfn>
+     <dd data-md>
       <p>The estimated scroll amount (in pixels, lines, or pages) that the user agent
 will scroll or zoom the page in response to the physical movement of an
 input device that supports the <code class="idl"><a data-link-type="idl" href="#wheelevent" id="ref-for-wheelevent①③">WheelEvent</a></code> interface (such as a mouse
@@ -7447,8 +7447,8 @@ positive or negative is environment and device dependent. However, if a user
 agent scrolls as the <a data-link-type="dfn" href="#default-action" id="ref-for-default-action④⑧">default action</a> then the sign of the <a data-link-type="dfn" href="#delta" id="ref-for-delta①③">delta</a> is given by a right-hand coordinate system where positive X,Y, and Z axes
 are directed towards the right-most edge, bottom-most edge, and farthest
 depth (away from the user) of the document, respectively.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="deprecates|deprecated" data-noexport="" id="deprecates">deprecated</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="deprecates|deprecated" data-noexport id="deprecates">deprecated</dfn>
+     <dd data-md>
       <p>Features marked as deprecated are included in the specification as reference
 to older implementations or specifications, but are OPTIONAL and
 discouraged.  Only features which have existing or in-progress replacements
@@ -7461,53 +7461,53 @@ specification SHOULD NOT use deprecated features, but SHOULD point instead
 to the replacements of which the feature is deprecated in favor.  Features
 marked as deprecated in this specification are expected to be dropped from
 future specifications.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dispatch">dispatch</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="dispatch">dispatch</dfn>
+     <dd data-md>
       <p>To create an event with attributes and methods appropriate to its type and
 context, and propagate it through the DOM tree in the specified manner.
 Interchangeable with the term <q><a data-link-type="dfn" href="#fire" id="ref-for-fire">fire</a></q>, e.g., <q>fire a <a data-link-type="dfn" href="#click" id="ref-for-click④③"><code>click</code></a> event</q> or <q>dispatch a <a data-link-type="dfn" href="#load" id="ref-for-load④"><code>load</code></a> event</q>.</p>
-     <dt data-md=""><dfn data-dfn-type="dfn" data-noexport="" id="document">document<a class="self-link" href="#document"></a></dfn>
-     <dd data-md="">
+     <dt data-md><dfn data-dfn-type="dfn" data-noexport id="document">document<a class="self-link" href="#document"></a></dfn>
+     <dd data-md>
       <p>An object instantiating the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document">Document</a></code> interface <a data-link-type="biblio" href="#biblio-dom-level-3-core">[DOM-Level-3-Core]</a>,
 representing the entire HTML or XML text document.  Conceptually, it is the
 root of the document tree, and provides the primary access to the document’s
 data.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dom-application">DOM application</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="dom-application">DOM application</dfn>
+     <dd data-md>
       <p>A DOM application is script or code, written by a content author or
 automatically generated, which takes advantage of the interfaces, methods,
 attributes, events, and other features described in this specification in
 order to make dynamic or interactive content, such as Web applications,
 exposed to users in a <a data-link-type="dfn" href="#user-agent" id="ref-for-user-agent⑥⑨">user agent</a>.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="dom-level-0">DOM Level 0</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="dom-level-0">DOM Level 0</dfn>
+     <dd data-md>
       <p>The term <q>DOM Level 0</q> refers to a mix of HTML document functionalities,
 often not formally specified but traditionally supported as de facto
 standards, implemented originally by Netscape Navigator version 3.0 or
 Microsoft Internet Explorer version 3.0.  In many cases, attributes or
 methods have been included for reasons of backward compatibility with <q>DOM
 Level 0</q>.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="empty-string">empty string</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="empty-string">empty string</dfn>
+     <dd data-md>
       <p>The empty string is a value of type <code>DOMString</code> of length <code>0</code>, i.e., a string which contains no characters (neither
 printing nor control characters).</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event">event</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="event">event</dfn>
+     <dd data-md>
       <p>An event is the representation of some occurrence (such as a mouse click on
 the presentation of an element, the removal of child node from an element,
 or any number of other possibilities) which is associated with its <a data-link-type="dfn" href="#event-target" id="ref-for-event-target⑤③">event
 target</a>. Each event is an instantiation of one specific <a data-link-type="dfn" href="#event-type" id="ref-for-event-type②⑤">event
 type</a>.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-focus">event focus</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="event-focus">event focus</dfn>
+     <dd data-md>
       <p>Event focus is a special state of receptivity and concentration on a
 particular element or other <a data-link-type="dfn" href="#event-target" id="ref-for-event-target⑤④">event target</a> within a document.  Each
 element has different behavior when focused, depending on its functionality,
 such as priming the element for activation (as for a button or hyperlink) or
 toggling state (as for a checkbox), receiving text input (as for a text form
-field), or copying selected text.  For more details, see <a href="#events-focusevent-doc-focus">§4.2.3 Document Focus and Focus Context</a>.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="focus ring" data-noexport="" id="focus-ring">event focus ring</dfn>
-     <dd data-md="">
+field), or copying selected text.  For more details, see <a href="#events-focusevent-doc-focus">§ 4.2.3 Document Focus and Focus Context</a>.</p>
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="focus ring" data-noexport id="focus-ring">event focus ring</dfn>
+     <dd data-md>
       <p>An event focus ring is an ordered set of <a data-link-type="dfn" href="#event-focus" id="ref-for-event-focus">event focus</a> targets within a
 document.  A <a data-link-type="dfn" href="#host-language" id="ref-for-host-language①②">host language</a> MAY define one or more ways to determine
 the order of targets, such as document order, a numerical index defined per
@@ -7516,9 +7516,9 @@ different models.  Each document MAY contain multiple focus rings, or
 conditional focus rings.  Typically, for document-order or indexed focus
 rings, focus <q>wraps around</q> from the last focus target to the
 first.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-handler">event handler</dfn>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-listener">event listener</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="event-handler">event handler</dfn>
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="event-listener">event listener</dfn>
+     <dd data-md>
       <p>An object that implements the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#callbackdef-eventlistener" id="ref-for-callbackdef-eventlistener">EventListener</a></code> interface and provides an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-eventlistener-handleevent" id="ref-for-dom-eventlistener-handleevent">handleEvent()</a></code> callback method. Event handlers are
 language-specific. Event handlers are invoked in the context of a particular
 object (the <a data-link-type="dfn" href="#current-event-target" id="ref-for-current-event-target①">current event target</a>) and are provided with the event
@@ -7526,8 +7526,8 @@ object itself.</p>
       <p class="note" role="note"> In JavaScript, user-defined functions are considered to implement the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#callbackdef-eventlistener" id="ref-for-callbackdef-eventlistener①">EventListener</a></code> interface. Thus the event object will be provided as the
 first parameter to the user-defined function when it is invoked.
 Additionally, JavaScript objects can also implement the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#callbackdef-eventlistener" id="ref-for-callbackdef-eventlistener②">EventListener</a></code> interface when they define a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-eventlistener-handleevent" id="ref-for-dom-eventlistener-handleevent①">handleEvent</a></code> method. </p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-order">event order</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="event-order">event order</dfn>
+     <dd data-md>
       <p>The sequence in which events from the same event source or process occur,
 using the same or related event interfaces. For example, in an environment
 with a mouse, a track pad, and a keyboard, each of those input devices would
@@ -7541,26 +7541,26 @@ user might change focus using the <code class="keycap">Tab</code> key, or by cli
 focused element with the mouse.  The event order in such cases depends on
 the state of the process, not on the state of the device that initiates the
 state change.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-phase">event phase</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="event-phase">event phase</dfn>
+     <dd data-md>
       <p>See <a data-link-type="dfn" href="#phase" id="ref-for-phase①">phase</a>.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-target">event target</dfn>
-     <dd data-md="">
-      <p>The object to which an <a data-link-type="dfn" href="#event" id="ref-for-event⑥⓪">event</a> is targeted using the <a href="#event-flow">§3.1 Event dispatch and DOM event flow</a>.
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="event-target">event target</dfn>
+     <dd data-md>
+      <p>The object to which an <a data-link-type="dfn" href="#event" id="ref-for-event⑥⓪">event</a> is targeted using the <a href="#event-flow">§ 3.1 Event dispatch and DOM event flow</a>.
 The event target is the value of the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-target" id="ref-for-dom-event-target③⑧">target</a></code> attribute.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="event-type">event type</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="event-type">event type</dfn>
+     <dd data-md>
       <p>An <em>event type</em> is an <a data-link-type="dfn" href="#event" id="ref-for-event⑥①">event</a> object with a particular name and
 which defines particular trigger conditions, properties, and other
 characteristics which distinguish it from other event types.  For example,
 the <a data-link-type="dfn" href="#click" id="ref-for-click④⑦"><code>click</code></a> event type has different characteristics than the <a data-link-type="dfn" href="#mouseover" id="ref-for-mouseover①⓪"><code>mouseover</code></a> or <a data-link-type="dfn" href="#load" id="ref-for-load⑤"><code>load</code></a> event types. The event type is exposed as
-the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-type" id="ref-for-dom-event-type②">type</a></code> attribute on the event object.  See <a href="#event-types">§4 Event Types</a> for
+the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-type" id="ref-for-dom-event-type②">type</a></code> attribute on the event object.  See <a href="#event-types">§ 4 Event Types</a> for
 more details.  Also loosely referred to as <em>"event"</em>, such as the <em><a data-link-type="dfn" href="#click" id="ref-for-click④⑧"><code>click</code></a> event</em>.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="fire">fire</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fire">fire</dfn>
+     <dd data-md>
       <p>A synonym for <a data-link-type="dfn" href="#dispatch" id="ref-for-dispatch②">dispatch</a>.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="host-language">host language</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="host-language">host language</dfn>
+     <dd data-md>
       <p>Any language which integrates the features of another language or API
 specification, while normatively referencing the origin specification rather
 than redefining those features, and extending those features only in ways
@@ -7569,105 +7569,105 @@ only intended to be implemented in the context of one or more host
 languages, not as a standalone language.  For example, XHTML, HTML, and SVG
 are host languages for UI Events, and they integrate and extend the objects
 and models defined in this specification.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="hysteresis">hysteresis</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="hysteresis">hysteresis</dfn>
+     <dd data-md>
       <p>A feature of human interface design to accept input values within a certain
 range of location or time, in order to improve the user experience.  For
 example, allowing for small deviation in the time it takes for a user to
 double-click a mouse button is temporal hysteresis, and not immediately
 closing a nested menu if the user mouses out from the parent window when
 transitioning to the child menu is locative hysteresis.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="ime">IME</dfn>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="input-method-editor">input method editor</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="ime">IME</dfn>
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="input-method-editor">input method editor</dfn>
+     <dd data-md>
       <p>An <em>input method editor</em> (IME), also known as a <em>front end
 processor</em>, is an application that performs the conversion between
 keystrokes and ideographs or other characters, usually by user-guided
 dictionary lookup, often used in East Asian languages (e.g., Chinese,
 Japanese, Korean).  An <a data-link-type="dfn" href="#ime" id="ref-for-ime①④">IME</a> MAY also be used for dictionary-based word
-completion, such as on mobile devices.  See <a href="#keys-IME">§5.3.3 Input Method Editors</a> for treatment of
+completion, such as on mobile devices.  See <a href="#keys-IME">§ 5.3.3 Input Method Editors</a> for treatment of
 IMEs in this specification.  See also <a data-link-type="dfn" href="#text-composition-system" id="ref-for-text-composition-system①⑥">text composition system</a>.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="key-mapping">key mapping</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="key-mapping">key mapping</dfn>
+     <dd data-md>
       <p>Key mapping is the process of assigning a key value to a particular key, and
 is the result of a combination of several factors, including the operating
 system and the keyboard layout (e.g., <a data-link-type="dfn" href="#qwerty" id="ref-for-qwerty②">QWERTY</a>, Dvorak, Spanish,
 InScript, Chinese, etc.), and after taking into account all <a data-link-type="dfn" href="#modifier-key" id="ref-for-modifier-key②">modifier
 key</a> (<code class="keycap">Shift</code>, <code class="keycap">Alt</code>, et al.) and <a data-link-type="dfn" href="#dead-key" id="ref-for-dead-key①⓪">dead key</a> states.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="key-value">key value</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="key-value">key value</dfn>
+     <dd data-md>
       <p>A key value is a <a data-link-type="dfn" href="#character-value" id="ref-for-character-value⑨">character value</a> or multi-character string (such as <code class="key">"<a href="http://www.w3.org/TR/uievents-key/#key-Enter">Enter</a>"</code>, <code class="key">"<a href="http://www.w3.org/TR/uievents-key/#key-Tab">Tab</a>"</code>, or <code class="key">"<a href="http://www.w3.org/TR/uievents-key/#key-MediaTrackNext">MediaTrackNext</a>"</code>) associated with a key in a
 particular state. Every key has a key value, whether or not it has a <a data-link-type="dfn" href="#character-value" id="ref-for-character-value①⓪">character value</a>. This includes control keys, function keys, <a data-link-type="dfn" href="#modifier-key" id="ref-for-modifier-key③">modifier keys</a>, <a data-link-type="dfn" href="#dead-key" id="ref-for-dead-key①①">dead keys</a>, and any other key. The key value of
 any given key at any given time depends upon the <a data-link-type="dfn" href="#key-mapping" id="ref-for-key-mapping④">key mapping</a>.</p>
-     <dt data-md=""><dfn data-dfn-type="dfn" data-noexport="" id="local-name">local name<a class="self-link" href="#local-name"></a></dfn>
-     <dd data-md="">
+     <dt data-md><dfn data-dfn-type="dfn" data-noexport id="local-name">local name<a class="self-link" href="#local-name"></a></dfn>
+     <dd data-md>
       <p>See local name in <a data-link-type="biblio" href="#biblio-xml-names11">[XML-Names11]</a>.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="modifier-key">modifier key</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="modifier-key">modifier key</dfn>
+     <dd data-md>
       <p>A modifier key changes the normal behavior of a key, such as to produce a
 character of a different case (as with the <code class="keycap">Shift</code> key), or to alter
-what functionality the key triggers (as with the <code class="keycap">Fn</code> or <code class="keycap">Alt</code> keys). See <a href="#keys-modifiers">§5.3.1 Modifier keys</a> for more information about modifier keys and
+what functionality the key triggers (as with the <code class="keycap">Fn</code> or <code class="keycap">Alt</code> keys). See <a href="#keys-modifiers">§ 5.3.1 Modifier keys</a> for more information about modifier keys and
 refer to the <a data-link-type="dfn" href="https://www.w3.org/TR/uievents-key/#keys-modifier" id="ref-for-keys-modifier①">Modifier Keys table</a> in <a data-link-type="biblio" href="#biblio-uievents-key">[UIEvents-Key]</a> for a list
 of valid modifier keys.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="namespace URIs" data-noexport="" id="namespace-uris">namespace URI</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="namespace URIs" data-noexport id="namespace-uris">namespace URI</dfn>
+     <dd data-md>
       <p>A <em>namespace URI</em> is a URI that identifies an XML namespace. This is
 called the namespace name in <a data-link-type="biblio" href="#biblio-xml-names11">[XML-Names11]</a>. See also sections 1.3.2 <a class="normative" href="http://www.w3.org/TR/DOM-Level-3-Core/core.html#baseURIs-Considerations"><em>DOM URIs</em></a> and 1.3.3 <a class="normative" href="http://www.w3.org/TR/DOM-Level-3-Core/core.html#Namespaces-Considerations"><em>XML Namespaces</em></a> regarding URIs and namespace URIs handling and comparison in the DOM APIs.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="phase">phase</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="phase">phase</dfn>
+     <dd data-md>
       <p>In the context of <a data-link-type="dfn" href="#event" id="ref-for-event⑥②">events</a>, a phase is set of logical traversals from
 node to node along the DOM tree, from the <a data-link-type="dfn" href="#window" id="ref-for-window⑤①">Window</a> to the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code> object, <a data-link-type="dfn" href="#root-element" id="ref-for-root-element⑦">root element</a>, and down to the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target⑤⑤">event target</a> (<a data-link-type="dfn" href="#capture-phase" id="ref-for-capture-phase①">capture
 phase</a>), at the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target⑤⑥">event target</a> itself (<a data-link-type="dfn" href="#target-phase" id="ref-for-target-phase①">target phase</a>), and
 back up the same chain (<a data-link-type="dfn" href="#bubble-phase" id="ref-for-bubble-phase②">bubbling phase</a>).</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="propagation-path">propagation path</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="propagation-path">propagation path</dfn>
+     <dd data-md>
       <p>The ordered set of <a data-link-type="dfn" href="#current-event-target" id="ref-for-current-event-target②">current event targets</a> though which an <a data-link-type="dfn" href="#event" id="ref-for-event⑥③">event</a> object will pass sequentially on the way to and back from the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target⑤⑦">event
 target</a>.  As the event propagates, each <a data-link-type="dfn" href="#current-event-target" id="ref-for-current-event-target③">current event target</a> in
 the propagation path is in turn set as the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-currenttarget" id="ref-for-dom-event-currenttarget①">currentTarget</a></code>. The
 propagation path is initially composed of one or more <a data-link-type="dfn" href="#event-phase" id="ref-for-event-phase①">event phases</a> as
 defined by the <a data-link-type="dfn" href="#event-type" id="ref-for-event-type②⑥">event type</a>, but MAY be interrupted.  Also known as an <em>event target chain</em>.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="qwerty">QWERTY</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="qwerty">QWERTY</dfn>
+     <dd data-md>
       <p>QWERTY (pronounced <q>ˈkwɜrti</q>) is a common keyboard layout,
 so named because the first five character keys on the top row of letter keys
 are Q, W, E, R, T, and Y.  There are many other popular keyboard layouts
 (including the Dvorak and Colemak layouts), most designed for localization
 or ergonomics.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="root-element">root element</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="root-element">root element</dfn>
+     <dd data-md>
       <p>The first element node of a document, of which all other elements are
 children. The document element.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="rotation">rotation</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="rotation">rotation</dfn>
+     <dd data-md>
       <p>An indication of incremental change on an input device using the <code class="idl"><a data-link-type="idl" href="#wheelevent" id="ref-for-wheelevent①④">WheelEvent</a></code> interface. On some devices this MAY be a literal rotation of
 a wheel, while on others, it MAY be movement along a flat surface, or
 pressure on a particular button.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="target-phase">target phase</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="target-phase">target phase</dfn>
+     <dd data-md>
       <p>The process by which an <a data-link-type="dfn" href="#event" id="ref-for-event⑥④">event</a> can be handled by the <a data-link-type="dfn" href="#event-target" id="ref-for-event-target⑤⑧">event
 target</a>. See the description of the <a data-link-type="dfn" href="#target-phase" id="ref-for-target-phase②">target phase</a> in the context of
 event flow for more details.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="text-composition-system">text composition system</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="text-composition-system">text composition system</dfn>
+     <dd data-md>
       <p>A software component that interprets some form of alternate input (such as a <a data-link-type="dfn" href="#input-method-editor" id="ref-for-input-method-editor①⓪">input method editor</a>, a speech processor, or a handwriting recognition
 system) and converts it to text.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="topmost-event-target">topmost event target</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="topmost-event-target">topmost event target</dfn>
+     <dd data-md>
       <p>The <a data-link-type="dfn" href="#topmost-event-target" id="ref-for-topmost-event-target①③">topmost event target</a> MUST be the element highest in the rendering
 order which is capable of being an <a data-link-type="dfn" href="#event-target" id="ref-for-event-target⑤⑨">event target</a>. In graphical user
 interfaces this is the element under the user’s pointing device. A user
 interface’s <q>hit testing</q> facility is used to determine the target. For
 specific details regarding hit testing and stacking order, refer to the <a data-link-type="dfn" href="#host-language" id="ref-for-host-language①③">host language</a>.</p>
-     <dt data-md=""><dfn data-dfn-type="dfn" data-noexport="" id="tree">tree<a class="self-link" href="#tree"></a></dfn>
-     <dd data-md="">
+     <dt data-md><dfn data-dfn-type="dfn" data-noexport id="tree">tree<a class="self-link" href="#tree"></a></dfn>
+     <dd data-md>
       <p>A data structure that represents a document as a hierarchical set of nodes
 with child-parent-sibling relationships, i.e., each node having one or more
 possible ancestors (nodes higher in the hierarchy in a direct lineage), one
 or more possible descendants (nodes lower in the hierarchy in a direct
 lineage), and one or more possible peers (nodes of the same level in the
 hierarchy, with the same immediate ancestor).</p>
-     <dt data-md=""><dfn data-dfn-type="dfn" data-noexport="" id="unicode-character-categories">Unicode character categories<a class="self-link" href="#unicode-character-categories"></a></dfn>
-     <dd data-md="">
+     <dt data-md><dfn data-dfn-type="dfn" data-noexport id="unicode-character-categories">Unicode character categories<a class="self-link" href="#unicode-character-categories"></a></dfn>
+     <dd data-md>
       <p>A subset of the General Category values that are defined for each Unicode
 code point. This subset contains all the
 Letter (<abbr title="Letter, Lowercase">Ll</abbr>, <abbr title="Letter, Modifier">Lm</abbr>, <abbr title="Letter, Other">Lo</abbr>, <abbr title="Letter, Titlecase">Lt</abbr>, <abbr title="Letter, Uppercase">Lu</abbr>),
@@ -7675,20 +7675,20 @@ Number (<abbr title="Number, Decimal Digit">Nd</abbr>, <abbr title="Number, Lett
 Punctuation (<abbr title="Punctuation, Connector">Pc</abbr>, <abbr title="Punctuation, Dash">Pd</abbr>, <abbr title="Punctuation, Close">Pe</abbr>, <abbr title="Punctuation, Final quote">Pf</abbr>, <abbr title="Punctuation, Initial quote">Pi</abbr>, <abbr title="Punctuation, Other">Po</abbr>, <abbr title="Punctuation, Open">Ps</abbr>)
 and Symbol (<abbr title="Symbol, Currency">Sc</abbr>, <abbr title="Symbol, Modifier">Sk</abbr>, <abbr title="Symbol, Math">Sm</abbr>, <abbr title="Symbol, Other">So</abbr>)
 category values.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="un-initialized-value">un-initialized value</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="un-initialized-value">un-initialized value</dfn>
+     <dd data-md>
       <p>The value of any event attribute (such as <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-bubbles" id="ref-for-dom-event-bubbles①">bubbles</a></code> or <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-currenttarget" id="ref-for-dom-event-currenttarget②">currentTarget</a></code>) before the event has been initialized with <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-event-initevent" id="ref-for-dom-event-initevent②①">initEvent()</a></code>. The un-initialized values of an event apply
 immediately after a new event has been created using the method <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#dom-document-createevent" id="ref-for-dom-document-createevent③">createEvent()</a></code>.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="user-agent">user agent</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="user-agent">user agent</dfn>
+     <dd data-md>
       <p>A program, such as a browser or content authoring tool, normally running on
 a client machine, which acts on a user’s behalf in retrieving, interpreting,
 executing, presenting, or creating content.  Users MAY act on the content
 using different user agents at different times, for different purposes.  See
-the <a href="#conf-interactive-ua">§1.2.1 Web browsers and other dynamic or interactive user agents</a> and <a href="#conf-author-tools">§1.2.2 Authoring tools</a> for details on the
+the <a href="#conf-interactive-ua">§ 1.2.1 Web browsers and other dynamic or interactive user agents</a> and <a href="#conf-author-tools">§ 1.2.2 Authoring tools</a> for details on the
 requirements for a <em>conforming</em> user agent.</p>
-     <dt data-md=""><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="window">Window</dfn>
-     <dd data-md="">
+     <dt data-md><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="window">Window</dfn>
+     <dd data-md>
       <p>The <code>Window</code> is the object referred to by the current document’s
 browsing context’s Window Proxy object as defined in <a href="http://dev.w3.org/html5/spec/single-page.html#windowproxy" title="HTML5 WindowProxy description">HTML5</a> <a data-link-type="biblio" href="#biblio-html5">[HTML5]</a>.</p>
     </dl>
@@ -8030,69 +8030,436 @@ browsing context’s Window Proxy object as defined in <a href="http://dev.w3.or
     </ul>
    <li><a href="#window">Window</a><span>, in §13</span>
   </ul>
+  <aside class="dfn-panel" data-for="term-for-customevent">
+   <a href="https://dom.spec.whatwg.org/#customevent">https://dom.spec.whatwg.org/#customevent</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-customevent">9.2. Custom Events</a>
+    <li><a href="#ref-for-customevent①">11.1.4. New Interfaces</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-document">
+   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-document">13. Glossary</a> <a href="#ref-for-document①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-event">
+   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-event①">3.6. Constructing Mouse and Keyboard Events</a> <a href="#ref-for-event②">(2)</a> <a href="#ref-for-event③">(3)</a> <a href="#ref-for-event④">(4)</a> <a href="#ref-for-event⑤">(5)</a> <a href="#ref-for-event⑥">(6)</a>
+    <li><a href="#ref-for-event⑦">4.1.1.1. UIEvent</a> <a href="#ref-for-event⑧">(2)</a>
+    <li><a href="#ref-for-event⑨">4.1.2. UI Event Types</a>
+    <li><a href="#ref-for-event①⓪">4.1.2.1. load</a> <a href="#ref-for-event①①">(2)</a>
+    <li><a href="#ref-for-event①②">4.1.2.2. unload</a> <a href="#ref-for-event①③">(2)</a>
+    <li><a href="#ref-for-event①④">4.1.2.3. abort</a> <a href="#ref-for-event①⑤">(2)</a>
+    <li><a href="#ref-for-event①⑥">4.1.2.4. error</a> <a href="#ref-for-event①⑦">(2)</a>
+    <li><a href="#ref-for-event①⑧">4.1.2.5. select</a> <a href="#ref-for-event①⑨">(2)</a>
+    <li><a href="#ref-for-event②⓪">4.2.4.1. blur</a>
+    <li><a href="#ref-for-event②①">4.2.4.2. focus</a>
+    <li><a href="#ref-for-event②②">4.2.4.3. focusin</a>
+    <li><a href="#ref-for-event②③">4.2.4.4. focusout</a>
+    <li><a href="#ref-for-event②④">4.3.4.1. auxclick</a>
+    <li><a href="#ref-for-event②⑤">4.3.4.2. click</a>
+    <li><a href="#ref-for-event②⑥">4.3.4.3. dblclick</a>
+    <li><a href="#ref-for-event②⑦">4.3.4.4. mousedown</a>
+    <li><a href="#ref-for-event②⑧">4.3.4.5. mouseenter</a>
+    <li><a href="#ref-for-event②⑨">4.3.4.6. mouseleave</a>
+    <li><a href="#ref-for-event③⓪">4.3.4.7. mousemove</a>
+    <li><a href="#ref-for-event③①">4.3.4.8. mouseout</a>
+    <li><a href="#ref-for-event③②">4.3.4.9. mouseover</a>
+    <li><a href="#ref-for-event③③">4.3.4.10. mouseup</a>
+    <li><a href="#ref-for-event③④">4.4.2.1. wheel</a>
+    <li><a href="#ref-for-event③⑤">4.5.3.1. beforeinput</a>
+    <li><a href="#ref-for-event③⑥">4.5.3.2. input</a>
+    <li><a href="#ref-for-event③⑦">4.6.4.1. keydown</a>
+    <li><a href="#ref-for-event③⑧">4.6.4.2. keyup</a>
+    <li><a href="#ref-for-event③⑨">4.7.7.1. compositionstart</a>
+    <li><a href="#ref-for-event④⓪">4.7.7.2. compositionupdate</a>
+    <li><a href="#ref-for-event④①">4.7.7.3. compositionend</a>
+    <li><a href="#ref-for-event④②">6. Legacy Event Initializers</a>
+    <li><a href="#ref-for-event④③">8.1.1.1. DOMActivate</a>
+    <li><a href="#ref-for-event④④">8.2.1.1. DOMFocusIn</a>
+    <li><a href="#ref-for-event④⑤">8.2.1.2. DOMFocusOut</a>
+    <li><a href="#ref-for-event④⑥">8.3.1.1. keypress</a>
+    <li><a href="#ref-for-event④⑦">8.4.2.1. DOMAttrModified</a>
+    <li><a href="#ref-for-event④⑧">8.4.2.2. DOMCharacterDataModified</a>
+    <li><a href="#ref-for-event④⑨">8.4.2.3. DOMNodeInserted</a>
+    <li><a href="#ref-for-event⑤⓪">8.4.2.4. DOMNodeInsertedIntoDocument</a>
+    <li><a href="#ref-for-event⑤①">8.4.2.5. DOMNodeRemoved</a>
+    <li><a href="#ref-for-event⑤②">8.4.2.6. DOMNodeRemovedFromDocument</a>
+    <li><a href="#ref-for-event⑤③">8.4.2.7. DOMSubtreeModified</a>
+    <li><a href="#ref-for-event⑤④">11.1.3. Changes to DOM Level 2 Events interfaces</a> <a href="#ref-for-event⑤⑤">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
+   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-eventinit">4.1.1.2. UIEventInit</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-callbackdef-eventlistener">
+   <a href="https://dom.spec.whatwg.org/#callbackdef-eventlistener">https://dom.spec.whatwg.org/#callbackdef-eventlistener</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-callbackdef-eventlistener">13. Glossary</a> <a href="#ref-for-callbackdef-eventlistener①">(2)</a> <a href="#ref-for-callbackdef-eventlistener②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-eventtarget">
+   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-eventtarget">1.2.1. Web browsers and other dynamic or interactive user agents</a>
+    <li><a href="#ref-for-eventtarget①">4.2.1.1. FocusEvent</a> <a href="#ref-for-eventtarget②">(2)</a> <a href="#ref-for-eventtarget③">(3)</a>
+    <li><a href="#ref-for-eventtarget④">4.2.1.2. FocusEventInit</a>
+    <li><a href="#ref-for-eventtarget⑤">4.3.1.1. MouseEvent</a> <a href="#ref-for-eventtarget⑥">(2)</a> <a href="#ref-for-eventtarget⑦">(3)</a>
+    <li><a href="#ref-for-eventtarget⑧">4.3.1.2. MouseEventInit</a> <a href="#ref-for-eventtarget⑨">(2)</a>
+    <li><a href="#ref-for-eventtarget①⓪">11.1.3. Changes to DOM Level 2 Events interfaces</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-mutationevent">
+   <a href="https://dom.spec.whatwg.org/#mutationevent">https://dom.spec.whatwg.org/#mutationevent</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-mutationevent">8. Legacy Event Types</a> <a href="#ref-for-mutationevent①">(2)</a> <a href="#ref-for-mutationevent②">(3)</a> <a href="#ref-for-mutationevent③">(4)</a> <a href="#ref-for-mutationevent④">(5)</a> <a href="#ref-for-mutationevent⑤">(6)</a> <a href="#ref-for-mutationevent⑥">(7)</a>
+    <li><a href="#ref-for-mutationevent⑦">8.4. Legacy MutationEvent events</a> <a href="#ref-for-mutationevent⑧">(2)</a> <a href="#ref-for-mutationevent⑨">(3)</a> <a href="#ref-for-mutationevent①⓪">(4)</a>
+    <li><a href="#ref-for-mutationevent①①">8.4.1. Interface MutationEvent</a> <a href="#ref-for-mutationevent①②">(2)</a> <a href="#ref-for-mutationevent①③">(3)</a> <a href="#ref-for-mutationevent①④">(4)</a> <a href="#ref-for-mutationevent①⑤">(5)</a>
+    <li><a href="#ref-for-mutationevent①⑥">8.4.2. Legacy MutationEvent event types</a>
+    <li><a href="#ref-for-mutationevent①⑦">8.4.2.1. DOMAttrModified</a> <a href="#ref-for-mutationevent①⑧">(2)</a> <a href="#ref-for-mutationevent①⑨">(3)</a> <a href="#ref-for-mutationevent②⓪">(4)</a> <a href="#ref-for-mutationevent②①">(5)</a> <a href="#ref-for-mutationevent②②">(6)</a>
+    <li><a href="#ref-for-mutationevent②③">8.4.2.2. DOMCharacterDataModified</a> <a href="#ref-for-mutationevent②④">(2)</a> <a href="#ref-for-mutationevent②⑤">(3)</a> <a href="#ref-for-mutationevent②⑥">(4)</a> <a href="#ref-for-mutationevent②⑦">(5)</a> <a href="#ref-for-mutationevent②⑧">(6)</a>
+    <li><a href="#ref-for-mutationevent②⑨">8.4.2.3. DOMNodeInserted</a> <a href="#ref-for-mutationevent③⓪">(2)</a> <a href="#ref-for-mutationevent③①">(3)</a> <a href="#ref-for-mutationevent③②">(4)</a> <a href="#ref-for-mutationevent③③">(5)</a> <a href="#ref-for-mutationevent③④">(6)</a>
+    <li><a href="#ref-for-mutationevent③⑤">8.4.2.4. DOMNodeInsertedIntoDocument</a> <a href="#ref-for-mutationevent③⑥">(2)</a> <a href="#ref-for-mutationevent③⑦">(3)</a> <a href="#ref-for-mutationevent③⑧">(4)</a> <a href="#ref-for-mutationevent③⑨">(5)</a> <a href="#ref-for-mutationevent④⓪">(6)</a>
+    <li><a href="#ref-for-mutationevent④①">8.4.2.5. DOMNodeRemoved</a> <a href="#ref-for-mutationevent④②">(2)</a> <a href="#ref-for-mutationevent④③">(3)</a> <a href="#ref-for-mutationevent④④">(4)</a> <a href="#ref-for-mutationevent④⑤">(5)</a> <a href="#ref-for-mutationevent④⑥">(6)</a>
+    <li><a href="#ref-for-mutationevent④⑦">8.4.2.6. DOMNodeRemovedFromDocument</a> <a href="#ref-for-mutationevent④⑧">(2)</a> <a href="#ref-for-mutationevent④⑨">(3)</a> <a href="#ref-for-mutationevent⑤⓪">(4)</a> <a href="#ref-for-mutationevent⑤①">(5)</a> <a href="#ref-for-mutationevent⑤②">(6)</a>
+    <li><a href="#ref-for-mutationevent⑤③">8.4.2.7. DOMSubtreeModified</a> <a href="#ref-for-mutationevent⑤④">(2)</a> <a href="#ref-for-mutationevent⑤⑤">(3)</a> <a href="#ref-for-mutationevent⑤⑥">(4)</a> <a href="#ref-for-mutationevent⑤⑦">(5)</a> <a href="#ref-for-mutationevent⑤⑧">(6)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-event-bubbles">
+   <a href="https://dom.spec.whatwg.org/#dom-event-bubbles">https://dom.spec.whatwg.org/#dom-event-bubbles</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-event-bubbles">3.1. Event dispatch and DOM event flow</a>
+    <li><a href="#ref-for-dom-event-bubbles①">13. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-event-cancelable">
+   <a href="https://dom.spec.whatwg.org/#dom-event-cancelable">https://dom.spec.whatwg.org/#dom-event-cancelable</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-event-cancelable">3.2. Default actions and cancelable events</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-document-createevent">
+   <a href="https://dom.spec.whatwg.org/#dom-document-createevent">https://dom.spec.whatwg.org/#dom-document-createevent</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-document-createevent">3.4. Trusted events</a>
+    <li><a href="#ref-for-dom-document-createevent①">7.2.1. Interface KeyboardEvent (supplemental)</a>
+    <li><a href="#ref-for-dom-document-createevent②">8.4.1. Interface MutationEvent</a>
+    <li><a href="#ref-for-dom-document-createevent③">13. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-event-currenttarget">
+   <a href="https://dom.spec.whatwg.org/#dom-event-currenttarget">https://dom.spec.whatwg.org/#dom-event-currenttarget</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-event-currenttarget">13. Glossary</a> <a href="#ref-for-dom-event-currenttarget①">(2)</a> <a href="#ref-for-dom-event-currenttarget②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-event-defaultprevented">
+   <a href="https://dom.spec.whatwg.org/#dom-event-defaultprevented">https://dom.spec.whatwg.org/#dom-event-defaultprevented</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-event-defaultprevented">3.2. Default actions and cancelable events</a>
+    <li><a href="#ref-for-dom-event-defaultprevented①">11.1.3. Changes to DOM Level 2 Events interfaces</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-eventtarget-dispatchevent">
+   <a href="https://dom.spec.whatwg.org/#dom-eventtarget-dispatchevent">https://dom.spec.whatwg.org/#dom-eventtarget-dispatchevent</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-eventtarget-dispatchevent">3.1. Event dispatch and DOM event flow</a>
+    <li><a href="#ref-for-dom-eventtarget-dispatchevent①">3.2. Default actions and cancelable events</a>
+    <li><a href="#ref-for-dom-eventtarget-dispatchevent②">3.4. Trusted events</a>
+    <li><a href="#ref-for-dom-eventtarget-dispatchevent③">11.1.3. Changes to DOM Level 2 Events interfaces</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-eventlistener-handleevent">
+   <a href="https://dom.spec.whatwg.org/#dom-eventlistener-handleevent">https://dom.spec.whatwg.org/#dom-eventlistener-handleevent</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-eventlistener-handleevent">13. Glossary</a> <a href="#ref-for-dom-eventlistener-handleevent①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-eventlistener-handleevent">
+   <a href="https://dom.spec.whatwg.org/#dom-eventlistener-handleevent">https://dom.spec.whatwg.org/#dom-eventlistener-handleevent</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-eventlistener-handleevent">13. Glossary</a> <a href="#ref-for-dom-eventlistener-handleevent①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-event-initevent">
+   <a href="https://dom.spec.whatwg.org/#dom-event-initevent">https://dom.spec.whatwg.org/#dom-event-initevent</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-event-initevent">3.4. Trusted events</a>
+    <li><a href="#ref-for-dom-event-initevent①">6.1.1. Initializers for interface UIEvent</a> <a href="#ref-for-dom-event-initevent②">(2)</a> <a href="#ref-for-dom-event-initevent③">(3)</a> <a href="#ref-for-dom-event-initevent④">(4)</a>
+    <li><a href="#ref-for-dom-event-initevent⑤">6.1.2. Initializers for interface MouseEvent</a> <a href="#ref-for-dom-event-initevent⑥">(2)</a> <a href="#ref-for-dom-event-initevent⑦">(3)</a>
+    <li><a href="#ref-for-dom-event-initevent⑧">6.1.3. Initializers for interface WheelEvent</a> <a href="#ref-for-dom-event-initevent⑨">(2)</a> <a href="#ref-for-dom-event-initevent①⓪">(3)</a>
+    <li><a href="#ref-for-dom-event-initevent①①">6.1.4. Initializers for interface KeyboardEvent</a> <a href="#ref-for-dom-event-initevent①②">(2)</a> <a href="#ref-for-dom-event-initevent①③">(3)</a>
+    <li><a href="#ref-for-dom-event-initevent①④">6.1.5. Initializers for interface CompositionEvent</a> <a href="#ref-for-dom-event-initevent①⑤">(2)</a> <a href="#ref-for-dom-event-initevent①⑥">(3)</a>
+    <li><a href="#ref-for-dom-event-initevent①⑦">8.4.1. Interface MutationEvent</a> <a href="#ref-for-dom-event-initevent①⑧">(2)</a> <a href="#ref-for-dom-event-initevent①⑨">(3)</a> <a href="#ref-for-dom-event-initevent②⓪">(4)</a>
+    <li><a href="#ref-for-dom-event-initevent②①">13. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-event-istrusted">
+   <a href="https://dom.spec.whatwg.org/#dom-event-istrusted">https://dom.spec.whatwg.org/#dom-event-istrusted</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-event-istrusted">3.4. Trusted events</a> <a href="#ref-for-dom-event-istrusted①">(2)</a> <a href="#ref-for-dom-event-istrusted②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-event-preventdefault">
+   <a href="https://dom.spec.whatwg.org/#dom-event-preventdefault">https://dom.spec.whatwg.org/#dom-event-preventdefault</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-event-preventdefault">3.2. Default actions and cancelable events</a> <a href="#ref-for-dom-event-preventdefault①">(2)</a>
+    <li><a href="#ref-for-dom-event-preventdefault②">3.4. Trusted events</a>
+    <li><a href="#ref-for-dom-event-preventdefault③">4.7.4. Canceling Composition Events</a> <a href="#ref-for-dom-event-preventdefault④">(2)</a>
+    <li><a href="#ref-for-dom-event-preventdefault⑤">4.7.7.1. compositionstart</a>
+    <li><a href="#ref-for-dom-event-preventdefault⑥">5.3.4. Default actions and cancelable keyboard events</a> <a href="#ref-for-dom-event-preventdefault⑦">(2)</a> <a href="#ref-for-dom-event-preventdefault⑧">(3)</a>
+    <li><a href="#ref-for-dom-event-preventdefault⑨">13. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-event-stopimmediatepropagation">
+   <a href="https://dom.spec.whatwg.org/#dom-event-stopimmediatepropagation">https://dom.spec.whatwg.org/#dom-event-stopimmediatepropagation</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-event-stopimmediatepropagation">11.1.3. Changes to DOM Level 2 Events interfaces</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-event-stoppropagation">
+   <a href="https://dom.spec.whatwg.org/#dom-event-stoppropagation">https://dom.spec.whatwg.org/#dom-event-stoppropagation</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-event-stoppropagation">3.1. Event dispatch and DOM event flow</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-event-target">
+   <a href="https://dom.spec.whatwg.org/#dom-event-target">https://dom.spec.whatwg.org/#dom-event-target</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-event-target">4.1.2.1. load</a>
+    <li><a href="#ref-for-dom-event-target①">4.1.2.2. unload</a>
+    <li><a href="#ref-for-dom-event-target②">4.1.2.3. abort</a>
+    <li><a href="#ref-for-dom-event-target③">4.1.2.4. error</a>
+    <li><a href="#ref-for-dom-event-target④">4.1.2.5. select</a>
+    <li><a href="#ref-for-dom-event-target⑤">4.2.4.1. blur</a>
+    <li><a href="#ref-for-dom-event-target⑥">4.2.4.2. focus</a>
+    <li><a href="#ref-for-dom-event-target⑦">4.2.4.3. focusin</a>
+    <li><a href="#ref-for-dom-event-target⑧">4.2.4.4. focusout</a>
+    <li><a href="#ref-for-dom-event-target⑨">4.3.4.1. auxclick</a>
+    <li><a href="#ref-for-dom-event-target①⓪">4.3.4.2. click</a>
+    <li><a href="#ref-for-dom-event-target①①">4.3.4.3. dblclick</a>
+    <li><a href="#ref-for-dom-event-target①②">4.3.4.4. mousedown</a>
+    <li><a href="#ref-for-dom-event-target①③">4.3.4.5. mouseenter</a>
+    <li><a href="#ref-for-dom-event-target①④">4.3.4.6. mouseleave</a>
+    <li><a href="#ref-for-dom-event-target①⑤">4.3.4.7. mousemove</a>
+    <li><a href="#ref-for-dom-event-target①⑥">4.3.4.8. mouseout</a>
+    <li><a href="#ref-for-dom-event-target①⑦">4.3.4.9. mouseover</a>
+    <li><a href="#ref-for-dom-event-target①⑧">4.3.4.10. mouseup</a>
+    <li><a href="#ref-for-dom-event-target①⑨">4.4.2.1. wheel</a>
+    <li><a href="#ref-for-dom-event-target②⓪">4.5.3.1. beforeinput</a>
+    <li><a href="#ref-for-dom-event-target②①">4.5.3.2. input</a>
+    <li><a href="#ref-for-dom-event-target②②">4.6.4.1. keydown</a>
+    <li><a href="#ref-for-dom-event-target②③">4.6.4.2. keyup</a>
+    <li><a href="#ref-for-dom-event-target②④">4.7.7.1. compositionstart</a>
+    <li><a href="#ref-for-dom-event-target②⑤">4.7.7.2. compositionupdate</a>
+    <li><a href="#ref-for-dom-event-target②⑥">4.7.7.3. compositionend</a>
+    <li><a href="#ref-for-dom-event-target②⑦">8.1.1.1. DOMActivate</a>
+    <li><a href="#ref-for-dom-event-target②⑧">8.2.1.1. DOMFocusIn</a>
+    <li><a href="#ref-for-dom-event-target②⑨">8.2.1.2. DOMFocusOut</a>
+    <li><a href="#ref-for-dom-event-target③⓪">8.3.1.1. keypress</a>
+    <li><a href="#ref-for-dom-event-target③①">8.4.2.1. DOMAttrModified</a>
+    <li><a href="#ref-for-dom-event-target③②">8.4.2.2. DOMCharacterDataModified</a>
+    <li><a href="#ref-for-dom-event-target③③">8.4.2.3. DOMNodeInserted</a>
+    <li><a href="#ref-for-dom-event-target③④">8.4.2.4. DOMNodeInsertedIntoDocument</a>
+    <li><a href="#ref-for-dom-event-target③⑤">8.4.2.5. DOMNodeRemoved</a>
+    <li><a href="#ref-for-dom-event-target③⑥">8.4.2.6. DOMNodeRemovedFromDocument</a>
+    <li><a href="#ref-for-dom-event-target③⑦">8.4.2.7. DOMSubtreeModified</a>
+    <li><a href="#ref-for-dom-event-target③⑧">13. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-event-timestamp">
+   <a href="https://dom.spec.whatwg.org/#dom-event-timestamp">https://dom.spec.whatwg.org/#dom-event-timestamp</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-event-timestamp">11.1.3. Changes to DOM Level 2 Events interfaces</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-event-type">
+   <a href="https://dom.spec.whatwg.org/#dom-event-type">https://dom.spec.whatwg.org/#dom-event-type</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-event-type">11.1.3. Changes to DOM Level 2 Events interfaces</a> <a href="#ref-for-dom-event-type①">(2)</a>
+    <li><a href="#ref-for-dom-event-type②">13. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-window">
+   <a href="https://html.spec.whatwg.org/multipage/window-object.html#window">https://html.spec.whatwg.org/multipage/window-object.html#window</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-window②">4.1.1.1. UIEvent</a>
+    <li><a href="#ref-for-window③">4.1.1.2. UIEventInit</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-the-input-element">
+   <a href="https://html.spec.whatwg.org/multipage/input.html#the-input-element">https://html.spec.whatwg.org/multipage/input.html#the-input-element</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-the-input-element">4.1.2.5. select</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-the-textarea-element">
+   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-the-textarea-element">4.1.2.5. select</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-XProperty">
+   <a href="https://svgwg.org/svg2-draft/geometry.html#XProperty">https://svgwg.org/svg2-draft/geometry.html#XProperty</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-XProperty">5.3. Keyboard Event key Values</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-">
+   <a href="http://www.w3.org/TR/uievents/#">http://www.w3.org/TR/uievents/#</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#termref-for-">4.6.1.1. KeyboardEvent</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-keys-modifier">
+   <a href="https://www.w3.org/TR/uievents-key/#keys-modifier">https://www.w3.org/TR/uievents-key/#keys-modifier</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-keys-modifier">4.6.1.1. KeyboardEvent</a>
+    <li><a href="#ref-for-keys-modifier①">13. Glossary</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
+   <a href="https://heycam.github.io/webidl/#idl-DOMString">https://heycam.github.io/webidl/#idl-DOMString</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-idl-DOMString">4.1.1.1. UIEvent</a>
+    <li><a href="#ref-for-idl-DOMString①">4.2.1.1. FocusEvent</a>
+    <li><a href="#ref-for-idl-DOMString②">4.3.1.1. MouseEvent</a> <a href="#ref-for-idl-DOMString③">(2)</a>
+    <li><a href="#ref-for-idl-DOMString④">4.4.1.1. WheelEvent</a>
+    <li><a href="#ref-for-idl-DOMString⑤">4.5.1.1. InputEvent</a> <a href="#ref-for-idl-DOMString⑥">(2)</a> <a href="#ref-for-idl-DOMString⑦">(3)</a> <a href="#ref-for-idl-DOMString⑧">(4)</a> <a href="#ref-for-idl-DOMString⑨">(5)</a>
+    <li><a href="#ref-for-idl-DOMString①⓪">4.5.1.2. InputEventInit</a> <a href="#ref-for-idl-DOMString①①">(2)</a> <a href="#ref-for-idl-DOMString①②">(3)</a> <a href="#ref-for-idl-DOMString①③">(4)</a>
+    <li><a href="#ref-for-idl-DOMString①④">4.6.1.1. KeyboardEvent</a> <a href="#ref-for-idl-DOMString①⑤">(2)</a> <a href="#ref-for-idl-DOMString①⑥">(3)</a> <a href="#ref-for-idl-DOMString①⑦">(4)</a> <a href="#ref-for-idl-DOMString①⑧">(5)</a> <a href="#ref-for-idl-DOMString①⑨">(6)</a>
+    <li><a href="#ref-for-idl-DOMString②⓪">4.6.1.2. KeyboardEventInit</a> <a href="#ref-for-idl-DOMString②①">(2)</a> <a href="#ref-for-idl-DOMString②②">(3)</a> <a href="#ref-for-idl-DOMString②③">(4)</a>
+    <li><a href="#ref-for-idl-DOMString②④">4.7.1.1. CompositionEvent</a> <a href="#ref-for-idl-DOMString②⑤">(2)</a> <a href="#ref-for-idl-DOMString②⑥">(3)</a>
+    <li><a href="#ref-for-idl-DOMString②⑦">4.7.1.2. CompositionEventInit</a> <a href="#ref-for-idl-DOMString②⑧">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-Exposed">
+   <a href="https://heycam.github.io/webidl/#Exposed">https://heycam.github.io/webidl/#Exposed</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-Exposed">4.1.1.1. UIEvent</a>
+    <li><a href="#ref-for-Exposed①">4.2.1.1. FocusEvent</a>
+    <li><a href="#ref-for-Exposed②">4.3.1.1. MouseEvent</a>
+    <li><a href="#ref-for-Exposed③">4.4.1.1. WheelEvent</a>
+    <li><a href="#ref-for-Exposed④">4.5.1.1. InputEvent</a>
+    <li><a href="#ref-for-Exposed⑤">4.6.1.1. KeyboardEvent</a>
+    <li><a href="#ref-for-Exposed⑥">4.7.1.1. CompositionEvent</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-idl-boolean">
+   <a href="https://heycam.github.io/webidl/#idl-boolean">https://heycam.github.io/webidl/#idl-boolean</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-idl-boolean">4.3.1.1. MouseEvent</a> <a href="#ref-for-idl-boolean①">(2)</a> <a href="#ref-for-idl-boolean②">(3)</a> <a href="#ref-for-idl-boolean③">(4)</a> <a href="#ref-for-idl-boolean④">(5)</a> <a href="#ref-for-idl-boolean⑤">(6)</a> <a href="#ref-for-idl-boolean⑥">(7)</a> <a href="#ref-for-idl-boolean⑦">(8)</a> <a href="#ref-for-idl-boolean⑧">(9)</a>
+    <li><a href="#ref-for-idl-boolean⑨">4.3.2. Event Modifier Initializers</a> <a href="#ref-for-idl-boolean①⓪">(2)</a> <a href="#ref-for-idl-boolean①①">(3)</a> <a href="#ref-for-idl-boolean①②">(4)</a> <a href="#ref-for-idl-boolean①③">(5)</a> <a href="#ref-for-idl-boolean①④">(6)</a> <a href="#ref-for-idl-boolean①⑤">(7)</a> <a href="#ref-for-idl-boolean①⑥">(8)</a> <a href="#ref-for-idl-boolean①⑦">(9)</a> <a href="#ref-for-idl-boolean①⑧">(10)</a> <a href="#ref-for-idl-boolean①⑨">(11)</a> <a href="#ref-for-idl-boolean②⓪">(12)</a> <a href="#ref-for-idl-boolean②①">(13)</a> <a href="#ref-for-idl-boolean②②">(14)</a> <a href="#ref-for-idl-boolean②③">(15)</a> <a href="#ref-for-idl-boolean②④">(16)</a> <a href="#ref-for-idl-boolean②⑤">(17)</a> <a href="#ref-for-idl-boolean②⑥">(18)</a> <a href="#ref-for-idl-boolean②⑦">(19)</a> <a href="#ref-for-idl-boolean②⑧">(20)</a> <a href="#ref-for-idl-boolean②⑨">(21)</a> <a href="#ref-for-idl-boolean③⓪">(22)</a> <a href="#ref-for-idl-boolean③①">(23)</a> <a href="#ref-for-idl-boolean③②">(24)</a> <a href="#ref-for-idl-boolean③③">(25)</a> <a href="#ref-for-idl-boolean③④">(26)</a> <a href="#ref-for-idl-boolean③⑤">(27)</a> <a href="#ref-for-idl-boolean③⑥">(28)</a>
+    <li><a href="#ref-for-idl-boolean③⑦">4.5.1.1. InputEvent</a> <a href="#ref-for-idl-boolean③⑧">(2)</a>
+    <li><a href="#ref-for-idl-boolean③⑨">4.5.1.2. InputEventInit</a> <a href="#ref-for-idl-boolean④⓪">(2)</a>
+    <li><a href="#ref-for-idl-boolean④①">4.6.1.1. KeyboardEvent</a> <a href="#ref-for-idl-boolean④②">(2)</a> <a href="#ref-for-idl-boolean④③">(3)</a> <a href="#ref-for-idl-boolean④④">(4)</a> <a href="#ref-for-idl-boolean④⑤">(5)</a> <a href="#ref-for-idl-boolean④⑥">(6)</a> <a href="#ref-for-idl-boolean④⑦">(7)</a> <a href="#ref-for-idl-boolean④⑧">(8)</a> <a href="#ref-for-idl-boolean④⑨">(9)</a> <a href="#ref-for-idl-boolean⑤⓪">(10)</a> <a href="#ref-for-idl-boolean⑤①">(11)</a> <a href="#ref-for-idl-boolean⑤②">(12)</a> <a href="#ref-for-idl-boolean⑤③">(13)</a>
+    <li><a href="#ref-for-idl-boolean⑤④">4.6.1.2. KeyboardEventInit</a> <a href="#ref-for-idl-boolean⑤⑤">(2)</a> <a href="#ref-for-idl-boolean⑤⑥">(3)</a> <a href="#ref-for-idl-boolean⑤⑦">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-idl-double">
+   <a href="https://heycam.github.io/webidl/#idl-double">https://heycam.github.io/webidl/#idl-double</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-idl-double">4.4.1.1. WheelEvent</a> <a href="#ref-for-idl-double①">(2)</a> <a href="#ref-for-idl-double②">(3)</a> <a href="#ref-for-idl-double③">(4)</a> <a href="#ref-for-idl-double④">(5)</a> <a href="#ref-for-idl-double⑤">(6)</a>
+    <li><a href="#ref-for-idl-double⑥">4.4.1.2. WheelEventInit</a> <a href="#ref-for-idl-double⑦">(2)</a> <a href="#ref-for-idl-double⑧">(3)</a> <a href="#ref-for-idl-double⑨">(4)</a> <a href="#ref-for-idl-double①⓪">(5)</a> <a href="#ref-for-idl-double①①">(6)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-idl-long">
+   <a href="https://heycam.github.io/webidl/#idl-long">https://heycam.github.io/webidl/#idl-long</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-idl-long">4.1.1.1. UIEvent</a>
+    <li><a href="#ref-for-idl-long①">4.1.1.2. UIEventInit</a>
+    <li><a href="#ref-for-idl-long②">4.3.1.1. MouseEvent</a> <a href="#ref-for-idl-long③">(2)</a> <a href="#ref-for-idl-long④">(3)</a> <a href="#ref-for-idl-long⑤">(4)</a> <a href="#ref-for-idl-long⑥">(5)</a> <a href="#ref-for-idl-long⑦">(6)</a> <a href="#ref-for-idl-long⑧">(7)</a> <a href="#ref-for-idl-long⑨">(8)</a>
+    <li><a href="#ref-for-idl-long①⓪">4.3.1.2. MouseEventInit</a> <a href="#ref-for-idl-long①①">(2)</a> <a href="#ref-for-idl-long①②">(3)</a> <a href="#ref-for-idl-long①③">(4)</a> <a href="#ref-for-idl-long①④">(5)</a> <a href="#ref-for-idl-long①⑤">(6)</a> <a href="#ref-for-idl-long①⑥">(7)</a> <a href="#ref-for-idl-long①⑦">(8)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-idl-short">
+   <a href="https://heycam.github.io/webidl/#idl-short">https://heycam.github.io/webidl/#idl-short</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-idl-short">4.3.1.1. MouseEvent</a> <a href="#ref-for-idl-short①">(2)</a>
+    <li><a href="#ref-for-idl-short②">4.3.1.2. MouseEventInit</a> <a href="#ref-for-idl-short③">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
+   <a href="https://heycam.github.io/webidl/#idl-unsigned-long">https://heycam.github.io/webidl/#idl-unsigned-long</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-idl-unsigned-long">4.4.1.1. WheelEvent</a> <a href="#ref-for-idl-unsigned-long①">(2)</a> <a href="#ref-for-idl-unsigned-long②">(3)</a> <a href="#ref-for-idl-unsigned-long③">(4)</a> <a href="#ref-for-idl-unsigned-long④">(5)</a>
+    <li><a href="#ref-for-idl-unsigned-long⑤">4.4.1.2. WheelEventInit</a> <a href="#ref-for-idl-unsigned-long⑥">(2)</a>
+    <li><a href="#ref-for-idl-unsigned-long⑦">4.6.1.1. KeyboardEvent</a> <a href="#ref-for-idl-unsigned-long⑧">(2)</a> <a href="#ref-for-idl-unsigned-long⑨">(3)</a> <a href="#ref-for-idl-unsigned-long①⓪">(4)</a> <a href="#ref-for-idl-unsigned-long①①">(5)</a> <a href="#ref-for-idl-unsigned-long①②">(6)</a>
+    <li><a href="#ref-for-idl-unsigned-long①③">4.6.1.2. KeyboardEventInit</a> <a href="#ref-for-idl-unsigned-long①④">(2)</a>
+    <li><a href="#ref-for-idl-unsigned-long①⑤">7.1.1. Interface UIEvent (supplemental)</a> <a href="#ref-for-idl-unsigned-long①⑥">(2)</a>
+    <li><a href="#ref-for-idl-unsigned-long①⑦">7.2.1. Interface KeyboardEvent (supplemental)</a> <a href="#ref-for-idl-unsigned-long①⑧">(2)</a> <a href="#ref-for-idl-unsigned-long①⑨">(3)</a> <a href="#ref-for-idl-unsigned-long②⓪">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-idl-unsigned-short">
+   <a href="https://heycam.github.io/webidl/#idl-unsigned-short">https://heycam.github.io/webidl/#idl-unsigned-short</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-idl-unsigned-short">4.3.1.1. MouseEvent</a> <a href="#ref-for-idl-unsigned-short①">(2)</a>
+    <li><a href="#ref-for-idl-unsigned-short②">4.3.1.2. MouseEventInit</a> <a href="#ref-for-idl-unsigned-short③">(2)</a>
+   </ul>
+  </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
    <li>
     <a data-link-type="biblio">[DOM]</a> defines the following terms:
     <ul>
-     <li><a href="https://dom.spec.whatwg.org/#customevent">CustomEvent</a>
-     <li><a href="https://dom.spec.whatwg.org/#document">Document</a>
-     <li><a href="https://dom.spec.whatwg.org/#event">Event</a>
-     <li><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">EventInit</a>
-     <li><a href="https://dom.spec.whatwg.org/#callbackdef-eventlistener">EventListener</a>
-     <li><a href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>
-     <li><a href="https://dom.spec.whatwg.org/#mutationevent">MutationEvent</a>
-     <li><a href="https://dom.spec.whatwg.org/#dom-event-bubbles">bubbles</a>
-     <li><a href="https://dom.spec.whatwg.org/#dom-event-cancelable">cancelable</a>
-     <li><a href="https://dom.spec.whatwg.org/#dom-document-createevent">createEvent(interface)</a>
-     <li><a href="https://dom.spec.whatwg.org/#dom-event-currenttarget">currentTarget</a>
-     <li><a href="https://dom.spec.whatwg.org/#dom-event-defaultprevented">defaultPrevented</a>
-     <li><a href="https://dom.spec.whatwg.org/#dom-eventtarget-dispatchevent">dispatchEvent(event)</a>
-     <li><a href="https://dom.spec.whatwg.org/#dom-eventlistener-handleevent">handleEvent</a>
-     <li><a href="https://dom.spec.whatwg.org/#dom-eventlistener-handleevent">handleEvent(event)</a>
-     <li><a href="https://dom.spec.whatwg.org/#dom-event-initevent">initEvent(type)</a>
-     <li><a href="https://dom.spec.whatwg.org/#dom-event-istrusted">isTrusted</a>
-     <li><a href="https://dom.spec.whatwg.org/#dom-event-preventdefault">preventDefault()</a>
-     <li><a href="https://dom.spec.whatwg.org/#dom-event-stopimmediatepropagation">stopImmediatePropagation()</a>
-     <li><a href="https://dom.spec.whatwg.org/#dom-event-stoppropagation">stopPropagation()</a>
-     <li><a href="https://dom.spec.whatwg.org/#dom-event-target">target</a>
-     <li><a href="https://dom.spec.whatwg.org/#dom-event-timestamp">timeStamp</a>
-     <li><a href="https://dom.spec.whatwg.org/#dom-event-type">type</a>
+     <li><span class="dfn-paneled" id="term-for-customevent" style="color:initial">CustomEvent</span>
+     <li><span class="dfn-paneled" id="term-for-document" style="color:initial">Document</span>
+     <li><span class="dfn-paneled" id="term-for-event" style="color:initial">Event</span>
+     <li><span class="dfn-paneled" id="term-for-dictdef-eventinit" style="color:initial">EventInit</span>
+     <li><span class="dfn-paneled" id="term-for-callbackdef-eventlistener" style="color:initial">EventListener</span>
+     <li><span class="dfn-paneled" id="term-for-eventtarget" style="color:initial">EventTarget</span>
+     <li><span class="dfn-paneled" id="term-for-mutationevent" style="color:initial">MutationEvent</span>
+     <li><span class="dfn-paneled" id="term-for-dom-event-bubbles" style="color:initial">bubbles</span>
+     <li><span class="dfn-paneled" id="term-for-dom-event-cancelable" style="color:initial">cancelable</span>
+     <li><span class="dfn-paneled" id="term-for-dom-document-createevent" style="color:initial">createEvent(interface)</span>
+     <li><span class="dfn-paneled" id="term-for-dom-event-currenttarget" style="color:initial">currentTarget</span>
+     <li><span class="dfn-paneled" id="term-for-dom-event-defaultprevented" style="color:initial">defaultPrevented</span>
+     <li><span class="dfn-paneled" id="term-for-dom-eventtarget-dispatchevent" style="color:initial">dispatchEvent(event)</span>
+     <li><span class="dfn-paneled" id="term-for-dom-eventlistener-handleevent" style="color:initial">handleEvent</span>
+     <li><span class="dfn-paneled" id="term-for-dom-eventlistener-handleevent①" style="color:initial">handleEvent(event)</span>
+     <li><span class="dfn-paneled" id="term-for-dom-event-initevent" style="color:initial">initEvent(type)</span>
+     <li><span class="dfn-paneled" id="term-for-dom-event-istrusted" style="color:initial">isTrusted</span>
+     <li><span class="dfn-paneled" id="term-for-dom-event-preventdefault" style="color:initial">preventDefault()</span>
+     <li><span class="dfn-paneled" id="term-for-dom-event-stopimmediatepropagation" style="color:initial">stopImmediatePropagation()</span>
+     <li><span class="dfn-paneled" id="term-for-dom-event-stoppropagation" style="color:initial">stopPropagation()</span>
+     <li><span class="dfn-paneled" id="term-for-dom-event-target" style="color:initial">target</span>
+     <li><span class="dfn-paneled" id="term-for-dom-event-timestamp" style="color:initial">timeStamp</span>
+     <li><span class="dfn-paneled" id="term-for-dom-event-type" style="color:initial">type</span>
     </ul>
    <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
-     <li><a href="https://html.spec.whatwg.org/multipage/window-object.html#window">Window</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/input.html#the-input-element">input</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element">textarea</a>
+     <li><span class="dfn-paneled" id="term-for-window" style="color:initial">Window</span>
+     <li><span class="dfn-paneled" id="term-for-the-input-element" style="color:initial">input</span>
+     <li><span class="dfn-paneled" id="term-for-the-textarea-element" style="color:initial">textarea</span>
     </ul>
    <li>
     <a data-link-type="biblio">[SVG2]</a> defines the following terms:
     <ul>
-     <li><a href="https://svgwg.org/svg2-draft/geometry.html#XProperty">x</a>
-    </ul>
-   <li>
-    <a data-link-type="biblio">[uievents]</a> defines the following terms:
-    <ul>
-     <li><a href="https://www.w3.org/TR/uievents/#dom-keyboardevent-which">which</a>
+     <li><span class="dfn-paneled" id="term-for-XProperty" style="color:initial">x</span>
     </ul>
    <li>
     <a data-link-type="biblio">[UIEvents-Key]</a> defines the following terms:
     <ul>
-     <li><a href="http://www.w3.org/TR/uievents/#">key attribute value</a>
-     <li><a href="https://www.w3.org/TR/uievents-key/#keys-modifier">modifier keys table</a>
+     <li><span class="dfn-paneled" id="term-for-" style="color:initial">key attribute value</span>
+     <li><span class="dfn-paneled" id="term-for-keys-modifier" style="color:initial">modifier keys table</span>
     </ul>
    <li>
     <a data-link-type="biblio">[WebIDL]</a> defines the following terms:
     <ul>
-     <li><a href="https://heycam.github.io/webidl/#idl-DOMString">DOMString</a>
-     <li><a href="https://heycam.github.io/webidl/#Exposed">Exposed</a>
-     <li><a href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>
-     <li><a href="https://heycam.github.io/webidl/#idl-double">double</a>
-     <li><a href="https://heycam.github.io/webidl/#idl-long">long</a>
-     <li><a href="https://heycam.github.io/webidl/#idl-short">short</a>
-     <li><a href="https://heycam.github.io/webidl/#idl-unsigned-long">unsigned long</a>
-     <li><a href="https://heycam.github.io/webidl/#idl-unsigned-short">unsigned short</a>
+     <li><span class="dfn-paneled" id="term-for-idl-DOMString" style="color:initial">DOMString</span>
+     <li><span class="dfn-paneled" id="term-for-Exposed" style="color:initial">Exposed</span>
+     <li><span class="dfn-paneled" id="term-for-idl-boolean" style="color:initial">boolean</span>
+     <li><span class="dfn-paneled" id="term-for-idl-double" style="color:initial">double</span>
+     <li><span class="dfn-paneled" id="term-for-idl-long" style="color:initial">long</span>
+     <li><span class="dfn-paneled" id="term-for-idl-short" style="color:initial">short</span>
+     <li><span class="dfn-paneled" id="term-for-idl-unsigned-long" style="color:initial">unsigned long</span>
+     <li><span class="dfn-paneled" id="term-for-idl-unsigned-short" style="color:initial">unsigned short</span>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
@@ -8111,15 +8478,13 @@ browsing context’s Window Proxy object as defined in <a href="http://dev.w3.or
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
    <dt id="biblio-svg2">[SVG2]
-   <dd>Nikos Andronikos; et al. <a href="https://www.w3.org/TR/SVG2/">Scalable Vector Graphics (SVG) 2</a>. 15 September 2016. CR. URL: <a href="https://www.w3.org/TR/SVG2/">https://www.w3.org/TR/SVG2/</a>
-   <dt id="biblio-uievents">[UIEVENTS]
-   <dd>Gary Kacmarcik; Travis Leithead. <a href="https://www.w3.org/TR/uievents/">UI Events</a>. 4 August 2016. WD. URL: <a href="https://www.w3.org/TR/uievents/">https://www.w3.org/TR/uievents/</a>
+   <dd>Amelia Bellamy-Royds; et al. <a href="https://www.w3.org/TR/SVG2/">Scalable Vector Graphics (SVG) 2</a>. 4 October 2018. CR. URL: <a href="https://www.w3.org/TR/SVG2/">https://www.w3.org/TR/SVG2/</a>
    <dt id="biblio-uievents-code">[UIEvents-Code]
    <dd>Gary Kacmarcik; Travis Leithead. <a href="https://www.w3.org/TR/uievents-code/">UI Events KeyboardEvent code Values</a>. 1 June 2017. CR. URL: <a href="https://www.w3.org/TR/uievents-code/">https://www.w3.org/TR/uievents-code/</a>
    <dt id="biblio-uievents-key">[UIEvents-Key]
    <dd>Gary Kacmarcik; Travis Leithead. <a href="https://www.w3.org/TR/uievents-key/">UI Events KeyboardEvent key Values</a>. 1 June 2017. CR. URL: <a href="https://www.w3.org/TR/uievents-key/">https://www.w3.org/TR/uievents-key/</a>
    <dt id="biblio-webidl">[WebIDL]
-   <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. <a href="https://heycam.github.io/webidl/">Web IDL</a>. 15 December 2016. ED. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
+   <dd>Boris Zbarsky. <a href="https://heycam.github.io/webidl/">Web IDL</a>. 15 December 2016. ED. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
@@ -8132,13 +8497,13 @@ browsing context’s Window Proxy object as defined in <a href="http://dev.w3.or
    <dt id="biblio-html401">[HTML401]
    <dd>Dave Raggett; Arnaud Le Hors; Ian Jacobs. <a href="https://www.w3.org/TR/html401/">HTML 4.01 Specification</a>. 27 March 2018. REC. URL: <a href="https://www.w3.org/TR/html401/">https://www.w3.org/TR/html401/</a>
    <dt id="biblio-input-events">[Input-Events]
-   <dd>Johannes Wilm; Ben Peters. <a href="https://www.w3.org/TR/input-events-1/">Input Events Level 1</a>. 5 September 2017. WD. URL: <a href="https://www.w3.org/TR/input-events-1/">https://www.w3.org/TR/input-events-1/</a>
+   <dd>Johannes Wilm; Ben Peters. <a href="https://www.w3.org/TR/input-events-1/">Input Events Level 1</a>. 30 May 2019. WD. URL: <a href="https://www.w3.org/TR/input-events-1/">https://www.w3.org/TR/input-events-1/</a>
    <dt id="biblio-rfc20">[RFC20]
    <dd>V.G. Cerf. <a href="https://tools.ietf.org/html/rfc20">ASCII format for network interchange</a>. October 1969. Internet Standard. URL: <a href="https://tools.ietf.org/html/rfc20">https://tools.ietf.org/html/rfc20</a>
    <dt id="biblio-uaag20">[UAAG20]
    <dd>James Allan; et al. <a href="https://www.w3.org/TR/UAAG20/">User Agent Accessibility Guidelines (UAAG) 2.0</a>. 15 December 2015. NOTE. URL: <a href="https://www.w3.org/TR/UAAG20/">https://www.w3.org/TR/UAAG20/</a>
    <dt id="biblio-uax15">[UAX15]
-   <dd>Mark Davis; Ken Whistler. <a href="https://www.unicode.org/reports/tr15/tr15-45.html">Unicode Normalization Forms</a>. 26 May 2017. Unicode Standard Annex #15. URL: <a href="https://www.unicode.org/reports/tr15/tr15-45.html">https://www.unicode.org/reports/tr15/tr15-45.html</a>
+   <dd>Ken Whistler. <a href="https://www.unicode.org/reports/tr15/tr15-48.html">Unicode Normalization Forms</a>. 4 February 2019. Unicode Standard Annex #15. URL: <a href="https://www.unicode.org/reports/tr15/tr15-48.html">https://www.unicode.org/reports/tr15/tr15-48.html</a>
    <dt id="biblio-unicode">[Unicode]
    <dd><a href="https://www.unicode.org/versions/latest/">The Unicode Standard</a>. URL: <a href="https://www.unicode.org/versions/latest/">https://www.unicode.org/versions/latest/</a>
    <dt id="biblio-us-ascii">[US-ASCII]
@@ -8151,157 +8516,157 @@ browsing context’s Window Proxy object as defined in <a href="http://dev.w3.or
    <dd>Tim Bray; et al. <a href="https://www.w3.org/TR/xml-names11/">Namespaces in XML 1.1 (Second Edition)</a>. 16 August 2006. REC. URL: <a href="https://www.w3.org/TR/xml-names11/">https://www.w3.org/TR/xml-names11/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl highlight def">[<a class="nv" href="#dom-uievent-uievent"><code>Constructor</code></a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③⓪"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-uievent-uievent-type-eventinitdict-type"><code>type</code></a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit②①">UIEventInit</a> <a class="nv" href="#dom-uievent-uievent-type-eventinitdict-eventinitdict"><code>eventInitDict</code></a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑦">Exposed</a>=<span class="n">Window</span>]
-<span class="kt">interface</span> <a class="nv" href="#uievent"><code>UIEvent</code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event" id="ref-for-event⑦①">Event</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window②①⓪">Window</a>? <a class="nv" data-readonly="" data-type="Window?" href="#dom-uievent-view"><code>view</code></a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①⑨"><span class="kt">long</span></a> <a class="nv" data-readonly="" data-type="long" href="#dom-uievent-detail"><code>detail</code></a>;
+<pre class="idl highlight def">[<a href="#dom-uievent-uievent"><code><c- g>Constructor</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③⓪"><c- b>DOMString</c-></a> <a href="#dom-uievent-uievent-type-eventinitdict-type"><code><c- g>type</c-></code></a>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit②①"><c- n>UIEventInit</c-></a> <a href="#dom-uievent-uievent-type-eventinitdict-eventinitdict"><code><c- g>eventInitDict</c-></code></a>), <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑦"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<c- b>interface</c-> <a href="#uievent"><code><c- g>UIEvent</c-></code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#event" id="ref-for-event⑦①"><c- n>Event</c-></a> {
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window②①⓪"><c- n>Window</c-></a>? <a data-readonly data-type="Window?" href="#dom-uievent-view"><code><c- g>view</c-></code></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①⑨"><c- b>long</c-></a> <a data-readonly data-type="long" href="#dom-uievent-detail"><code><c- g>detail</c-></code></a>;
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-uieventinit"><code>UIEventInit</code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit" id="ref-for-dictdef-eventinit①">EventInit</a> {
-  <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window③①⓪">Window</a>? <a class="nv" data-default="null" data-type="Window? " href="#dom-uieventinit-view"><code>view</code></a> = <span class="kt">null</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①⑧"><span class="kt">long</span></a> <a class="nv" data-default="0" data-type="long " href="#dom-uieventinit-detail"><code>detail</code></a> = 0;
+<c- b>dictionary</c-> <a href="#dictdef-uieventinit"><code><c- g>UIEventInit</c-></code></a> : <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#dictdef-eventinit" id="ref-for-dictdef-eventinit①"><c- n>EventInit</c-></a> {
+  <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window③①⓪"><c- n>Window</c-></a>? <a data-default="null" data-type="Window? " href="#dom-uieventinit-view"><code><c- g>view</c-></code></a> = <c- b>null</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①⑧"><c- b>long</c-></a> <a data-default="0" data-type="long " href="#dom-uieventinit-detail"><code><c- g>detail</c-></code></a> = 0;
 };
 
-[<a class="nv" href="#dom-focusevent-focusevent"><code>Constructor</code></a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①①⓪"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-focusevent-focusevent-type-eventinitdict-type"><code>type</code></a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-focuseventinit" id="ref-for-dictdef-focuseventinit①①">FocusEventInit</a> <a class="nv" href="#dom-focusevent-focusevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code></a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①①">Exposed</a>=<span class="n">Window</span>]
-<span class="kt">interface</span> <a class="nv" href="#focusevent"><code>FocusEvent</code></a> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent①⑨①">UIEvent</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget①①">EventTarget</a>? <a class="nv" data-readonly="" data-type="EventTarget?" href="#dom-focusevent-relatedtarget"><code>relatedTarget</code></a>;
+[<a href="#dom-focusevent-focusevent"><code><c- g>Constructor</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①①⓪"><c- b>DOMString</c-></a> <a href="#dom-focusevent-focusevent-type-eventinitdict-type"><code><c- g>type</c-></code></a>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-focuseventinit" id="ref-for-dictdef-focuseventinit①①"><c- n>FocusEventInit</c-></a> <a href="#dom-focusevent-focusevent-type-eventinitdict-eventinitdict"><code><c- g>eventInitDict</c-></code></a>), <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①①"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<c- b>interface</c-> <a href="#focusevent"><code><c- g>FocusEvent</c-></code></a> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent①⑨①"><c- n>UIEvent</c-></a> {
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget①①"><c- n>EventTarget</c-></a>? <a data-readonly data-type="EventTarget?" href="#dom-focusevent-relatedtarget"><code><c- g>relatedTarget</c-></code></a>;
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-focuseventinit"><code>FocusEventInit</code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit③①">UIEventInit</a> {
-  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget④①">EventTarget</a>? <a class="nv" data-default="null" data-type="EventTarget? " href="#dom-focuseventinit-relatedtarget"><code>relatedTarget</code></a> = <span class="kt">null</span>;
+<c- b>dictionary</c-> <a href="#dictdef-focuseventinit"><code><c- g>FocusEventInit</c-></code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit③①"><c- n>UIEventInit</c-></a> {
+  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget④①"><c- n>EventTarget</c-></a>? <a data-default="null" data-type="EventTarget? " href="#dom-focuseventinit-relatedtarget"><code><c- g>relatedTarget</c-></code></a> = <c- b>null</c->;
 };
 
-[<a class="nv" href="#dom-mouseevent-mouseevent"><code>Constructor</code></a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑨"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-mouseevent-mouseevent-type-eventinitdict-type"><code>type</code></a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-mouseeventinit" id="ref-for-dictdef-mouseeventinit①①">MouseEventInit</a> <a class="nv" href="#dom-mouseevent-mouseevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code></a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed②①">Exposed</a>=<span class="n">Window</span>]
-<span class="kt">interface</span> <a class="nv" href="#mouseevent"><code>MouseEvent</code></a> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent②⑧①">UIEvent</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long②①"><span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="#dom-mouseevent-screenx" id="ref-for-dom-mouseevent-screenx①⑤">screenX</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long③①"><span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="#dom-mouseevent-screeny" id="ref-for-dom-mouseevent-screeny①⑤">screenY</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long④①"><span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="#dom-mouseevent-clientx" id="ref-for-dom-mouseevent-clientx①⑥">clientX</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long⑤①"><span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="long" href="#dom-mouseevent-clienty" id="ref-for-dom-mouseevent-clienty①⑥">clientY</a>;
+[<a href="#dom-mouseevent-mouseevent"><code><c- g>Constructor</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑨"><c- b>DOMString</c-></a> <a href="#dom-mouseevent-mouseevent-type-eventinitdict-type"><code><c- g>type</c-></code></a>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-mouseeventinit" id="ref-for-dictdef-mouseeventinit①①"><c- n>MouseEventInit</c-></a> <a href="#dom-mouseevent-mouseevent-type-eventinitdict-eventinitdict"><code><c- g>eventInitDict</c-></code></a>), <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed②①"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<c- b>interface</c-> <a href="#mouseevent"><code><c- g>MouseEvent</c-></code></a> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent②⑧①"><c- n>UIEvent</c-></a> {
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long②①"><c- b>long</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="long" href="#dom-mouseevent-screenx" id="ref-for-dom-mouseevent-screenx①⑤"><c- g>screenX</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long③①"><c- b>long</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="long" href="#dom-mouseevent-screeny" id="ref-for-dom-mouseevent-screeny①⑤"><c- g>screenY</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long④①"><c- b>long</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="long" href="#dom-mouseevent-clientx" id="ref-for-dom-mouseevent-clientx①⑥"><c- g>clientX</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long⑤①"><c- b>long</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="long" href="#dom-mouseevent-clienty" id="ref-for-dom-mouseevent-clienty①⑥"><c- g>clientY</c-></a>;
 
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑤⑧"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-mouseevent-ctrlkey" id="ref-for-dom-mouseevent-ctrlkey①④">ctrlKey</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①①⓪"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-mouseevent-shiftkey" id="ref-for-dom-mouseevent-shiftkey①④">shiftKey</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②①⓪"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-mouseevent-altkey" id="ref-for-dom-mouseevent-altkey①③">altKey</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③①⓪"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-mouseevent-metakey" id="ref-for-dom-mouseevent-metakey①③">metaKey</a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑤⑧"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="boolean" href="#dom-mouseevent-ctrlkey" id="ref-for-dom-mouseevent-ctrlkey①④"><c- g>ctrlKey</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①①⓪"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="boolean" href="#dom-mouseevent-shiftkey" id="ref-for-dom-mouseevent-shiftkey①④"><c- g>shiftKey</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②①⓪"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="boolean" href="#dom-mouseevent-altkey" id="ref-for-dom-mouseevent-altkey①③"><c- g>altKey</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③①⓪"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="boolean" href="#dom-mouseevent-metakey" id="ref-for-dom-mouseevent-metakey①③"><c- g>metaKey</c-></a>;
 
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-short" id="ref-for-idl-short④"><span class="kt">short</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="short" href="#dom-mouseevent-button" id="ref-for-dom-mouseevent-button②⑥">button</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short④"><span class="kt">unsigned</span> <span class="kt">short</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned short" href="#dom-mouseevent-buttons" id="ref-for-dom-mouseevent-buttons②④">buttons</a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-short" id="ref-for-idl-short④"><c- b>short</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="short" href="#dom-mouseevent-button" id="ref-for-dom-mouseevent-button②⑥"><c- g>button</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short④"><c- b>unsigned</c-> <c- b>short</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="unsigned short" href="#dom-mouseevent-buttons" id="ref-for-dom-mouseevent-buttons②④"><c- g>buttons</c-></a>;
 
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget⑤①">EventTarget</a>? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="EventTarget?" href="#dom-mouseevent-relatedtarget" id="ref-for-dom-mouseevent-relatedtarget①④">relatedTarget</a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget⑤①"><c- n>EventTarget</c-></a>? <a class="idl-code" data-link-type="attribute" data-readonly data-type="EventTarget?" href="#dom-mouseevent-relatedtarget" id="ref-for-dom-mouseevent-relatedtarget①④"><c- g>relatedTarget</c-></a>;
 
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④①⓪"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="method" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate①⑦">getModifierState</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③①"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-mouseevent-getmodifierstate-keyarg-keyarg"><code>keyArg</code></a>);
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④①⓪"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-mouseevent-getmodifierstate" id="ref-for-dom-mouseevent-getmodifierstate①⑦"><c- g>getModifierState</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③①"><c- b>DOMString</c-></a> <a href="#dom-mouseevent-getmodifierstate-keyarg-keyarg"><code><c- g>keyArg</c-></code></a>);
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-mouseeventinit"><code>MouseEventInit</code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-eventmodifierinit" id="ref-for-dictdef-eventmodifierinit②①">EventModifierInit</a> {
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①⓪①"><span class="kt">long</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-screenx" id="ref-for-dom-mouseeventinit-screenx①">screenX</a> = 0;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①①①"><span class="kt">long</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-screeny" id="ref-for-dom-mouseeventinit-screeny①">screenY</a> = 0;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①②①"><span class="kt">long</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-clientx" id="ref-for-dom-mouseeventinit-clientx①">clientX</a> = 0;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①③①"><span class="kt">long</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-clienty" id="ref-for-dom-mouseeventinit-clienty①">clientY</a> = 0;
+<c- b>dictionary</c-> <a href="#dictdef-mouseeventinit"><code><c- g>MouseEventInit</c-></code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-eventmodifierinit" id="ref-for-dictdef-eventmodifierinit②①"><c- n>EventModifierInit</c-></a> {
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①⓪①"><c- b>long</c-></a> <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-screenx" id="ref-for-dom-mouseeventinit-screenx①"><c- g>screenX</c-></a> = 0;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①①①"><c- b>long</c-></a> <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-screeny" id="ref-for-dom-mouseeventinit-screeny①"><c- g>screenY</c-></a> = 0;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①②①"><c- b>long</c-></a> <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-clientx" id="ref-for-dom-mouseeventinit-clientx①"><c- g>clientX</c-></a> = 0;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①③①"><c- b>long</c-></a> <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="long " href="#dom-mouseeventinit-clienty" id="ref-for-dom-mouseeventinit-clienty①"><c- g>clientY</c-></a> = 0;
 
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-short" id="ref-for-idl-short②①"><span class="kt">short</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="short " href="#dom-mouseeventinit-button" id="ref-for-dom-mouseeventinit-button①">button</a> = 0;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short②①"><span class="kt">unsigned</span> <span class="kt">short</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned short " href="#dom-mouseeventinit-buttons" id="ref-for-dom-mouseeventinit-buttons①">buttons</a> = 0;
-  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget⑧①">EventTarget</a>? <a class="nv idl-code" data-default="null" data-link-type="dict-member" data-type="EventTarget? " href="#dom-mouseeventinit-relatedtarget" id="ref-for-dom-mouseeventinit-relatedtarget①">relatedTarget</a> = <span class="kt">null</span>;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-short" id="ref-for-idl-short②①"><c- b>short</c-></a> <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="short " href="#dom-mouseeventinit-button" id="ref-for-dom-mouseeventinit-button①"><c- g>button</c-></a> = 0;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-short" id="ref-for-idl-unsigned-short②①"><c- b>unsigned</c-> <c- b>short</c-></a> <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned short " href="#dom-mouseeventinit-buttons" id="ref-for-dom-mouseeventinit-buttons①"><c- g>buttons</c-></a> = 0;
+  <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget" id="ref-for-eventtarget⑧①"><c- n>EventTarget</c-></a>? <a class="idl-code" data-default="null" data-link-type="dict-member" data-type="EventTarget? " href="#dom-mouseeventinit-relatedtarget" id="ref-for-dom-mouseeventinit-relatedtarget①"><c- g>relatedTarget</c-></a> = <c- b>null</c->;
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-eventmodifierinit"><code>EventModifierInit</code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit④①">UIEventInit</a> {
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑨①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-ctrlkey" id="ref-for-dom-eventmodifierinit-ctrlkey①">ctrlKey</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①⓪①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-shiftkey" id="ref-for-dom-eventmodifierinit-shiftkey①">shiftKey</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①①①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-altkey" id="ref-for-dom-eventmodifierinit-altkey①">altKey</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①②①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-metakey" id="ref-for-dom-eventmodifierinit-metakey①">metaKey</a> = <span class="kt">false</span>;
+<c- b>dictionary</c-> <a href="#dictdef-eventmodifierinit"><code><c- g>EventModifierInit</c-></code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit④①"><c- n>UIEventInit</c-></a> {
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑨①"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-ctrlkey" id="ref-for-dom-eventmodifierinit-ctrlkey①"><c- g>ctrlKey</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①⓪①"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-shiftkey" id="ref-for-dom-eventmodifierinit-shiftkey①"><c- g>shiftKey</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①①①"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-altkey" id="ref-for-dom-eventmodifierinit-altkey①"><c- g>altKey</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①②①"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-metakey" id="ref-for-dom-eventmodifierinit-metakey①"><c- g>metaKey</c-></a> = <c- b>false</c->;
 
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①③①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifieraltgraph" id="ref-for-dom-eventmodifierinit-modifieraltgraph①">modifierAltGraph</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①④①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiercapslock" id="ref-for-dom-eventmodifierinit-modifiercapslock①">modifierCapsLock</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①⑤①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierfn" id="ref-for-dom-eventmodifierinit-modifierfn①">modifierFn</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①⑥①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierfnlock" id="ref-for-dom-eventmodifierinit-modifierfnlock①">modifierFnLock</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①⑦①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierhyper" id="ref-for-dom-eventmodifierinit-modifierhyper①">modifierHyper</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①⑧①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiernumlock" id="ref-for-dom-eventmodifierinit-modifiernumlock①">modifierNumLock</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①⑨①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierscrolllock" id="ref-for-dom-eventmodifierinit-modifierscrolllock①">modifierScrollLock</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②⓪①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiersuper" id="ref-for-dom-eventmodifierinit-modifiersuper①">modifierSuper</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②①①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiersymbol" id="ref-for-dom-eventmodifierinit-modifiersymbol①">modifierSymbol</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②②①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiersymbollock" id="ref-for-dom-eventmodifierinit-modifiersymbollock①">modifierSymbolLock</a> = <span class="kt">false</span>;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①③①"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifieraltgraph" id="ref-for-dom-eventmodifierinit-modifieraltgraph①"><c- g>modifierAltGraph</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①④①"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiercapslock" id="ref-for-dom-eventmodifierinit-modifiercapslock①"><c- g>modifierCapsLock</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①⑤①"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierfn" id="ref-for-dom-eventmodifierinit-modifierfn①"><c- g>modifierFn</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①⑥①"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierfnlock" id="ref-for-dom-eventmodifierinit-modifierfnlock①"><c- g>modifierFnLock</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①⑦①"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierhyper" id="ref-for-dom-eventmodifierinit-modifierhyper①"><c- g>modifierHyper</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①⑧①"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiernumlock" id="ref-for-dom-eventmodifierinit-modifiernumlock①"><c- g>modifierNumLock</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①⑨①"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifierscrolllock" id="ref-for-dom-eventmodifierinit-modifierscrolllock①"><c- g>modifierScrollLock</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②⓪①"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiersuper" id="ref-for-dom-eventmodifierinit-modifiersuper①"><c- g>modifierSuper</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②①①"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiersymbol" id="ref-for-dom-eventmodifierinit-modifiersymbol①"><c- g>modifierSymbol</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean②②①"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-eventmodifierinit-modifiersymbollock" id="ref-for-dom-eventmodifierinit-modifiersymbollock①"><c- g>modifierSymbolLock</c-></a> = <c- b>false</c->;
 };
 
-[<a class="nv" href="#dom-wheelevent-wheelevent"><code>Constructor</code></a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString④①"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-wheelevent-wheelevent-type-eventinitdict-type"><code>type</code></a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-wheeleventinit" id="ref-for-dictdef-wheeleventinit①①">WheelEventInit</a> <a class="nv" href="#dom-wheelevent-wheelevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code></a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed③①">Exposed</a>=<span class="n">Window</span>]
-<span class="kt">interface</span> <a class="nv" href="#wheelevent"><code>WheelEvent</code></a> : <a class="n" data-link-type="idl-name" href="#mouseevent" id="ref-for-mouseevent①④①①">MouseEvent</a> {
+[<a href="#dom-wheelevent-wheelevent"><code><c- g>Constructor</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString④①"><c- b>DOMString</c-></a> <a href="#dom-wheelevent-wheelevent-type-eventinitdict-type"><code><c- g>type</c-></code></a>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-wheeleventinit" id="ref-for-dictdef-wheeleventinit①①"><c- n>WheelEventInit</c-></a> <a href="#dom-wheelevent-wheelevent-type-eventinitdict-eventinitdict"><code><c- g>eventInitDict</c-></code></a>), <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed③①"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<c- b>interface</c-> <a href="#wheelevent"><code><c- g>WheelEvent</c-></code></a> : <a class="n" data-link-type="idl-name" href="#mouseevent" id="ref-for-mouseevent①④①①"><c- n>MouseEvent</c-></a> {
   // DeltaModeCode
-  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②①"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-wheelevent-dom_delta_pixel" id="ref-for-dom-wheelevent-dom_delta_pixel③">DOM_DELTA_PIXEL</a> = 0x00;
-  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①①⓪"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-wheelevent-dom_delta_line" id="ref-for-dom-wheelevent-dom_delta_line②">DOM_DELTA_LINE</a>  = 0x01;
-  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②②"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-wheelevent-dom_delta_page" id="ref-for-dom-wheelevent-dom_delta_page②">DOM_DELTA_PAGE</a>  = 0x02;
+  <c- b>const</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="const" href="#dom-wheelevent-dom_delta_pixel" id="ref-for-dom-wheelevent-dom_delta_pixel③"><c- g>DOM_DELTA_PIXEL</c-></a> = 0x00;
+  <c- b>const</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①①⓪"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="const" href="#dom-wheelevent-dom_delta_line" id="ref-for-dom-wheelevent-dom_delta_line②"><c- g>DOM_DELTA_LINE</c-></a>  = 0x01;
+  <c- b>const</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long②②"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="const" href="#dom-wheelevent-dom_delta_page" id="ref-for-dom-wheelevent-dom_delta_page②"><c- g>DOM_DELTA_PAGE</c-></a>  = 0x02;
 
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①③"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="double" href="#dom-wheelevent-deltax" id="ref-for-dom-wheelevent-deltax⑤">deltaX</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①②"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="double" href="#dom-wheelevent-deltay" id="ref-for-dom-wheelevent-deltay⑤">deltaY</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②①"><span class="kt">double</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="double" href="#dom-wheelevent-deltaz" id="ref-for-dom-wheelevent-deltaz⑤">deltaZ</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long③①"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-wheelevent-deltamode" id="ref-for-dom-wheelevent-deltamode⑤">deltaMode</a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①③"><c- b>double</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="double" href="#dom-wheelevent-deltax" id="ref-for-dom-wheelevent-deltax⑤"><c- g>deltaX</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①②"><c- b>double</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="double" href="#dom-wheelevent-deltay" id="ref-for-dom-wheelevent-deltay⑤"><c- g>deltaY</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②①"><c- b>double</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="double" href="#dom-wheelevent-deltaz" id="ref-for-dom-wheelevent-deltaz⑤"><c- g>deltaZ</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long③①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="unsigned long" href="#dom-wheelevent-deltamode" id="ref-for-dom-wheelevent-deltamode⑤"><c- g>deltaMode</c-></a>;
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-wheeleventinit"><code>WheelEventInit</code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-mouseeventinit" id="ref-for-dictdef-mouseeventinit②①">MouseEventInit</a> {
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑥①"><span class="kt">double</span></a> <a class="nv idl-code" data-default="0.0" data-link-type="dict-member" data-type="double " href="#dom-wheeleventinit-deltax" id="ref-for-dom-wheeleventinit-deltax①">deltaX</a> = 0.0;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑦①"><span class="kt">double</span></a> <a class="nv idl-code" data-default="0.0" data-link-type="dict-member" data-type="double " href="#dom-wheeleventinit-deltay" id="ref-for-dom-wheeleventinit-deltay①">deltaY</a> = 0.0;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑧①"><span class="kt">double</span></a> <a class="nv idl-code" data-default="0.0" data-link-type="dict-member" data-type="double " href="#dom-wheeleventinit-deltaz" id="ref-for-dom-wheeleventinit-deltaz①">deltaZ</a> = 0.0;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑤①"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned long " href="#dom-wheeleventinit-deltamode" id="ref-for-dom-wheeleventinit-deltamode①">deltaMode</a> = 0;
+<c- b>dictionary</c-> <a href="#dictdef-wheeleventinit"><code><c- g>WheelEventInit</c-></code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-mouseeventinit" id="ref-for-dictdef-mouseeventinit②①"><c- n>MouseEventInit</c-></a> {
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑥①"><c- b>double</c-></a> <a class="idl-code" data-default="0.0" data-link-type="dict-member" data-type="double " href="#dom-wheeleventinit-deltax" id="ref-for-dom-wheeleventinit-deltax①"><c- g>deltaX</c-></a> = 0.0;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑦①"><c- b>double</c-></a> <a class="idl-code" data-default="0.0" data-link-type="dict-member" data-type="double " href="#dom-wheeleventinit-deltay" id="ref-for-dom-wheeleventinit-deltay①"><c- g>deltaY</c-></a> = 0.0;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double⑧①"><c- b>double</c-></a> <a class="idl-code" data-default="0.0" data-link-type="dict-member" data-type="double " href="#dom-wheeleventinit-deltaz" id="ref-for-dom-wheeleventinit-deltaz①"><c- g>deltaZ</c-></a> = 0.0;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑤①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned long " href="#dom-wheeleventinit-deltamode" id="ref-for-dom-wheeleventinit-deltamode①"><c- g>deltaMode</c-></a> = 0;
 };
 
-[<a class="nv" href="#dom-inputevent-inputevent"><code>Constructor</code></a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑤①"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-inputevent-inputevent-type-eventinitdict-type"><code>type</code></a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-inputeventinit" id="ref-for-dictdef-inputeventinit①">InputEventInit</a> <a class="nv" href="#dom-inputevent-inputevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code></a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed④①">Exposed</a>=<span class="n">Window</span>]
-<span class="kt">interface</span> <a class="nv" href="#inputevent"><code>InputEvent</code></a> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent⑤①①">UIEvent</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑥①"><span class="kt">DOMString</span></a>? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString?" href="#dom-inputevent-data" id="ref-for-dom-inputevent-data⑦">data</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③⑦①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-inputevent-iscomposing" id="ref-for-dom-inputevent-iscomposing③">isComposing</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑦①"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-inputevent-inputtype" id="ref-for-dom-inputevent-inputtype①">inputType</a>;
+[<a href="#dom-inputevent-inputevent"><code><c- g>Constructor</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑤①"><c- b>DOMString</c-></a> <a href="#dom-inputevent-inputevent-type-eventinitdict-type"><code><c- g>type</c-></code></a>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-inputeventinit" id="ref-for-dictdef-inputeventinit①"><c- n>InputEventInit</c-></a> <a href="#dom-inputevent-inputevent-type-eventinitdict-eventinitdict"><code><c- g>eventInitDict</c-></code></a>), <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed④①"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<c- b>interface</c-> <a href="#inputevent"><code><c- g>InputEvent</c-></code></a> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent⑤①①"><c- n>UIEvent</c-></a> {
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑥①"><c- b>DOMString</c-></a>? <a class="idl-code" data-link-type="attribute" data-readonly data-type="DOMString?" href="#dom-inputevent-data" id="ref-for-dom-inputevent-data⑦"><c- g>data</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③⑦①"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="boolean" href="#dom-inputevent-iscomposing" id="ref-for-dom-inputevent-iscomposing③"><c- g>isComposing</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString⑦①"><c- b>DOMString</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="DOMString" href="#dom-inputevent-inputtype" id="ref-for-dom-inputevent-inputtype①"><c- g>inputType</c-></a>;
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-inputeventinit"><code>InputEventInit</code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit⑤①">UIEventInit</a> {
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⓪①"><span class="kt">DOMString</span></a>? <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString? " href="#dom-inputeventinit-data" id="ref-for-dom-inputeventinit-data①">data</a> = "";
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③⑨①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-inputeventinit-iscomposing" id="ref-for-dom-inputeventinit-iscomposing①">isComposing</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①①①"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-inputeventinit-inputtype" id="ref-for-dom-inputeventinit-inputtype①">inputType</a> = "";
+<c- b>dictionary</c-> <a href="#dictdef-inputeventinit"><code><c- g>InputEventInit</c-></code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit⑤①"><c- n>UIEventInit</c-></a> {
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⓪①"><c- b>DOMString</c-></a>? <a class="idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString? " href="#dom-inputeventinit-data" id="ref-for-dom-inputeventinit-data①"><c- g>data</c-></a> = "";
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③⑨①"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-inputeventinit-iscomposing" id="ref-for-dom-inputeventinit-iscomposing①"><c- g>isComposing</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①①①"><c- b>DOMString</c-></a> <a class="idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-inputeventinit-inputtype" id="ref-for-dom-inputeventinit-inputtype①"><c- g>inputType</c-></a> = "";
 };
 
-[<a class="nv" href="#dom-keyboardevent-keyboardevent"><code>Constructor</code></a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①④①"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-keyboardevent-keyboardevent-type-eventinitdict-type"><code>type</code></a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-keyboardeventinit" id="ref-for-dictdef-keyboardeventinit①①">KeyboardEventInit</a> <a class="nv" href="#dom-keyboardevent-keyboardevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code></a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑤①">Exposed</a>=<span class="n">Window</span>]
-<span class="kt">interface</span> <a class="nv" href="#keyboardevent"><code>KeyboardEvent</code></a> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent⑤⑥①">UIEvent</a> {
+[<a href="#dom-keyboardevent-keyboardevent"><code><c- g>Constructor</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①④①"><c- b>DOMString</c-></a> <a href="#dom-keyboardevent-keyboardevent-type-eventinitdict-type"><code><c- g>type</c-></code></a>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-keyboardeventinit" id="ref-for-dictdef-keyboardeventinit①①"><c- n>KeyboardEventInit</c-></a> <a href="#dom-keyboardevent-keyboardevent-type-eventinitdict-eventinitdict"><code><c- g>eventInitDict</c-></code></a>), <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑤①"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<c- b>interface</c-> <a href="#keyboardevent"><code><c- g>KeyboardEvent</c-></code></a> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent⑤⑥①"><c- n>UIEvent</c-></a> {
   // KeyLocationCode
-  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑦①"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_standard" id="ref-for-dom-keyboardevent-dom_key_location_standard⑨">DOM_KEY_LOCATION_STANDARD</a> = 0x00;
-  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑧①"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_left" id="ref-for-dom-keyboardevent-dom_key_location_left①①">DOM_KEY_LOCATION_LEFT</a> = 0x01;
-  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑨①"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_right" id="ref-for-dom-keyboardevent-dom_key_location_right⑦">DOM_KEY_LOCATION_RIGHT</a> = 0x02;
-  <span class="kt">const</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①⓪①"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_numpad" id="ref-for-dom-keyboardevent-dom_key_location_numpad⑥">DOM_KEY_LOCATION_NUMPAD</a> = 0x03;
+  <c- b>const</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑦①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_standard" id="ref-for-dom-keyboardevent-dom_key_location_standard⑨"><c- g>DOM_KEY_LOCATION_STANDARD</c-></a> = 0x00;
+  <c- b>const</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑧①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_left" id="ref-for-dom-keyboardevent-dom_key_location_left①①"><c- g>DOM_KEY_LOCATION_LEFT</c-></a> = 0x01;
+  <c- b>const</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long⑨①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_right" id="ref-for-dom-keyboardevent-dom_key_location_right⑦"><c- g>DOM_KEY_LOCATION_RIGHT</c-></a> = 0x02;
+  <c- b>const</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①⓪①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="const" href="#dom-keyboardevent-dom_key_location_numpad" id="ref-for-dom-keyboardevent-dom_key_location_numpad⑥"><c- g>DOM_KEY_LOCATION_NUMPAD</c-></a> = 0x03;
 
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑤①"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-keyboardevent-key" id="ref-for-dom-keyboardevent-key③①⓪">key</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑥①"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-keyboardevent-code" id="ref-for-dom-keyboardevent-code②①⓪">code</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①①①"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-keyboardevent-location" id="ref-for-dom-keyboardevent-location②⓪">location</a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑤①"><c- b>DOMString</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="DOMString" href="#dom-keyboardevent-key" id="ref-for-dom-keyboardevent-key③①⓪"><c- g>key</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑥①"><c- b>DOMString</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="DOMString" href="#dom-keyboardevent-code" id="ref-for-dom-keyboardevent-code②①⓪"><c- g>code</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①①①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="unsigned long" href="#dom-keyboardevent-location" id="ref-for-dom-keyboardevent-location②⓪"><c- g>location</c-></a>;
 
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④①①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-ctrlkey" id="ref-for-dom-keyboardevent-ctrlkey②①">ctrlKey</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④②①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-shiftkey" id="ref-for-dom-keyboardevent-shiftkey②⑦">shiftKey</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④③①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-altkey" id="ref-for-dom-keyboardevent-altkey②①">altKey</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④④①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-metakey" id="ref-for-dom-keyboardevent-metakey②①">metaKey</a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④①①"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="boolean" href="#dom-keyboardevent-ctrlkey" id="ref-for-dom-keyboardevent-ctrlkey②①"><c- g>ctrlKey</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④②①"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="boolean" href="#dom-keyboardevent-shiftkey" id="ref-for-dom-keyboardevent-shiftkey②⑦"><c- g>shiftKey</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④③①"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="boolean" href="#dom-keyboardevent-altkey" id="ref-for-dom-keyboardevent-altkey②①"><c- g>altKey</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④④①"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="boolean" href="#dom-keyboardevent-metakey" id="ref-for-dom-keyboardevent-metakey②①"><c- g>metaKey</c-></a>;
 
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④⑤①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-repeat" id="ref-for-dom-keyboardevent-repeat⑥">repeat</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④⑥①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="boolean" href="#dom-keyboardevent-iscomposing" id="ref-for-dom-keyboardevent-iscomposing①⓪">isComposing</a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④⑤①"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="boolean" href="#dom-keyboardevent-repeat" id="ref-for-dom-keyboardevent-repeat⑥"><c- g>repeat</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④⑥①"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="boolean" href="#dom-keyboardevent-iscomposing" id="ref-for-dom-keyboardevent-iscomposing①⓪"><c- g>isComposing</c-></a>;
 
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④⑦①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-link-type="method" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate①⑧①">getModifierState</a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑦①"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-keyboardevent-getmodifierstate-keyarg-keyarg"><code>keyArg</code></a>);
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean④⑦①"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-keyboardevent-getmodifierstate" id="ref-for-dom-keyboardevent-getmodifierstate①⑧①"><c- g>getModifierState</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①⑦①"><c- b>DOMString</c-></a> <a href="#dom-keyboardevent-getmodifierstate-keyarg-keyarg"><code><c- g>keyArg</c-></code></a>);
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-keyboardeventinit"><code>KeyboardEventInit</code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-eventmodifierinit" id="ref-for-dictdef-eventmodifierinit③①">EventModifierInit</a> {
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⓪①"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-keyboardeventinit-key" id="ref-for-dom-keyboardeventinit-key①">key</a> = "";
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②①①"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-keyboardeventinit-code" id="ref-for-dom-keyboardeventinit-code①">code</a> = "";
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①③①"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned long " href="#dom-keyboardeventinit-location" id="ref-for-dom-keyboardeventinit-location①">location</a> = 0;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑤④①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-keyboardeventinit-repeat" id="ref-for-dom-keyboardeventinit-repeat①">repeat</a> = <span class="kt">false</span>;
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑤⑤①"><span class="kt">boolean</span></a> <a class="nv idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-keyboardeventinit-iscomposing" id="ref-for-dom-keyboardeventinit-iscomposing①">isComposing</a> = <span class="kt">false</span>;
+<c- b>dictionary</c-> <a href="#dictdef-keyboardeventinit"><code><c- g>KeyboardEventInit</c-></code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-eventmodifierinit" id="ref-for-dictdef-eventmodifierinit③①"><c- n>EventModifierInit</c-></a> {
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⓪①"><c- b>DOMString</c-></a> <a class="idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-keyboardeventinit-key" id="ref-for-dom-keyboardeventinit-key①"><c- g>key</c-></a> = "";
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②①①"><c- b>DOMString</c-></a> <a class="idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-keyboardeventinit-code" id="ref-for-dom-keyboardeventinit-code①"><c- g>code</c-></a> = "";
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①③①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-default="0" data-link-type="dict-member" data-type="unsigned long " href="#dom-keyboardeventinit-location" id="ref-for-dom-keyboardeventinit-location①"><c- g>location</c-></a> = 0;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑤④①"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-keyboardeventinit-repeat" id="ref-for-dom-keyboardeventinit-repeat①"><c- g>repeat</c-></a> = <c- b>false</c->;
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean⑤⑤①"><c- b>boolean</c-></a> <a class="idl-code" data-default="false" data-link-type="dict-member" data-type="boolean " href="#dom-keyboardeventinit-iscomposing" id="ref-for-dom-keyboardeventinit-iscomposing①"><c- g>isComposing</c-></a> = <c- b>false</c->;
 };
 
-[<a class="nv" href="#dom-compositionevent-compositionevent"><code>Constructor</code></a>(<a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②④①"><span class="kt">DOMString</span></a> <a class="nv" href="#dom-compositionevent-compositionevent-type-eventinitdict-type"><code>type</code></a>, <span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-compositioneventinit" id="ref-for-dictdef-compositioneventinit①①">CompositionEventInit</a> <a class="nv" href="#dom-compositionevent-compositionevent-type-eventinitdict-eventinitdict"><code>eventInitDict</code></a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑥①">Exposed</a>=<span class="n">Window</span>]
-<span class="kt">interface</span> <a class="nv" href="#compositionevent"><code>CompositionEvent</code></a> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent⑥①①">UIEvent</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑤①"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-compositionevent-data" id="ref-for-dom-compositionevent-data①⑨">data</a>;
+[<a href="#dom-compositionevent-compositionevent"><code><c- g>Constructor</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②④①"><c- b>DOMString</c-></a> <a href="#dom-compositionevent-compositionevent-type-eventinitdict-type"><code><c- g>type</c-></code></a>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-compositioneventinit" id="ref-for-dictdef-compositioneventinit①①"><c- n>CompositionEventInit</c-></a> <a href="#dom-compositionevent-compositionevent-type-eventinitdict-eventinitdict"><code><c- g>eventInitDict</c-></code></a>), <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑥①"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<c- b>interface</c-> <a href="#compositionevent"><code><c- g>CompositionEvent</c-></code></a> : <a class="n" data-link-type="idl-name" href="#uievent" id="ref-for-uievent⑥①①"><c- n>UIEvent</c-></a> {
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑤①"><c- b>DOMString</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="DOMString" href="#dom-compositionevent-data" id="ref-for-dom-compositionevent-data①⑨"><c- g>data</c-></a>;
 };
 
-<span class="kt">dictionary</span> <a class="nv" href="#dictdef-compositioneventinit"><code>CompositionEventInit</code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit⑥①">UIEventInit</a> {
-  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑦①"><span class="kt">DOMString</span></a> <a class="nv idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-compositioneventinit-data" id="ref-for-dom-compositioneventinit-data①">data</a> = "";
+<c- b>dictionary</c-> <a href="#dictdef-compositioneventinit"><code><c- g>CompositionEventInit</c-></code></a> : <a class="n" data-link-type="idl-name" href="#dictdef-uieventinit" id="ref-for-dictdef-uieventinit⑥①"><c- n>UIEventInit</c-></a> {
+  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②⑦①"><c- b>DOMString</c-></a> <a class="idl-code" data-default="&quot;&quot;" data-link-type="dict-member" data-type="DOMString " href="#dom-compositioneventinit-data" id="ref-for-dom-compositioneventinit-data①"><c- g>data</c-></a> = "";
 };
 
-<span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="#uievent" id="ref-for-uievent⑦③①">UIEvent</a> {
+<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#uievent" id="ref-for-uievent⑦③①"><c- g>UIEvent</c-></a> {
   // The following support legacy user agents
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①⑤①"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-uievent-which" id="ref-for-dom-uievent-which④①">which</a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①⑤①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="unsigned long" href="#dom-uievent-which" id="ref-for-dom-uievent-which④①"><c- g>which</c-></a>;
 };
 
-<span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="#keyboardevent" id="ref-for-keyboardevent⑦⑨①">KeyboardEvent</a> {
+<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#keyboardevent" id="ref-for-keyboardevent⑦⑨①"><c- g>KeyboardEvent</c-></a> {
   // The following support legacy user agents
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①⑦①"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-keyboardevent-charcode" id="ref-for-dom-keyboardevent-charcode④①">charCode</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①⑧①"><span class="kt">unsigned</span> <span class="kt">long</span></a> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="unsigned long" href="#dom-keyboardevent-keycode" id="ref-for-dom-keyboardevent-keycode⑤①">keyCode</a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①⑦①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="unsigned long" href="#dom-keyboardevent-charcode" id="ref-for-dom-keyboardevent-charcode④①"><c- g>charCode</c-></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long" id="ref-for-idl-unsigned-long①⑧①"><c- b>unsigned</c-> <c- b>long</c-></a> <a class="idl-code" data-link-type="attribute" data-readonly data-type="unsigned long" href="#dom-keyboardevent-keycode" id="ref-for-dom-keyboardevent-keycode⑤①"><c- g>keyCode</c-></a>;
 };
 
 </pre>
@@ -10305,57 +10670,57 @@ browsing context’s Window Proxy object as defined in <a href="http://dev.w3.or
   </aside>
 <script>/* script-dfn-panel */
 
-        document.body.addEventListener("click", function(e) {
-            var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-            // Find the dfn element or panel, if any, that was clicked on.
-            var el = e.target;
-            var target;
-            var hitALink = false;
-            while(el.parentElement) {
-                if(el.tagName == "A") {
-                    // Clicking on a link in a <dfn> shouldn't summon the panel
-                    hitALink = true;
-                }
-                if(el.classList.contains("dfn-paneled")) {
-                    target = "dfn";
-                    break;
-                }
-                if(el.classList.contains("dfn-panel")) {
-                    target = "dfn-panel";
-                    break;
-                }
-                el = el.parentElement;
-            }
-            if(target != "dfn-panel") {
-                // Turn off any currently "on" or "activated" panels.
-                queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-                    el.classList.remove("on");
-                    el.classList.remove("activated");
-                });
-            }
-            if(target == "dfn" && !hitALink) {
-                // open the panel
-                var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-                if(dfnPanel) {
-                    dfnPanel.classList.add("on");
-                    var rect = el.getBoundingClientRect();
-                    dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-                    dfnPanel.style.top = window.scrollY + rect.top + "px";
-                    var panelRect = dfnPanel.getBoundingClientRect();
-                    var panelWidth = panelRect.right - panelRect.left;
-                    if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                        // Reposition, because the panel is overflowing
-                        dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-                    }
-                } else {
-                    console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-                }
-            } else if(target == "dfn-panel") {
-                // Switch it to "activated" state, which pins it.
-                el.classList.add("activated");
-                el.style.left = null;
-                el.style.top = null;
-            }
-
+document.body.addEventListener("click", function(e) {
+    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
+    // Find the dfn element or panel, if any, that was clicked on.
+    var el = e.target;
+    var target;
+    var hitALink = false;
+    while(el.parentElement) {
+        if(el.tagName == "A") {
+            // Clicking on a link in a <dfn> shouldn't summon the panel
+            hitALink = true;
+        }
+        if(el.classList.contains("dfn-paneled")) {
+            target = "dfn";
+            break;
+        }
+        if(el.classList.contains("dfn-panel")) {
+            target = "dfn-panel";
+            break;
+        }
+        el = el.parentElement;
+    }
+    if(target != "dfn-panel") {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
+            el.classList.remove("on");
+            el.classList.remove("activated");
         });
-        </script>
+    }
+    if(target == "dfn" && !hitALink) {
+        // open the panel
+        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
+        if(dfnPanel) {
+            dfnPanel.classList.add("on");
+            var rect = el.getBoundingClientRect();
+            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
+            dfnPanel.style.top = window.scrollY + rect.top + "px";
+            var panelRect = dfnPanel.getBoundingClientRect();
+            var panelWidth = panelRect.right - panelRect.left;
+            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
+                // Reposition, because the panel is overflowing
+                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
+            }
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
+        }
+    } else if(target == "dfn-panel") {
+        // Switch it to "activated" state, which pins it.
+        el.classList.add("activated");
+        el.style.left = null;
+        el.style.top = null;
+    }
+
+});
+</script>


### PR DESCRIPTION
I updated bikeshed just now and it seems index.html
will look differently with the latest version. Just recompiling to
make things easier for the other pull requests.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 13, 2020, 5:19 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fuievents%2Fa6c23519703ea7c2b62af9e161e39fd799c2eaae%2Findex.html%3FisPreview%3Dtrue)

```
[33m🕵️‍♀️  That doesn't seem to be a ReSpec document. Please check manually:[39m [36m[Function: url][39m
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/uievents%23260.)._
</details>
