### PR TITLE
Specify non-cancelable wheel events when there are no non-passive listeners

### DIFF
--- a/sections/event-types.txt
+++ b/sections/event-types.txt
@@ -2268,11 +2268,6 @@ myDiv.addEventListener("auxclick", function(e) {
 			that there are no non-passive listeners</a> for the event.
 			</p>
 
-			<p>
-			User agents that support the non-standard <code>mousewheel</code> event
-			should implement the above-mentioned interventions also for the
-			<code>mousewheel</code> event.
-			</p>
 
 <h3 id="events-inputevents">Input Events</h3>
 

--- a/sections/event-types.txt
+++ b/sections/event-types.txt
@@ -2254,10 +2254,24 @@ myDiv.addEventListener("auxclick", function(e) {
 			Calling <code>preventDefault</code> on a wheel event can prevent
 			or otherwise interrupt scrolling. For maximum scroll performance, a
 			user agent may not wait for each wheel event associated with the scroll
-			to be processed to see if it will be canceled. In such cases it is
-			possible that only the first wheel event of a scrolling sequence is
-			cancelable. For the rest of the wheel events the user agent should
-			set their <code>cancelable</code> property to <code>false</code>.
+			to be processed to see if it will be canceled. In such cases the user
+			agent should generate <code>wheel</code> events whose
+			<code>cancelable</code> property is <code>false</code>, indicating that
+			<code>preventDefault</code> cannot be used to prevent or interrupt
+			scrolling. Otherwise <code>cancelable</code> will be <code>true</code>.
+			</p>
+
+			<p>
+			In particular, a user agent should generate only uncancelable
+			<code>wheel</code> events when it
+			<a href="https://dom.spec.whatwg.org/#observing-event-listeners">observes
+			that there are no non-passive listeners</a> for the event.
+			</p>
+
+			<p>
+			User agents that support the non-standard <code>mousewheel</code> event
+			should implement the above-mentioned interventions also for the
+			<code>mousewheel</code> event.
 			</p>
 
 <h3 id="events-inputevents">Input Events</h3>


### PR DESCRIPTION
Fixes #282

This uses the same language as in https://w3c.github.io/touch-events/#cancelability

The following tasks have been completed:

 * [ ] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [x] Modified Web platform tests https://github.com/web-platform-tests/wpt/pull/34464

Implementation commitment:

 * [x] WebKit already implemented
 * [x] Chromium already implemented
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=) (not sure if Gecko implements this)