### PR TITLE
Reflect the reality for the focus event order 

### DIFF
--- a/sections/event-types.txt
+++ b/sections/event-types.txt
@@ -329,13 +329,13 @@ events.
 		=| # | Event Type | Notes                                              |
 		 +---+------------+----------------------------------------------------+
 		+|   |            | <em>User shifts focus</em>                         |
-		+| 1 | focusin    | Sent before first target element receives focus    |
-		+| 2 | focus      | Sent after first target element receives focus     |
+		+| 1 | focus      | Sent after first target element receives focus     |
+		+| 2 | focusin    | Follows the focus event                            |
 		+|   |            | <em>User shifts focus</em>                         |
-		+| 3 | focusout   | Sent before first target element loses focus       |
-		+| 4 | focusin    | Sent before second target element receives focus   |
-		+| 5 | blur       | Sent after first target element loses focus        |
-		+| 6 | focus      | Sent after second target element receives focus    |
+		+| 3 | blur       | Sent after first target element loses focus        |
+		+| 4 | focusout   | Follows the blur event                             |
+		+| 5 | focus      | Sent after second target element receives focus    |
+		+| 6 | focusin    | Follows the focus event                            |
 		++---+------------+----------------------------------------------------+
 
 		<p class="note">
@@ -419,9 +419,8 @@ events.
 
 			A <a>user agent</a> MUST dispatch this event when an <a>event
 			target</a> loses focus. The focus MUST be taken from the element
-			before the dispatch of this event type.  This event type is similar
-			to EVENT{focusout}, but is dispatched after focus is shifted, and
-			does not bubble.
+			before the dispatch of this event type. This event type is similar
+			to [=focusout=], but does not bubble.
 
 		<h5 id="event-type-focus"><dfn>focus</dfn></h5>
 
@@ -447,9 +446,8 @@ events.
 
 			A <a>user agent</a> MUST dispatch this event when an <a>event
 			target</a> receives focus. The focus MUST be given to the element
-			before the dispatch of this event type.  This event type is similar
-			to EVENT{focusin}, but is dispatched after focus is shifted, and
-			does not bubble.
+			before the dispatch of this event type. This event type is similar
+			to [=focusin=], but does not bubble.
 
 		<h5 id="event-type-focusin"><dfn>focusin</dfn></h5>
 
@@ -473,22 +471,11 @@ events.
 			 |                  | </ul>                                                                                |
 			++------------------+--------------------------------------------------------------------------------------+
 
-			A <a>user agent</a> MUST dispatch this event when an <a>event
-			target</a> is about to receive focus. This event type MUST be
-			dispatched before the element is given focus.  The <a>event
-			target</a> MUST be the element which is about to receive focus.
-			This event type is similar to EVENT{focus}, but is dispatched
-			before focus is shifted, and does bubble.
-
-			<p class="note">
-			When using this event type, the content author can use the event's
-			{{FocusEvent/relatedTarget}} attribute (or a host-language-specific
-			method or means) to get the currently focused element before the
-			focus shifts to the next focus <a>event target</a>, thus having
-			access to both the element losing focus and the element gaining
-			focus without the use of the EVENT{blur} or EVENT{focusout} event
-			types.
-			</p>
+			A <a>user agent</a> MUST dispatch this event when an <a>event target</a>
+			receives focus. The <a>event target</a> MUST be the element which
+			received focus. The [=focus=] event MUST fire before the dispatch of
+			this event type. This event type is similar to [=focus=], but does
+			not bubble.
 
 		<h5 id="event-type-focusout"><dfn>focusout</dfn></h5>
 
@@ -512,12 +499,10 @@ events.
 			 |                  | </ul>                                                                                |
 			++------------------+--------------------------------------------------------------------------------------+
 
-			A <a>user agent</a> MUST dispatch this event when an <a>event
-			target</a> is about to lose focus. This event type MUST be
-			dispatched before the element loses focus.  The <a>event target</a>
-			MUST be the element which is about to lose focus.  This event type
-			is similar to EVENT{blur}, but is dispatched before focus is
-			shifted, and does bubble.
+			A <a>user agent</a> MUST dispatch this event when an <a>event target</a>
+			loses focus. The <a>event target</a> MUST be the element which lost
+			focus. The [=blur=] event MUST fire before the dispatch of this event
+			type. This event type is similar to [=blur=], but does not bubble.
 
 <h3 id="events-mouseevents">Mouse Events</h3>
 

--- a/sections/event-types.txt
+++ b/sections/event-types.txt
@@ -502,7 +502,7 @@ events.
 			A <a>user agent</a> MUST dispatch this event when an <a>event target</a>
 			loses focus. The <a>event target</a> MUST be the element which lost
 			focus. The [=blur=] event MUST fire before the dispatch of this event
-			type. This event type is similar to [=blur=], but does not bubble.
+			type. This event type is similar to [=blur=], but does bubble.
 
 <h3 id="events-mouseevents">Mouse Events</h3>
 

--- a/sections/event-types.txt
+++ b/sections/event-types.txt
@@ -475,7 +475,7 @@ events.
 			receives focus. The <a>event target</a> MUST be the element which
 			received focus. The [=focus=] event MUST fire before the dispatch of
 			this event type. This event type is similar to [=focus=], but does
-			not bubble.
+			bubble.
 
 		<h5 id="event-type-focusout"><dfn>focusout</dfn></h5>
 


### PR DESCRIPTION
Closes #88

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [x] Modified Web platform tests (link to pull request): https://github.com/web-platform-tests/wpt/pull/26401

Implementation commitment:

 * [x] WebKit: Already implemented
 * [x] Chromium: Already implemented
 * [x] Gecko: Already implemented


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 23, 2021, 5:13 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fuievents%2Fe5716cf9d439146b4e26effcdbe96af8e16d9f40%2Findex.html%3FisPreview%3Dtrue)

```
🕵️‍♀️  That doesn't seem to be a ReSpec document. Please check manually: https://rawcdn.githack.com/w3c/uievents/e5716cf9d439146b4e26effcdbe96af8e16d9f40/index.html?isPreview=true&publishDate=2021-03-23
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/uievents%23290.)._
</details>
