### PR TITLE
Update event-interfaces section to match event-types section

### DIFF
--- a/sections/event-interfaces.txt
+++ b/sections/event-interfaces.txt
@@ -72,10 +72,11 @@ The following chart describes the inheritance structure of the interfaces descri
      +-------------------+---o----+----o-----+-------o--------+--------o---------+-----o------+-------------------------------------------------+
     +| abort             | Sync   | No       | <a>Window</a>, | Event            | No         | None                                            |
      |                   |        |          | Element        |                  |            |                                                 |
+    +| auxclick          | Sync   | Yes      | Element        | PointerEvent     | Yes        | Varies                                          |
     +| beforeinput       | Sync   | Yes      | Element        | InputEvent       | Yes        | Update the DOM element                          |
     +| blur              | Sync   | No       | <a>Window</a>, | FocusEvent       | No         | None                                            |
      |                   |        |          | Element        |                  |            |                                                 |
-    +| click             | Sync   | Yes      | Element        | MouseEvent       | Yes        | Varies: for <a>targets</a> with an associated   |
+    +| click             | Sync   | Yes      | Element        | PointerEvent     | Yes        | Varies: for <a>targets</a> with an associated   |
      |                   |        |          |                |                  |            | activation behavior, executes the <a>activation |
      |                   |        |          |                |                  |            | behavior</a>; for focusable <a>targets</a>,     |
      |                   |        |          |                |                  |            | gives the element focus.                        |
@@ -83,6 +84,7 @@ The following chart describes the inheritance structure of the interfaces descri
      |                   |        |          |                |                  |            | window                                          |
     +| compositionupdate | Sync   | Yes      | Element        | CompositionEvent | No         | None                                            |
     +| compositionend    | Sync   | Yes      | Element        | CompositionEvent | No         | None                                            |
+    +| contextmenu       | Sync   | Yes      | Element        | PointerEvent     | Yes        | Invoke a context menu if supported              |
     +| dblclick          | Sync   | Yes      | Element        | MouseEvent       | No         | Varies: for <a>targets</a> with an associated   |
      |                   |        |          |                |                  |            | activation behavior, executes the <a>activation |
      |                   |        |          |                |                  |            | behavior</a>; for focusable <a>targets</a>,     |
@@ -118,8 +120,7 @@ The following chart describes the inheritance structure of the interfaces descri
     +| mousemove         | Sync   | Yes      | Element        | MouseEvent       | <a href="#mousemove-now-cancelable">Yes</a>     | None       |
     +| mouseout          | Sync   | Yes      | Element        | MouseEvent       | Yes        | None                                            |
     +| mouseover         | Sync   | Yes      | Element        | MouseEvent       | Yes        | None                                            |
-    +| mouseup           | Sync   | Yes      | Element        | MouseEvent       | Yes        | Invoke a context menu (in combination with the  |
-     |                   |        |          |                |                  |            | right mouse button, if supported)               |
+    +| mouseup           | Sync   | Yes      | Element        | MouseEvent       | Yes        | None                                            |
     +| select            | Sync   | Yes      | Element        | Event            | No         | None                                            |
     +| unload            | Sync   | No       | <a>Window</a>, | Event            | No         | None                                            |
      |                   |        |          | Document,      |                  |            |                                                 |


### PR DESCRIPTION
Added missing `auxclick` and `contextmenu` events, updated the DOM interface for `click` event, and fixed the default action for `mouseup` event.

Related to #316

The following tasks have been completed:

 * [X] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [X] Modified Web platform tests (link to pull request): This is fixing only a stale summary in the spec. The tests were added through original updates.

Implementation commitment: Not applicable, this is fixing only a stale summary in the spec.