### PR TITLE
Remove text selection from the dblclick default action - #328

### DIFF
--- a/sections/event-interfaces.txt
+++ b/sections/event-interfaces.txt
@@ -88,9 +88,7 @@ The following chart describes the inheritance structure of the interfaces descri
     +| dblclick          | Sync   | Yes      | Element        | MouseEvent       | No         | Varies: for <a>targets</a> with an associated   |
      |                   |        |          |                |                  |            | activation behavior, executes the <a>activation |
      |                   |        |          |                |                  |            | behavior</a>; for focusable <a>targets</a>,     |
-     |                   |        |          |                |                  |            | gives the element focus; for selectable         |
-     |                   |        |          |                |                  |            | <a>targets</a>, selects part or all of the      |
-     |                   |        |          |                |                  |            | element's content.                              |
+     |                   |        |          |                |                  |            | gives the element focus.                        |
     +| error             | Async  | No       | <a>Window</a>, | Event            | No         | None                                            |
      |                   |        |          | Element        |                  |            |                                                 |
     +| focus             | Sync   | No       | <a>Window</a>, | FocusEvent       | No         | None                                            |

--- a/sections/event-types.txt
+++ b/sections/event-types.txt
@@ -1572,15 +1572,9 @@ myDiv.addEventListener("auxclick", function(e) {
 			As with the EVENT{click} event type, the <a>default action</a> of
 			the EVENT{dblclick} event type varies based on the <a>event
 			target</a> of the event and the value of the {{MouseEvent/button}}
-			or {{MouseEvent/buttons}} attributes. Normally, the typical
+			or {{MouseEvent/buttons}} attributes. The typical
 			<a>default actions</a> of the EVENT{dblclick} event type match those
-			of the EVENT{click} event type, with the following additional
-			behavior:
-
-			*	If the <a>event target</a> is selectable, the <a>default
-				action</a> MUST be to select part or all of the selectable
-				content. Subsequent clicks MAY select additional selectable
-				portions of that content.
+			of the EVENT{click} event type.
 
 		<h5 id="event-type-mousedown"><dfn>mousedown</dfn></h5>
 


### PR DESCRIPTION
Text selection begins on all browsers on the mousedown event (consistent
with OS text selection), allowing extending the selection by continuing
to drag. The dblclick event is too late to prevent text selection, so we
should remove this default action to prevent confusion.

Mousedown already includes text selection as a possible default action
in the note.

Closes #328

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [x] Modified Web platform tests: Selection is not a required behavior of mousedown, so it is unclear whether it should be tested.

Implementation commitment:

This is already the current behavior on WebKit, Chromium and Gecko.