### PR TITLE
Add a note in ui events spec about UA-provided writing assistance text insertion event ordering.

### DIFF
--- a/sections/event-inputevent.txt
+++ b/sections/event-inputevent.txt
@@ -98,6 +98,13 @@
 		+| 2 | input       |                                                   |
 		++---+-------------+---------------------------------------------------+
 
+		<p class="note">
+		UA-provided writing assistance such as text prediction, spell checking and auto correction, etc,
+		may insert replacement text. No <a href="#events-compositionevents">composition events</a> should
+		be dispatched around input events during insertion, and the <code>inputType</code> attribute of
+		the input events should be set to <code>"insertReplacementText"</code>.
+		</p>
+
 	<h4 id="events-input-types">Input Event Types</h4>
 
 		<h5 id="event-type-beforeinput"><dfn>beforeinput</dfn></h5>


### PR DESCRIPTION
Closes https://github.com/w3c/input-events/issues/152.
