### PR TITLE
Prevent `<code>` becoming propdescs

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: python build.py --includes-only
       - uses: w3c/spec-prod@v2
         with:
           GH_PAGES_BRANCH: gh-pages

--- a/index.bs
+++ b/index.bs
@@ -67,69 +67,69 @@ spec:infra; type:dfn; text:code point
 </pre>
 
 <pre class="include">
-path: sections/introduction.txt
+path: sections/introduction.include
 </pre>
 
 <pre class="include">
-path: sections/conventions.txt
+path: sections/conventions.include
 </pre>
 
 <!-- Section 3: Architecture =============================================== -->
 <pre class="include">
-path: sections/architecture.txt
+path: sections/architecture.include
 </pre>
 
 <!-- Section 4: Basic Event Interfaces ===================================== -->
 <pre class="include">
-path: sections/event-interfaces.txt
+path: sections/event-interfaces.include
 </pre>
 
 <!-- Section 5: The Events ================================================= -->
 <pre class="include">
-path: sections/event-types.txt
+path: sections/event-types.include
 </pre>
 
 <!-- Section 6: Keyboard and key values ==================================== -->
 <pre class="include">
-path: sections/keyboard.txt
+path: sections/keyboard.include
 </pre>
 
 <!-- Appendix A: Legacy Event Initializers ================================= -->
 <pre class="include">
-path: sections/legacy-event-initializers.txt
+path: sections/legacy-event-initializers.include
 </pre>
 
 <!-- Appendix B: Legacy Key Attributes ===================================== -->
 <pre class="include">
-path: sections/legacy-key-attributes.txt
+path: sections/legacy-key-attributes.include
 </pre>
 
 <!-- Appendix C: Legacy Event Types ======================================== -->
 <pre class="include">
-path: sections/legacy-event-types.txt
+path: sections/legacy-event-types.include
 </pre>
 
 <!-- Appendix D: Extending Events ========================================== -->
 <pre class="include">
-path: sections/extending-events.txt
+path: sections/extending-events.include
 </pre>
 
 <!-- Appendix E: Security Considerations =================================== -->
 <pre class="include">
-path: sections/security.txt
+path: sections/security.include
 </pre>
 
 <!-- Appendix F: Changes =================================================== -->
 <pre class="include">
-path: sections/changes.txt
+path: sections/changes.include
 </pre>
 
 <!-- Appendix G: Acknowledgements ========================================== -->
 <pre class="include">
-path: sections/acknowledgements.txt
+path: sections/acknowledgements.include
 </pre>
 
 <!-- Appendix H: Glossary  ================================================= -->
 <pre class="include">
-path: sections/glossary.txt
+path: sections/glossary.include
 </pre>

--- a/sections/keyboard.txt
+++ b/sections/keyboard.txt
@@ -309,9 +309,9 @@ unavailable in the PDF version or printed version of this specification.
 	contain the intermediate state of the dead key sequence reported via the
 	{{CompositionEvent/data}} attribute. As in the previous example, the key
 	value for the key marked KEYCAP{O} on a <a>QWERTY</a> keyboard has a
-	{{CompositionEvent/data}} value of <code class="char">'&#xF6;'</code> in an
+	{{CompositionEvent/data}} value of <code class="char">"&#xF6;"</code> in an
 	unshifted state during a dead-key operation to add an umlaut diacritic, and
-	<code class="char">'&#xD6;'</code> in a shifted state during a dead-key
+	<code class="char">"&#xD6;"</code> in a shifted state during a dead-key
 	operation to add an umlaut diacritic.
 	</p>
 
@@ -336,7 +336,7 @@ unavailable in the PDF version or printed version of this specification.
 	executable programs it is equivalent to the mathematical multiplication
 	operation, while in other documents or executable programs, that function is
 	reserved for the multiplication symbol (GLYPH{&#xD7;}, Unicode value
-	UNI{U+00D7}) or the Latin small letter <code>'x'</code>
+	UNI{U+00D7}) or the Latin small letter <code>"x"</code>
 	(due to the lack of a multiplication key on many keyboards and the
 	superficial resemblance of the glyphs GLYPH{&#xD7;} and GLYPH{x}).  Thus,
 	the semantic meaning or function of character representations is outside the


### PR DESCRIPTION
Closes #310

Single quotes are special in bikeshed per [the docs](https://tabatkins.github.io/bikeshed/#link-types):

> "propdesc" - used by the 'foo' shorthand. A union of "property" and "descriptor". 