### PR TITLE
Make CompositionEvent.init take a Window rather than WindowProxy

### DIFF
--- a/sections/legacy-event-initializers.txt
+++ b/sections/legacy-event-initializers.txt
@@ -307,7 +307,7 @@ described in this Appendix.
 			undefined initCompositionEvent(DOMString typeArg,
 				optional boolean bubblesArg = false,
 				optional boolean cancelableArg = false,
-				optional WindowProxy? viewArg = null,
+				optional Window? viewArg = null,
 				optional DOMString dataArg = "");
 		};
 		</pre>


### PR DESCRIPTION
This matches all other initUIEvent methods, the existing parameter explanations of the spec, [Firefox](https://searchfox.org/mozilla-central/source/dom/webidl/CompositionEvent.webidl#39), and [Chromium](https://github.com/chromium/chromium/blob/20be7de2e281fe8481a75713ead9d25d5c741515/third_party/blink/renderer/core/events/composition_event.idl#L38).

Although WebKit uses WindowProxy, it's worth noting that it uses it in place of Window for other UIEvents too. (they have a [FIXME for KeyboardEvent](https://github.com/WebKit/WebKit/blob/75ba0c46a4b93f5162d2c4f21efebcdd1e333110/Source/WebCore/dom/KeyboardEvent.idl#L53) for example)

The following tasks have been completed:

 * [ ] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [x] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=) (N/A as they already use Window)
 * [x] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=) (N/A as they already use Window)