### PR TITLE
Remove redundant checkbox in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,7 @@ Closes #??
 
 The following tasks have been completed:
 
- * [ ] Confirmed there are no ReSpec/BikeShed errors or warnings.
- * [ ] Modified Web platform tests (link to pull request)
+ * [ ] Modified web-platform-tests (link to pull request)
 
 Implementation commitment:
 


### PR DESCRIPTION
The CI check covers build errors.