### PR TITLE
Add missing params for initCompositionEvent

### DIFF
--- a/sections/legacy-event-initializers.txt
+++ b/sections/legacy-event-initializers.txt
@@ -304,12 +304,16 @@ described in this Appendix.
 		<pre class="idl">
 		partial interface CompositionEvent {
 			// Originally introduced (and deprecated) in this specification
-			undefined initCompositionEvent();
+			undefined initCompositionEvent(DOMString typeArg,
+				optional boolean bubblesArg = false,
+				optional boolean cancelableArg = false,
+				optional WindowProxy? viewArg = null,
+				optional DOMString dataArg = "");
 		};
 		</pre>
 
 		<dl dfn-for="CompositionEvent">
-			<dt><dfn method>initCompositionEvent()</dfn></dt>
+			<dt><dfn method>initCompositionEvent(typeArg)</dfn></dt>
 			<dd>
 				Initializes attributes of a <code>CompositionEvent</code>
 				object. This method has the same behavior as
@@ -344,11 +348,6 @@ described in this Appendix.
 					<dt>DOMString dataArg</dt>
 					<dd>
 						Specifies {{CompositionEvent/data}}.
-					</dd>
-
-					<dt>DOMString locale</dt>
-					<dd>
-						Specifies the <code>locale</code> attribute of the CompositionEvent.
 					</dd>
 				</dl>
 			</dd>


### PR DESCRIPTION
This removes `locale` parameter as the corresponding attribute has been removed since cb2e9ff0394742744190335b2496ebe976962f06.

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [x] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [x] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=1700969) - Gecko still implements `locale`.